### PR TITLE
[SPIR-V] Re-enable more tests

### DIFF
--- a/test/Basic/TestFloat32Pipeline.test
+++ b/test/Basic/TestFloat32Pipeline.test
@@ -39,9 +39,6 @@ DescriptorSets:
 ...
 #--- end
 
-# https://github.com/llvm/llvm-project/issues/140739
-# UNSUPPORTED: Clang-Vulkan
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s

--- a/test/Basic/simple.test
+++ b/test/Basic/simple.test
@@ -41,9 +41,6 @@ DescriptorSets:
 ...
 #--- end
 
-# https://github.com/llvm/llvm-project/issues/140739
-# UNSUPPORTED: Clang-Vulkan
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/simple.hlsl
 # RUN: %offloader %t/simple.yaml %t.o | FileCheck %s

--- a/test/Feature/Attributes/IfBranchAttr.test
+++ b/test/Feature/Attributes/IfBranchAttr.test
@@ -48,7 +48,6 @@ DescriptorSets:
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s
 
-# UNSUPPORTED: Clang-Vulkan
 # CHECK: Name: In
 # CHECK: Format: Int32
 # CHECK: Data: [ 1, 4, 9, 16, 25, 36, 49, 64 ]

--- a/test/Feature/Attributes/IfBranchFlatten.test
+++ b/test/Feature/Attributes/IfBranchFlatten.test
@@ -48,7 +48,6 @@ DescriptorSets:
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s
 
-# UNSUPPORTED: Clang-Vulkan
 # CHECK: Name: In
 # CHECK: Format: Int32
 # CHECK: Data: [ 1, 4, 9, 16, 25, 36, 49, 64 ]

--- a/test/Feature/StructuredBuffer/srv.test
+++ b/test/Feature/StructuredBuffer/srv.test
@@ -44,9 +44,6 @@ DescriptorSets:
 ...
 #--- end
 
-# https://github.com/llvm/llvm-project/issues/140739
-# UNSUPPORTED: Clang-Vulkan
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s

--- a/test/Tools/Offloader/BufferFloat-16bit.test
+++ b/test/Tools/Offloader/BufferFloat-16bit.test
@@ -157,7 +157,6 @@ DescriptorSets:
 
 # REQUIRES: Half
 
-# UNSUPPORTED: Clang-Vulkan
 # RUN: split-file %s %t
 # RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Tools/Offloader/BufferFloat-error-16bit.test
+++ b/test/Tools/Offloader/BufferFloat-error-16bit.test
@@ -77,7 +77,6 @@ DescriptorSets:
 
 # REQUIRES: Half
 
-# UNSUPPORTED: Clang-Vulkan
 # RUN: split-file %s %t
 # RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: not %offloader %t/pipeline.yaml %t.o 2>&1 | FileCheck %s


### PR DESCRIPTION
Those tests are passing on the latest version of LLVM

Need to re-check this on top of #258