### PR TITLE
Enable passing clang builders for prs

### DIFF
--- a/.github/workflows/macos-clang-mtl.yaml
+++ b/.github/workflows/macos-clang-mtl.yaml
@@ -21,3 +21,4 @@ jobs:
       SKU: macOS
       Test-Clang: On
       TestTarget: check-hlsl-clang-mtl
+      HLSLTest-branch: ${{ github.ref }}

--- a/.github/workflows/macos-clang-mtl.yaml
+++ b/.github/workflows/macos-clang-mtl.yaml
@@ -9,6 +9,10 @@ on:
   schedule:
     - cron: '*/30 * * * *' # run every 30 minutes
 
+  pull_request:
+    branches:
+      - main
+
 jobs:
   macOS-Metal-Clang:
     uses: ./.github/workflows/test-all.yaml

--- a/.github/workflows/windows-intel-clang-d3d12.yaml
+++ b/.github/workflows/windows-intel-clang-d3d12.yaml
@@ -9,6 +9,10 @@ on:
   schedule:
     - cron: '0 * * * *' # run every 30 minutes
 
+  pull_request:
+    branches:
+      - main
+
 jobs:
   Windows-D3D12-Intel-Clang:
     uses: ./.github/workflows/test-all.yaml

--- a/.github/workflows/windows-intel-clang-d3d12.yaml
+++ b/.github/workflows/windows-intel-clang-d3d12.yaml
@@ -21,3 +21,5 @@ jobs:
       SKU: GPU-Intel
       Test-Clang: On
       TestTarget: check-hlsl-clang-d3d12
+      HLSLTest-branch: ${{ github.ref }}
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl

--- a/.github/workflows/windows-intel-clang-warp-d3d12.yaml
+++ b/.github/workflows/windows-intel-clang-warp-d3d12.yaml
@@ -9,6 +9,10 @@ on:
   schedule:
     - cron: '0 * * * *' # run every 30 minutes
 
+  pull_request:
+    branches:
+      - main
+
 jobs:
   Windows-D3D12-Warp-Clang:
     uses: ./.github/workflows/test-all.yaml

--- a/.github/workflows/windows-intel-clang-warp-d3d12.yaml
+++ b/.github/workflows/windows-intel-clang-warp-d3d12.yaml
@@ -21,4 +21,5 @@ jobs:
       SKU: GPU-Intel
       Test-Clang: On
       TestTarget: check-hlsl-clang-warp-d3d12
+      HLSLTest-branch: ${{ github.ref }}
       LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl

--- a/.github/workflows/windows-nv-clang-d3d12.yaml
+++ b/.github/workflows/windows-nv-clang-d3d12.yaml
@@ -18,4 +18,5 @@ jobs:
       SKU: GPU-NV
       Test-Clang: On
       TestTarget: check-hlsl-clang-d3d12
+      HLSLTest-branch: ${{ github.ref }}
       LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl

--- a/.github/workflows/windows-nv-clang-vk.yaml
+++ b/.github/workflows/windows-nv-clang-vk.yaml
@@ -18,4 +18,5 @@ jobs:
       SKU: GPU-NV
       Test-Clang: On
       TestTarget: check-hlsl-clang-vk
+      HLSLTest-branch: ${{ github.ref }}
       LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl

--- a/.github/workflows/windows-nv-dxc-d3d12.yaml
+++ b/.github/workflows/windows-nv-dxc-d3d12.yaml
@@ -19,4 +19,5 @@ jobs:
       Test-Clang: Off
       BuildType: Debug
       TestTarget: check-hlsl-d3d12
+      HLSLTest-branch: ${{ github.ref }}
       LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl

--- a/.github/workflows/windows-nv-dxc-vk.yaml
+++ b/.github/workflows/windows-nv-dxc-vk.yaml
@@ -19,4 +19,5 @@ jobs:
       Test-Clang: Off
       BuildType: Debug
       TestTarget: check-hlsl-vk
+      HLSLTest-branch: ${{ github.ref }}
       LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl

--- a/test/Basic/StructuredBuffer.test
+++ b/test/Basic/StructuredBuffer.test
@@ -39,6 +39,7 @@ DescriptorSets:
 ...
 #--- end
 
+# UNSUPPORTED: Clang
 # RUN: split-file %s %t
 # RUN: %if DirectX %{ dxc -T cs_6_0 -Fo %t.dxil %t/source.hlsl %}
 # RUN: %if DirectX %{ %offloader %t/pipeline.yaml %t.dxil | FileCheck %s %}


### PR DESCRIPTION
This PR adds the currently passing clang build configurations to the PR checks, and marks the StructuredBuffer test as unsupoorted on Clang because it is currently crashing Clang.