### PR TITLE
Add new imagediff tool

### DIFF
--- a/.github/workflows/test-all.yaml
+++ b/.github/workflows/test-all.yaml
@@ -146,7 +146,9 @@ jobs:
           lfs: true
           fetch-depth: 1
       - name: Checkout Golden Images - LFS objects
-        run: git lfs checkout
+        run: |
+             cd golden-images
+             git lfs checkout
       - name: Setup Windows
         if: inputs.OS == 'windows'
         uses: llvm/actions/setup-windows@main

--- a/.github/workflows/test-all.yaml
+++ b/.github/workflows/test-all.yaml
@@ -137,7 +137,7 @@ jobs:
           ref: ${{ inputs.HLSLTest-branch }}
           path: HLSLTest
           fetch-depth: 1
-      - name: Checkout HLSLTest
+      - name: Checkout Golden Images
         uses: actions/checkout@v4
         with:
           repository: llvm-beanz/offload-golden-images
@@ -145,6 +145,8 @@ jobs:
           path: golden-images
           lfs: true
           fetch-depth: 1
+      - name: Checkout Golden Images - LFS objects
+        run: git lfs checkout
       - name: Setup Windows
         if: inputs.OS == 'windows'
         uses: llvm/actions/setup-windows@main

--- a/.github/workflows/test-all.yaml
+++ b/.github/workflows/test-all.yaml
@@ -143,12 +143,7 @@ jobs:
           repository: llvm-beanz/offload-golden-images
           ref: main
           path: golden-images
-          lfs: true
           fetch-depth: 1
-      - name: Checkout Golden Images - LFS objects
-        run: |
-             cd golden-images
-             git lfs checkout
       - name: Setup Windows
         if: inputs.OS == 'windows'
         uses: llvm/actions/setup-windows@main

--- a/.github/workflows/test-all.yaml
+++ b/.github/workflows/test-all.yaml
@@ -137,6 +137,14 @@ jobs:
           ref: ${{ inputs.HLSLTest-branch }}
           path: HLSLTest
           fetch-depth: 1
+      - name: Checkout HLSLTest
+        uses: actions/checkout@v4
+        with:
+          repository: llvm-beanz/offload-golden-images
+          ref: main
+          path: golden-images
+          lfs: true
+          fetch-depth: 1
       - name: Setup Windows
         if: inputs.OS == 'windows'
         uses: llvm/actions/setup-windows@main
@@ -154,7 +162,7 @@ jobs:
             cd llvm-project
             mkdir build
             cd build
-            cmake -G Ninja ${{ inputs.LLVM-ExtraCMakeArgs }} -DCMAKE_BUILD_TYPE=${{ inputs.BuildType }} -C ${{ github.workspace }}/llvm-project/clang/cmake/caches/HLSL.cmake -C ${{ github.workspace }}/HLSLTest/cmake/caches/sccache.cmake -DDXC_DIR=${{ github.workspace }}/DXC/build/bin -DLLVM_EXTERNAL_HLSLTEST_SOURCE_DIR=${{ github.workspace }}/HLSLTest -DLLVM_EXTERNAL_PROJECTS="HLSLTest" -DLLVM_LIT_ARGS="--xunit-xml-output=testresults.xunit.xml -v" -DHLSLTEST_TEST_CLANG=${{ inputs.Test-Clang }} ${{ github.workspace }}/llvm-project/llvm/
+            cmake -G Ninja ${{ inputs.LLVM-ExtraCMakeArgs }} -DCMAKE_BUILD_TYPE=${{ inputs.BuildType }} -C ${{ github.workspace }}/llvm-project/clang/cmake/caches/HLSL.cmake -C ${{ github.workspace }}/HLSLTest/cmake/caches/sccache.cmake -DDXC_DIR=${{ github.workspace }}/DXC/build/bin -DLLVM_EXTERNAL_HLSLTEST_SOURCE_DIR=${{ github.workspace }}/HLSLTest -DLLVM_EXTERNAL_PROJECTS="HLSLTest" -DLLVM_LIT_ARGS="--xunit-xml-output=testresults.xunit.xml -v" -DHLSLTEST_TEST_CLANG=${{ inputs.Test-Clang }} -DGOLDENIMAGE_DIR=${{ github.workspace }}/golden-images ${{ github.workspace }}/llvm-project/llvm/
             ninja hlsl-test-depends
       - name: Run HLSL Tests
         run: |

--- a/include/Image/Color.h
+++ b/include/Image/Color.h
@@ -102,7 +102,7 @@ public:
     Color LCol = L.translateSpace(ColorSpace::LAB);
     Color RCol = R.translateSpace(ColorSpace::LAB);
     Color Res = LCol - RCol;
-    return std::sqrt((Res.R * Res.R) + (Res.G * Res.G) + (Res.B * Res.B));
+    return sqrt((Res.R * Res.R) + (Res.G * Res.G) + (Res.B * Res.B));
   }
 
 private:

--- a/include/Image/Color.h
+++ b/include/Image/Color.h
@@ -13,6 +13,7 @@
 #define HLSLTEST_IMAGE_COLOR_H
 
 #include <algorithm>
+#include <assert.h>
 #include <tuple>
 #include <type_traits>
 
@@ -39,6 +40,7 @@ template <typename NewTy, typename OldTy> NewTy convertColor(OldTy Val) {
   if constexpr (std::is_same_v<NewTy, OldTy>)
     return Val;
   double Dbl = toDouble(Val);
+  assert(Dbl >= 0.0 && Dbl <= 1.0 && "Value should be normalized");
   if constexpr (std::is_integral_v<NewTy>)
     return toInt<NewTy>(Dbl);
   return static_cast<NewTy>(Dbl);
@@ -88,6 +90,11 @@ public:
     if (NewCS == Space)
       return *this;
     return translateSpaceImpl(NewCS);
+  }
+
+  Color operator-(const Color &C) const {
+    assert(Space == C.Space && "Subtracting colors in different spaces!");
+    return Color(abs(R - C.R), abs(G - C.G), abs(B - C.B), Space);
   }
 
 private:

