### PR TITLE
Remove XFAIL on passing WaveGetLaneIndex test

### DIFF
--- a/test/Feature/WaveOps/WaveGetLaneIndex.test
+++ b/test/Feature/WaveOps/WaveGetLaneIndex.test
@@ -39,8 +39,6 @@ DescriptorSets:
 ...
 #--- end
 
-# https://github.com/llvm/llvm-project/issues/145953
-# XFAIL: Clang-Vulkan
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
This PR addresses a test that has begun to pass unexpectedly. 
The test is passing due to this commit: https://github.com/llvm/llvm-project/pull/144371
To prevent other PRs from being blocked, this test will be expected to pass from now on.

Fixes https://github.com/llvm/offload-test-suite/issues/283