### PR TITLE
D3D12: Remove unnecessary waits and command list executions

### DIFF
--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -286,7 +286,7 @@ public:
                                  CComPtr<ID3D12Resource> Source) {
     addUploadBeginBarrier(IS, Destination);
     IS.CmdList->CopyBufferRegion(Destination, 0, Source, 0, R.Size);
-    addUploadEndBarrier(IS, Destination, R.Access == DataAccess::ReadOnly);
+    addUploadEndBarrier(IS, Destination, R.Access == DataAccess::ReadWrite);
   }
 
   llvm::Error createSRV(Resource &R, InvocationState &IS,

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -553,7 +553,7 @@ public:
         ResourcePair->second.Readback->Unmap(0, nullptr);
       }
     }
-    return waitForSignal(IS);
+    return llvm::Error::success();
   }
 
   llvm::Error executeProgram(llvm::StringRef Program, Pipeline &P) override {
@@ -587,9 +587,6 @@ public:
     if (auto Err = readBack(P, State))
       return Err;
     llvm::outs() << "Read data back.\n";
-    if (auto Err = waitForSignal(State))
-      return Err;
-    llvm::outs() << "Wait and Sync...\n";
 
     return llvm::Error::success();
   }


### PR DESCRIPTION
There's no need to split the workload into multiple command-lists, and there are various unnecessary waitForSignal's that can be removed.

Also fixed logic for deciding if a resource is a UAV or not (UAV's are ReadWrite, not ReadOnly resources).