--- a/include/Image/Color.h
+++ b/include/Image/Color.h
@@ -14,6 +14,7 @@
 
 #include <algorithm>
 #include <assert.h>
+#include <math.h>
 #include <tuple>
 #include <type_traits>
 
@@ -95,6 +96,13 @@ public:
   Color operator-(const Color &C) const {
     assert(Space == C.Space && "Subtracting colors in different spaces!");
     return Color(abs(R - C.R), abs(G - C.G), abs(B - C.B), Space);
+  }
+
+  static double CIE75Distance(Color L, Color R) {
+    Color LCol = L.translateSpace(ColorSpace::LAB);
+    Color RCol = R.translateSpace(ColorSpace::LAB);
+    Color Res = LCol - RCol;
+    return std::sqrt((Res.R * Res.R) + (Res.G * Res.G) + (Res.B * Res.B));
   }
 
 private:

--- a/include/Image/Image.h
+++ b/include/Image/Image.h
@@ -12,6 +12,7 @@
 #ifndef HLSLTEST_IMAGE_IMAGE_H
 #define HLSLTEST_IMAGE_IMAGE_H
 
+#include "Image/Color.h"
 #include "Support/Pipeline.h"
 
 #include "llvm/ADT/StringRef.h"
@@ -81,6 +82,14 @@ class Image : public ImageRef {
     Data = llvm::StringRef(OwnedData.get(), Sz);
   }
 
+  Image(uint32_t H, uint32_t W, uint8_t D, uint8_t C, bool F,
+        std::unique_ptr<char[]> &&Ptr)
+      : ImageRef(H, W, D, C, F), OwnedData(std::move(Ptr)) {
+    uint64_t Sz = static_cast<uint64_t>(H) * static_cast<uint64_t>(W) *
+                  static_cast<uint64_t>(D) * static_cast<uint64_t>(C);
+    Data = llvm::StringRef(OwnedData.get(), Sz);
+  }
+
 public:
   // Not default constructable.
   Image() = delete;
@@ -93,10 +102,14 @@ public:
 
   ImageRef getRef() const { return ImageRef(*this); }
 
-  static llvm::Error WritePNG(ImageRef I, llvm::StringRef Path);
+  static llvm::Error writePNG(ImageRef I, llvm::StringRef Path);
 
   static Image translateImage(ImageRef I, uint8_t Depth, uint8_t Channels,
                               bool Float);
+  static llvm::Expected<Image> loadPNG(llvm::StringRef Path);
+
+  static llvm::Expected<Image> computeDistance(ImageRef LHS, ImageRef RHS,
+                                               double &RMS, double &Furthest);
 
   char *data() { return OwnedData.get(); }
 };

--- a/include/Image/ImageComparators.h
+++ b/include/Image/ImageComparators.h
@@ -90,65 +90,7 @@ public:
       OS << "Error: " << ErrStr << "\n";
   }
 
