### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ DescriptorSets:
       Format: Int32
       Data: [ 1, 2, 3, 4, 5, 6, 7, 8]
       DirectXBinding:
-        Register: 0 # implies b0 due to Access being RW
+        Register: 0 # implies b0 due to Access being Constant
         Space: 0
     - Access: ReadOnly
       Format: Float32


### PR DESCRIPTION
The comment implied that the constant buffer was R/W, which seems wrong. I suspect the comment was probably from an older version that had a UAV in that binding slot.