### PR TITLE
[VK] Fix crash on exit when using VVL

### DIFF
--- a/include/API/Device.h
+++ b/include/API/Device.h
@@ -62,7 +62,8 @@ public:
 #endif
 
 #ifdef OFFLOADTEST_ENABLE_VULKAN
-  static llvm::Error initializeVXDevices();
+  static llvm::Error initializeVKDevices();
+  static void cleanupVKDevices();
 #endif
 
 #ifdef OFFLOADTEST_ENABLE_METAL

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -770,13 +770,18 @@ private:
   llvm::SmallVector<std::shared_ptr<VKDevice>> Devices;
 
   VKContext() = default;
-  ~VKContext() { vkDestroyInstance(Instance, NULL); }
+  ~VKContext() { cleanup(); }
   VKContext(const VKContext &) = delete;
 
 public:
   static VKContext &instance() {
     static VKContext Ctx;
     return Ctx;
+  }
+
+  void cleanup() {
+    vkDestroyInstance(Instance, NULL);
+    Instance = VK_NULL_HANDLE;
   }
 
   llvm::Error initialize() {
@@ -850,6 +855,8 @@ public:
 };
 } // namespace
 
-llvm::Error Device::initializeVXDevices() {
+llvm::Error Device::initializeVKDevices() {
   return VKContext::instance().initialize();
 }
+
+void Device::cleanupVKDevices() { VKContext::instance().cleanup(); }


### PR DESCRIPTION
VVL has internal state which conflicts requires a specific cleanup
ordering. Because the VKContext relied on the global dtor, this order
was not respected.

There are 2 solutions:
 - use atexit
 - require an explicit call to vkDestroyDevice.

Thing is, users of `Device` except the object to be usable as a simple
singleton, with no explicit `destroy` to call.
For this reasons, it seems using `atexit` is the cleanest option from
the user perspective.