-  bool evaluateCheck(const CompareCheck &C, llvm::raw_ostream &Err) {
-    switch (C.Type) {
-    case CompareCheck::Furthest:
-      if (Furthest > C.Val) {
-        Err << "Furthest color distance check failed: " << Furthest
-            << " above threshold " << C.Val;
-        return false;
-      }
-      return true;
-    case CompareCheck::RMS:
-      if (RMS > C.Val) {
-        Err << "RMS check failed. RMS " << RMS << " above threshold " << C.Val;
-        return false;
-      }
-      return true;
-    case CompareCheck::DiffRMS:
-      if (DiffRMS > C.Val) {
-        Err << "Differing RMS check failed. RMS of differing pixels " << DiffRMS
-            << " above threshold " << C.Val;
-        return false;
-      }
-      return true;
-    case CompareCheck::PixelPercent: {
-      double DiffPercent = (static_cast<double>(VisibleDiffs) /
-                            static_cast<double>(Count) * 100.0);
-      if (DiffPercent > C.Val) {
-        Err << "PixelPercent check failed. Difference percent " << DiffPercent
-            << " above threshold " << C.Val;
-        return false;
-      }
-      return true;
-    }
-    case CompareCheck::Intervals: {
-      double DblCount = static_cast<double>(Count);
-      for (uint32_t I = 0; I < 10; ++I) {
-        if (I >= C.Vals.size()) {
-          if (Histogram[I] == 0)
-            continue;
-          Err << "Interval[" << I
-              << "]: Contains non-zero value: " << Histogram[I];
-          return false;
-        }
-
-        double DiffPercent =
-            (static_cast<double>(Histogram[I]) / DblCount * 100.0);
-        if (DiffPercent > C.Vals[I]) {
-          Err << "Interval[" << I << "]: Out of range. Maximum: " << C.Vals[I]
-              << " Actual: " << DiffPercent;
-          return false;
-        }
-      }
-      for (int I = C.Vals.size(); I < 10; ++I) {
-      }
-      return true;
-    }
-    case CompareCheck::None:
-      llvm_unreachable("Check run with no rule");
-    }
-  }
+  bool evaluateCheck(const CompareCheck &C, llvm::raw_ostream &Err);
 
   bool result() override {
     RMS = sqrt(RMS / static_cast<double>(Count));

--- a/include/Image/ImageComparators.h
+++ b/include/Image/ImageComparators.h
@@ -1,0 +1,75 @@
+//===- ImageComparators.h - Image Comparators -------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+//
+//===----------------------------------------------------------------------===//
+
+#include "Image/Color.h"
+#include "Image/Image.h"
+
+#include "llvm/Support/raw_ostream.h"
+
+#include <algorithm>
+
+#ifndef HLSLTEST_IMAGE_IMAGECOMPARATOR_H
+#define HLSLTEST_IMAGE_IMAGECOMPARATOR_H
+
+namespace hlsltest {
+class ImageComparatorDistance : public ImageComparatorBase {
+  double Furthest = 0.0;
+  double RMS = 0.0;
+  uint64_t Count = 0;
+
+public:
+  void processPixel(Color L, Color R) override {
+    double Distance = Color::CIE75Distance(L, R);
+    Furthest = std::max(Furthest, Distance);
+    RMS += Distance;
+    Count += 1;
+  }
+
+  void print(llvm::raw_ostream &OS) override {
+    OS << "RMS Difference: " << RMS << "\n";
+    OS << "Furthest Pixel Difference: " << Furthest << "\n";
+  }
+
+  bool result() override {
+    RMS /= (static_cast<double>(Count) * 3.0);
+    // 2.3 corresponds to a "just noticeable distance" for the CIE76
+    // difference algorithm. If no pixels are worse than that, there should be
+    // no noticeable difference in the image.
+    return Furthest < 2.3;
+  }
+};
+
+class ImageComparatorDiffImage : public ImageComparatorBase {
+  Image DiffImg;
+  float *DiffPtr;
+  llvm::StringRef OutputFilename;
+
+public:
+  virtual ~ImageComparatorDiffImage() {}
+  ImageComparatorDiffImage(uint32_t Height, uint32_t Width, llvm::StringRef OF)
+      : DiffImg(Height, Width, 4, 3, true), OutputFilename(OF) {
+    DiffPtr = reinterpret_cast<float *>(DiffImg.data());
+  }
+  void processPixel(Color L, Color R) override {
+    // TODO: I should probably instead use a color distance for this too...
+    DiffPtr[0] = abs(L.R - R.R);
+    DiffPtr[1] = abs(L.G - R.G);
+    DiffPtr[2] = abs(L.B - R.B);
+    DiffPtr += 3;
+  }
+
+  void print(llvm::raw_ostream &) override {
+    llvm::consumeError(Image::writePNG(DiffImg, OutputFilename));
+  }
+};
+} // namespace hlsltest
+
+#endif // HLSLTEST_IMAGE_IMAGECOMPARATOR_H

--- a/include/Image/ImageComparators.h
+++ b/include/Image/ImageComparators.h
@@ -12,6 +12,7 @@
 #include "Image/Color.h"
 #include "Image/Image.h"
 
+#include "llvm/Support/YAMLTraits.h"
 #include "llvm/Support/raw_ostream.h"
 
 #include <algorithm>
@@ -20,30 +21,146 @@
 #define HLSLTEST_IMAGE_IMAGECOMPARATOR_H
 
 namespace hlsltest {
+
+struct CompareCheck {
+  enum CheckType {
+    None,
+    Furthest,
+    RMS,
+    DiffRMS,
+    PixelPercent,
+    Intervals,
+  } Type = None;
+  double Val = 0;
+  std::vector<double> Vals = {};
+};
+
 class ImageComparatorDistance : public ImageComparatorBase {
   double Furthest = 0.0;
   double RMS = 0.0;
+  double DiffRMS = 0.0;
   uint64_t Count = 0;
+  uint64_t VisibleDiffs = 0;
+  uint64_t Histogram[10] = {0};
+
+  llvm::SmallVector<CompareCheck> Checks;
+
+  llvm::SmallString<256> ErrStr;
+
+  // 2.3 corresponds to a "just noticeable distance" for the CIE76
+  // difference algorithm. If no pixels are worse than that, there should be
+  // no noticeable difference in the image.
+  static constexpr double VisibleDiff = 2.3;
 
 public:
+  ImageComparatorDistance() {
+    Checks.push_back(CompareCheck{CompareCheck::Furthest, VisibleDiff});
+  }
+  ImageComparatorDistance(llvm::ArrayRef<CompareCheck> C) : Checks(C) {}
   void processPixel(Color L, Color R) override {
     double Distance = Color::CIE75Distance(L, R);
+    if (Distance > VisibleDiff) {
+      VisibleDiffs += 1;
+      DiffRMS += Distance;
+
+      // A difference >10 is a more than 10% off in the L*a*b color space.
+      int Idx = static_cast<int>(std::clamp(Distance - VisibleDiff, 0.0, 9.0));
+      Histogram[Idx] += 1;
+    }
+
     Furthest = std::max(Furthest, Distance);
     RMS += Distance;
     Count += 1;
   }
 
   void print(llvm::raw_ostream &OS) override {
+    double CountDbl = static_cast<double>(Count);
     OS << "RMS Difference: " << RMS << "\n";
     OS << "Furthest Pixel Difference: " << Furthest << "\n";
+    OS << "Pixels with visible differences: " << VisibleDiffs << " "
+       << (static_cast<double>(VisibleDiffs) / CountDbl * 100.0) << "%\n";
+    OS << "RMS Different Pixels Only: " << DiffRMS << "\n";
+    OS << "Total Pixels: " << Count << "\n";
+    OS << "Histogram Data:\n";
+    for (int I = 0; I < 10; ++I) {
+      OS << "\t[" << I << "]: " << Histogram[I] << " "
+         << (static_cast<double>(Histogram[I]) / CountDbl * 100.0) << "\n";
+    }
+    if (!ErrStr.empty())
+      OS << "Error: " << ErrStr << "\n";
+  }
+
+  bool evaluateCheck(const CompareCheck &C, llvm::raw_ostream &Err) {
+    switch (C.Type) {
+    case CompareCheck::Furthest:
+      if (Furthest > C.Val) {
+        Err << "Furthest color distance check failed: " << Furthest
+            << " above threshold " << C.Val;
+        return false;
+      }
+      return true;
+    case CompareCheck::RMS:
+      if (RMS > C.Val) {
+        Err << "RMS check failed. RMS " << RMS << " above threshold " << C.Val;
+        return false;
+      }
+      return true;
+    case CompareCheck::DiffRMS:
+      if (DiffRMS > C.Val) {
+        Err << "Differing RMS check failed. RMS of differing pixels " << DiffRMS
+            << " above threshold " << C.Val;
+        return false;
+      }
+      return true;
+    case CompareCheck::PixelPercent: {
+      double DiffPercent = (static_cast<double>(VisibleDiffs) /
+                            static_cast<double>(Count) * 100.0);
+      if (DiffPercent > C.Val) {
+        Err << "PixelPercent check failed. Difference percent " << DiffPercent
+            << " above threshold " << C.Val;
+        return false;
+      }
+      return true;
+    }
+    case CompareCheck::Intervals: {
+      double DblCount = static_cast<double>(Count);
+      for (uint32_t I = 0; I < 10; ++I) {
+        if (I >= C.Vals.size()) {
+          if (Histogram[I] == 0)
+            continue;
+          Err << "Interval[" << I
+              << "]: Contains non-zero value: " << Histogram[I];
+          return false;
+        }
+
+        double DiffPercent =
+            (static_cast<double>(Histogram[I]) / DblCount * 100.0);
+        if (DiffPercent > C.Vals[I]) {
+          Err << "Interval[" << I << "]: Out of range. Maximum: " << C.Vals[I]
+              << " Actual: " << DiffPercent;
+          return false;
+        }
+      }
+      for (int I = C.Vals.size(); I < 10; ++I) {
+      }
+      return true;
+    }
+    case CompareCheck::None:
+      llvm_unreachable("Check run with no rule");
+    }
   }
 
   bool result() override {
-    RMS /= (static_cast<double>(Count) * 3.0);
-    // 2.3 corresponds to a "just noticeable distance" for the CIE76
-    // difference algorithm. If no pixels are worse than that, there should be
-    // no noticeable difference in the image.
-    return Furthest < 2.3;
+    RMS = sqrt(RMS / static_cast<double>(Count));
+    DiffRMS = sqrt(DiffRMS / static_cast<double>(VisibleDiffs));
+    llvm::raw_svector_ostream Err(ErrStr);
+
+    for (const auto &C : Checks) {
+      if (!evaluateCheck(C, Err))
+        return false;
+    }
+
+    return true;
   }
 };
 
@@ -71,5 +188,28 @@ public:
   }
 };
 } // namespace hlsltest
+
+LLVM_YAML_IS_SEQUENCE_VECTOR(hlsltest::CompareCheck)
+
+namespace llvm {
+namespace yaml {
+
+template <> struct MappingTraits<hlsltest::CompareCheck> {
+  static void mapping(IO &I, hlsltest::CompareCheck &C);
+};
+
+template <> struct ScalarEnumerationTraits<hlsltest::CompareCheck::CheckType> {
+  static void enumeration(IO &I, hlsltest::CompareCheck::CheckType &V) {
+#define ENUM_CASE(Val) I.enumCase(V, #Val, hlsltest::CompareCheck::Val)
+    ENUM_CASE(Furthest);
+    ENUM_CASE(RMS);
+    ENUM_CASE(DiffRMS);
+    ENUM_CASE(PixelPercent);
+    ENUM_CASE(Intervals);
+#undef ENUM_CASE
+  }
+};
+} // namespace yaml
+} // namespace llvm
 
 #endif // HLSLTEST_IMAGE_IMAGECOMPARATOR_H

--- a/lib/Image/CMakeLists.txt
+++ b/lib/Image/CMakeLists.txt
@@ -1,4 +1,7 @@
-add_hlsl_library(Image Color.cpp Image.cpp)
+add_hlsl_library(Image
+                 Color.cpp
+                 Image.cpp
+                 ImageComparators.cpp)
 
 target_include_directories(HLSLTestImage PRIVATE SYSTEM BEFORE
                            "${HLSLTEST_BINARY_DIR}/third-party/libpng/"

--- a/lib/Image/Image.cpp
+++ b/lib/Image/Image.cpp
@@ -17,14 +17,16 @@
 #include "llvm/Support/Error.h"
 #include "llvm/Support/SwapByteOrder.h"
 
-#include <limits.h>
 #include <png.h>
+
+#include <algorithm>
+#include <limits.h>
 #include <stdio.h>
 
 using namespace hlsltest;
 
 template <typename DstType, typename SrcType>
-void TranslatePixelData(Image &Dst, ImageRef Src) {
+void TranslatePixelData(Image &Dst, ImageRef Src, bool ForWrite) {
   uint64_t Pixels = Dst.getHeight() * Dst.getWidth();
   uint32_t CopiedChannels = std::min(Dst.getChannels(), Src.getChannels());
   DstType *DstPtr = reinterpret_cast<DstType *>(Dst.data());
@@ -33,7 +35,7 @@ void TranslatePixelData(Image &Dst, ImageRef Src) {
     for (uint32_t J = 0; J < CopiedChannels; ++J, ++SrcPtr, ++DstPtr) {
       *DstPtr = ColorUtils::convertColor<DstType>(*SrcPtr);
 
-      if constexpr (sizeof(DstType) > 1 && !llvm::sys::IsBigEndianHost)
+      if (ForWrite && sizeof(DstType) > 1 && !llvm::sys::IsBigEndianHost)
         llvm::sys::swapByteOrder(*DstPtr);
     }
     // If the destination has more channels fill it with saturated values.
@@ -50,43 +52,56 @@ void TranslatePixelData(Image &Dst, ImageRef Src) {
   }
 }
 
-template <typename SrcType> void translatePixelSrc(Image &Dst, ImageRef Src) {
+template <typename SrcType>
+void translatePixelSrc(Image &Dst, ImageRef Src, bool ForWrite) {
 
   switch (Dst.getDepth()) {
   case 1:
     assert(!Dst.isFloat() && "No float8 support!");
-    TranslatePixelData<uint8_t, SrcType>(Dst, Src);
+    TranslatePixelData<uint8_t, SrcType>(Dst, Src, ForWrite);
     break;
   case 2:
     assert(!Dst.isFloat() && "No float16 support!");
-    TranslatePixelData<uint16_t, SrcType>(Dst, Src);
+    TranslatePixelData<uint16_t, SrcType>(Dst, Src, ForWrite);
+    break;
+  case 4:
+    if (Dst.isFloat())
+      TranslatePixelData<float, SrcType>(Dst, Src, ForWrite);
+    else
+      TranslatePixelData<uint32_t, SrcType>(Dst, Src, ForWrite);
+    break;
+  case 8:
+    if (Dst.isFloat())
+      TranslatePixelData<double, SrcType>(Dst, Src, ForWrite);
+    else
+      TranslatePixelData<uint64_t, SrcType>(Dst, Src, ForWrite);
     break;
   default:
     llvm_unreachable("Destination depth out of expected range.");
   }
 }
 
-void translatePixels(Image &Dst, ImageRef Src) {
+void translatePixels(Image &Dst, ImageRef Src, bool ForWrite = false) {
   switch (Src.getDepth()) {
   case 1:
     assert(!Src.isFloat() && "No float8 support!");
-    translatePixelSrc<uint8_t>(Dst, Src);
+    translatePixelSrc<uint8_t>(Dst, Src, ForWrite);
     break;
   case 2:
     assert(!Src.isFloat() && "No float16 support!");
-    translatePixelSrc<uint16_t>(Dst, Src);
+    translatePixelSrc<uint16_t>(Dst, Src, ForWrite);
     break;
   case 4:
     if (Src.isFloat())
-      translatePixelSrc<float>(Dst, Src);
+      translatePixelSrc<float>(Dst, Src, ForWrite);
     else
-      translatePixelSrc<uint32_t>(Dst, Src);
+      translatePixelSrc<uint32_t>(Dst, Src, ForWrite);
     break;
   case 8:
     if (Src.isFloat())
-      translatePixelSrc<double>(Dst, Src);
+      translatePixelSrc<double>(Dst, Src, ForWrite);
     else
-      translatePixelSrc<uint64_t>(Dst, Src);
+      translatePixelSrc<uint64_t>(Dst, Src, ForWrite);
     break;
   default:
     llvm_unreachable("Source depth out of expected range.");
@@ -101,13 +116,12 @@ Image Image::translateImage(ImageRef Src, uint8_t Depth, uint8_t Channels,
   return NewImage;
 }
 
-llvm::Error WritePNGImpl(ImageRef Img, llvm::StringRef OutputPath) {
+llvm::Error writePNGImpl(ImageRef Img, llvm::StringRef OutputPath) {
   png_structp PNG =
       png_create_write_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
   if (!PNG)
     return llvm::createStringError(std::errc::io_error,
                                    "Failed creating PNG data");
-
   png_infop PNGInfo = png_create_info_struct(PNG);
   FILE *F = nullptr;
   auto ScopeExit = llvm::make_scope_exit([&PNG, &PNGInfo, &F]() {
@@ -122,10 +136,14 @@ llvm::Error WritePNGImpl(ImageRef Img, llvm::StringRef OutputPath) {
   F = fopen(OutputPath.data(), "wb");
   if (!F)
     return llvm::createStringError(std::errc::io_error, "Failed openiong file");
+  unsigned ImgFormat =
+      Img.getChannels() == 4 ? PNG_COLOR_TYPE_RGB_ALPHA : PNG_COLOR_TYPE_RGB;
+  assert((Img.getChannels() == 3 || Img.getChannels() == 4) &&
+         "Only support RGB and RGBA images.");
   png_init_io(PNG, F);
   png_set_IHDR(PNG, PNGInfo, Img.getWidth(), Img.getHeight(), Img.getBitDepth(),
-               PNG_COLOR_TYPE_RGB_ALPHA, PNG_INTERLACE_NONE,
-               PNG_COMPRESSION_TYPE_BASE, PNG_FILTER_TYPE_BASE);
+               ImgFormat, PNG_INTERLACE_NONE, PNG_COMPRESSION_TYPE_BASE,
+               PNG_FILTER_TYPE_BASE);
   png_colorp ColorP =
       (png_colorp)png_malloc(PNG, PNG_MAX_PALETTE_LENGTH * sizeof(png_color));
   if (!ColorP)
@@ -150,11 +168,91 @@ llvm::Error WritePNGImpl(ImageRef Img, llvm::StringRef OutputPath) {
   return llvm::Error::success();
 }
 
-llvm::Error Image::WritePNG(ImageRef Img, llvm::StringRef Path) {
+llvm::Error Image::writePNG(ImageRef Img, llvm::StringRef Path) {
   uint32_t NewDepth = std::min(static_cast<uint32_t>(Img.getDepth()), 2u);
-  if (Img.isFloat() || Img.getDepth() != NewDepth) {
-    Image Translated = translateImage(Img, NewDepth, Img.getChannels(), false);
-    return WritePNGImpl(Translated, Path);
+
+  // If the image depth is > 1, we need to translate it to get the right
+  // endianness.
+  if (Img.getDepth() > 1) {
+    Image Translated = Image(Img.getHeight(), Img.getWidth(), NewDepth,
+                             Img.getChannels(), false);
+    translatePixels(Translated, Img, /* ForWrite */ true);
+    return writePNGImpl(Translated, Path);
   }
-  return WritePNGImpl(Img, Path);
+  return writePNGImpl(Img, Path);
+}
+
+llvm::Expected<Image> Image::loadPNG(llvm::StringRef Path) {
+  png_image PNG;
+  memset(&PNG, 0, sizeof(png_image));
+  PNG.version = PNG_IMAGE_VERSION;
+
+  if (png_image_begin_read_from_file(&PNG, Path.data()) == 0)
+    return llvm::createStringError(std::errc::io_error,
+                                   "Failed reading PNG header from file");
+
+  auto ScopeExit = llvm::make_scope_exit([&PNG]() { png_image_free(&PNG); });
+
+  PNG.format = PNG_FORMAT_RGB;
+  size_t Size = PNG_IMAGE_SIZE(PNG);
+  std::unique_ptr<char[]> Buffer = std::make_unique<char[]>(Size);
+
+  if (png_image_finish_read(&PNG, NULL /*background*/,
+                            reinterpret_cast<png_bytep>(Buffer.get()),
+                            0 /*row_stride*/, NULL /*colormap*/) == 0)
+    return llvm::createStringError(std::errc::io_error,
+                                   "Failed reading PNG data from file");
+  uint32_t BytesPerPixel =
+      static_cast<uint32_t>(Size / (PNG.height * PNG.width));
+  uint32_t Channels = 3;
+  Image Result =
+      Image(PNG.height, PNG.width, /*Depth*/ BytesPerPixel / Channels, Channels,
+            false, std::move(Buffer));
+  return Result;
+}
+
+llvm::Expected<Image> Image::computeDistance(ImageRef LHS, ImageRef RHS,
+                                             double &RMS, double &Furthest) {
+  if (LHS.getHeight() != RHS.getHeight() || LHS.getWidth() != RHS.getWidth())
+    return llvm::createStringError(
+        std::errc::not_supported,
+        "Cannot compute a difference of images with different dimensions.");
+  assert(LHS.getChannels() >= 3 &&
+         "Cannot operate on images with less than 3 channels.");
+  assert(RHS.getChannels() >= 3 &&
+         "Cannot operate on images with less than 3 channels.");
+  uint32_t CmpDepth = 4;
+  uint32_t CmpChannels = 3u;
+
+  Image L = Image::translateImage(LHS, CmpDepth, CmpChannels, true);
+  Image R = Image::translateImage(RHS, CmpDepth, CmpChannels, true);
+
+  Image NewImage =
+      Image(LHS.getHeight(), LHS.getWidth(), CmpDepth, CmpChannels, true);
+  const float *LPtr = reinterpret_cast<const float *>(L.data());
+  const float *RPtr = reinterpret_cast<const float *>(R.data());
+  float *Diff = reinterpret_cast<float *>(NewImage.data());
+
+  uint64_t PixelCt = static_cast<uint64_t>(NewImage.getHeight()) *
+                     static_cast<uint64_t>(NewImage.getWidth());
+  RMS = 0.0;
+  for (uint64_t I = 0; I < PixelCt; ++I, LPtr += 3, RPtr += 3, Diff += 3) {
+    Color LCol =
+        Color(LPtr[0], LPtr[1], LPtr[2]).translateSpace(ColorSpace::LAB);
+    Color RCol =
+        Color(RPtr[0], RPtr[1], RPtr[2]).translateSpace(ColorSpace::LAB);
+
+    Diff[0] = abs(LPtr[0] - RPtr[0]);
+    Diff[1] = abs(LPtr[1] - RPtr[1]);
+    Diff[2] = abs(LPtr[2] - RPtr[2]);
+    Color Res = LCol - RCol;
+    double Distance =
+        std::sqrt((Res.R * Res.R) + (Res.G * Res.G) + (Res.B * Res.B));
+    Furthest = std::max(Furthest, Distance);
+    RMS += Distance;
+  }
+
+  RMS /= (PixelCt * CmpChannels);
+
+  return NewImage;
 }

--- a/lib/Image/ImageComparators.cpp
+++ b/lib/Image/ImageComparators.cpp
@@ -21,3 +21,64 @@ void yaml::MappingTraits<CompareCheck>::mapping(IO &I, CompareCheck &C) {
   else
     I.mapRequired("Val", C.Val);
 }
+
+bool ImageComparatorDistance::evaluateCheck(const CompareCheck &C,
+                                            llvm::raw_ostream &Err) {
+  switch (C.Type) {
+  case CompareCheck::Furthest:
+    if (Furthest > C.Val) {
+      Err << "Furthest color distance check failed: " << Furthest
+          << " above threshold " << C.Val;
+      return false;
+    }
+    return true;
+  case CompareCheck::RMS:
+    if (RMS > C.Val) {
+      Err << "RMS check failed. RMS " << RMS << " above threshold " << C.Val;
+      return false;
+    }
+    return true;
+  case CompareCheck::DiffRMS:
+    if (DiffRMS > C.Val) {
+      Err << "Differing RMS check failed. RMS of differing pixels " << DiffRMS
+          << " above threshold " << C.Val;
+      return false;
+    }
+    return true;
+  case CompareCheck::PixelPercent: {
+    double DiffPercent = (static_cast<double>(VisibleDiffs) /
+                          static_cast<double>(Count) * 100.0);
+    if (DiffPercent > C.Val) {
+      Err << "PixelPercent check failed. Difference percent " << DiffPercent
+          << " above threshold " << C.Val;
+      return false;
+    }
+    return true;
+  }
+  case CompareCheck::Intervals: {
+    double DblCount = static_cast<double>(Count);
+    for (uint32_t I = 0; I < 10; ++I) {
+      if (I >= C.Vals.size()) {
+        if (Histogram[I] == 0)
+          continue;
+        Err << "Interval[" << I
+            << "]: Contains non-zero value: " << Histogram[I];
+        return false;
+      }
+
+      double DiffPercent =
+          (static_cast<double>(Histogram[I]) / DblCount * 100.0);
+      if (DiffPercent > C.Vals[I]) {
+        Err << "Interval[" << I << "]: Out of range. Maximum: " << C.Vals[I]
+            << " Actual: " << DiffPercent;
+        return false;
+      }
+    }
+    for (int I = C.Vals.size(); I < 10; ++I) {
+    }
+    return true;
+  }
+  case CompareCheck::None:
+    llvm_unreachable("Check run with no rule");
+  }
+}

--- a/lib/Image/ImageComparators.cpp
+++ b/lib/Image/ImageComparators.cpp
@@ -1,0 +1,23 @@
+//===- ImageComparators.cpp - Image Comparators -----------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+//
+//===----------------------------------------------------------------------===//
+
+#include "Image/ImageComparators.h"
+
+using namespace llvm;
+using namespace hlsltest;
+
+void yaml::MappingTraits<CompareCheck>::mapping(IO &I, CompareCheck &C) {
+  I.mapRequired("Type", C.Type);
+  if (C.Type == CompareCheck::Intervals)
+    I.mapRequired("Vals", C.Vals);
+  else
+    I.mapRequired("Val", C.Val);
+}

--- a/test/Basic/Mandelbrot.test
+++ b/test/Basic/Mandelbrot.test
@@ -75,6 +75,7 @@ DescriptorSets:
 # this test doesn't yet do anything... so we should skip it.
 
 # REQUIRES: goldenimage
+# UNSUPPORTED: Clang
 # RUN: split-file %s %t
 # RUN: %if DirectX %{ dxc -T cs_6_0 -Fo %t.dxil %t/source.hlsl %}
 # RUN: %if DirectX %{ %offloader %t/pipeline.yaml %t.dxil -r Output -o %t/output.png %}

--- a/test/Basic/Mandelbrot.test
+++ b/test/Basic/Mandelbrot.test
@@ -70,6 +70,23 @@ DescriptorSets:
         Width: 4096
         Depth: 16
 ...
+#--- rules.yaml
+---
+- Type: PixelPercent
+  Val: 0.1 # No more than 0.1% of pixels may be visibly different.
+- Type: DiffRMS
+  Val: 2.5 # The RMS of the visibly different pixels must be under 2.5 (a number chosen for no reason).
+- Type: Intervals
+  Vals: # Intervals specify percentage of pixels in distance intervals of 1 above 2.3.
+    - 0.1    # 0.1% of pixels are allowed to be between 2.3 & 3.3
+    - 0.75   # Interval of 3.3-4.3
+    - 0.05   # Interval of 4.3-5.3
+    - 0.01   # Interval of 5.3-6.3
+    - 0.0075 # Interval of 6.3-7.3
+    - 0.0075 # Interval of 7.3-8.3
+    - 0.0075 # Interval of 8.3-9.3
+    - 0.005  # Interval of 9.3-10.3 - No pixel diffs larger than 10.3 are allowed.
+...
 #--- end
 
 # this test doesn't yet do anything... so we should skip it.
@@ -84,4 +101,4 @@ DescriptorSets:
 # RUN: %if Metal %{ dxc -T cs_6_0 -Fo %t.dxil %t/source.hlsl %}
 # RUN: %if Metal %{ metal-shaderconverter %t.dxil -o=%t.metallib %}
 # RUN: %if Metal %{ %offloader %t/pipeline.yaml %t.metallib -r Output -o %t/output.png %}
-# RUN: imgdiff %t/output.png %goldenimage_dir/hlsl/Basic/Mandelbrot.png
+# RUN: imgdiff %t/output.png %goldenimage_dir/hlsl/Basic/Mandelbrot.png -rules %t/rules.yaml

--- a/test/Basic/Mandelbrot.test
+++ b/test/Basic/Mandelbrot.test
@@ -73,7 +73,7 @@ DescriptorSets:
 #--- rules.yaml
 ---
 - Type: PixelPercent
-  Val: 0.1 # No more than 0.1% of pixels may be visibly different.
+  Val: 0.2 # No more than 0.2% of pixels may be visibly different.
 - Type: DiffRMS
   Val: 2.5 # The RMS of the visibly different pixels must be under 2.5 (a number chosen for no reason).
 - Type: Intervals
@@ -81,9 +81,9 @@ DescriptorSets:
     - 0.1    # 0.1% of pixels are allowed to be between 2.3 & 3.3
     - 0.75   # Interval of 3.3-4.3
     - 0.05   # Interval of 4.3-5.3
-    - 0.01   # Interval of 5.3-6.3
-    - 0.0075 # Interval of 6.3-7.3
-    - 0.0075 # Interval of 7.3-8.3
+    - 0.05   # Interval of 5.3-6.3
+    - 0.01   # Interval of 6.3-7.3
+    - 0.01   # Interval of 7.3-8.3
     - 0.0075 # Interval of 8.3-9.3
     - 0.005  # Interval of 9.3-10.3 - No pixel diffs larger than 10.3 are allowed.
 ...

--- a/test/Basic/Mandelbrot.test
+++ b/test/Basic/Mandelbrot.test
@@ -83,4 +83,4 @@ DescriptorSets:
 # RUN: %if Metal %{ dxc -T cs_6_0 -Fo %t.dxil %t/source.hlsl %}
 # RUN: %if Metal %{ metal-shaderconverter %t.dxil -o=%t.metallib %}
 # RUN: %if Metal %{ %offloader %t/pipeline.yaml %t.metallib -r Output -o %t/output.png %}
-# RUN: cmp %t/output.png %goldenimage_dir/hlsl/Basic/Mandelbrot.png
+# RUN: imgdiff %t/output.png %goldenimage_dir/hlsl/Basic/Mandelbrot.png

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -59,6 +59,7 @@ list(APPEND HLSLTEST_DEPS
   offloader
   FileCheck
   split-file
+  imgdiff
   HLSLTestUnit)
 
 if (HLSLTEST_TEST_CLANG)

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -38,7 +38,8 @@ config.test_exec_root = os.path.join(config.hlsltest_obj_root, "test", config.hl
 
 tools = [
     ToolSubst("FileCheck", FindTool("FileCheck")),
-    ToolSubst("split-file", FindTool("split-file"))
+    ToolSubst("split-file", FindTool("split-file")),
+    ToolSubst("imgdiff", FindTool("imgdiff"))
 ]
 
 if config.hlsltest_test_warp:

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(api-query)
+add_subdirectory(imgdiff)
 add_subdirectory(offloader)

--- a/tools/imgdiff/CMakeLists.txt
+++ b/tools/imgdiff/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_hlsl_tool(imgdiff
+              imgdiff.cpp)
+
+target_link_libraries(imgdiff PRIVATE
+                      LLVMSupport
+                      HLSLTestImage
+                      HLSLTestSupport)

--- a/tools/imgdiff/imgdiff.cpp
+++ b/tools/imgdiff/imgdiff.cpp
@@ -1,0 +1,82 @@
+//===- imgdiff.cpp - Image Comparison Tool --------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+//
+//===----------------------------------------------------------------------===//
+
+#include "Image/Color.h"
+#include "Image/Image.h"
+
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/Error.h"
+#include "llvm/Support/InitLLVM.h"
+#include <string>
+
+using namespace llvm;
+using namespace hlsltest;
+
+static cl::opt<std::string> ExpectedPath(cl::Positional,
+                                         cl::desc("<expected image>"),
+                                         cl::value_desc("filename"));
+
+static cl::opt<std::string> ActualPath(cl::Positional,
+                                       cl::desc("<actual image>"),
+                                       cl::value_desc("filename"));
+
+enum class ComparisonMode { ExactMatch, CIE76 };
+
+static cl::opt<ComparisonMode>
+    Mode("mode", cl::desc("Comparison Mode"), cl::init(ComparisonMode::CIE76),
+         cl::values(clEnumValN(ComparisonMode::ExactMatch, "exact",
+                               "Exact Match of decoded image data"),
+                    clEnumValN(ComparisonMode::CIE76, "cie76",
+                               "CIE76 Color Difference")));
+
+static cl::opt<std::string> OutputFilename("o", cl::desc("Output filename"),
+                                           cl::value_desc("filename"));
+
+int main(int ArgC, char **ArgV) {
+  InitLLVM X(ArgC, ArgV);
+  cl::ParseCommandLineOptions(ArgC, ArgV, "Image Comparison Tool");
+  ExitOnError ExitOnErr("imgdiff: error: ");
+
+  Image ExpectedImage = ExitOnErr(Image::loadPNG(ExpectedPath));
+  Image ActualImage = ExitOnErr(Image::loadPNG(ActualPath));
+  if (ExpectedImage.size() != ActualImage.size())
+    ExitOnErr(createStringError(std::errc::executable_format_error,
+                                "Image sizes do not match"));
+  switch (Mode) {
+  case ComparisonMode::ExactMatch:
+    if (0 !=
+        memcmp(ExpectedImage.data(), ActualImage.data(), ExpectedImage.size()))
+      ExitOnErr(createStringError(std::errc::executable_format_error,
+                                  "Images do not match"));
+    return 0;
+  case ComparisonMode::CIE76: {
+    double RMS = 0.0;
+    double Furthest = 0.0;
+    auto ExDiff =
+        Image::computeDistance(ExpectedImage, ActualImage, RMS, Furthest);
+    if (!ExDiff)
+      ExitOnErr(ExDiff.takeError());
+    llvm::outs() << "RMS Difference: " << RMS << "\n";
+    llvm::outs() << "Furthest Pixel Difference: " << Furthest << "\n";
+    if (!OutputFilename.empty())
+      ExitOnErr(Image::writePNG(*ExDiff, OutputFilename));
+
+    // 2.3 corresponds to a "just noticeable distance" for the CIE76
+    // difference algorithm. If no pixels are worse than that, there should be
+    // no noticeable difference in the image.
+    if (Furthest < 2.3)
+      return 0;
+  }
+  }
+
+  return 1;
+}

--- a/tools/offloader/offloader.cpp
+++ b/tools/offloader/offloader.cpp
@@ -140,7 +140,7 @@ int run() {
       for (const auto &R : S.Resources) {
         if (R.OutputProps.Name == ImageOutput) {
           ImageRef Img = ImageRef(R);
-          ExitOnErr(Image::WritePNG(Img, OutputFilename));
+          ExitOnErr(Image::writePNG(Img, OutputFilename));
           return 0;
         }
       }


### PR DESCRIPTION
This change introduces a new image diff tool that has two modes for comparing PNG images.

The "Exact Match" mode loads a PNG and compares the decoded image data. This comensates for differences in the image generation tool, image headers or other encoding differences.

The "CIE76" mode compares the two images computing the CIE76 color difference, and fails if the difference of the worst pixel is greater than 2.3, which corresponds to a "just noticeable" difference. Additionally, when using the CIE match mode, a rules file may be specified with the `-rules` option to allow customizing the failure conditions based on furthest color distance, root mean square of the whole image, root mean square of the noticeably different pixels, percentage of pixels with differences, or percentage-based tolerance intervals.

The tool can also generate an image that represents the difference between the two rendered images.

In addition to introducing this tooling, this change also enables golden-image verification testing. Golden images are stored in a separate git repo (https://github.com/llvm-beanz/offload-golden-images), and are opted into during configuring the build by setting `GOLDENIMAGE_DIR` to the root of that checkout.

The only image currently tested is the Mandelbrot test.

A note for the future: CIE has several newer color difference models which would be worth using in place of the CIE76 model. I only implemented CIE76 because it was easy.