### PR TITLE
Add `AddUint64` tests

### DIFF
--- a/test/Feature/HLSLLib/adduint64.test
+++ b/test/Feature/HLSLLib/adduint64.test
@@ -63,11 +63,11 @@ DescriptorSets:
 ...
 #--- end
 
-# https://github.com/llvm/llvm-project/issues/149919
-# XFAIL: Clang-Vulkan
-
 # https://github.com/llvm/offload-test-suite/issues/292
 # XFAIL: DXC-Metal
+
+https://github.com/llvm/offload-test-suite/issues/344
+# XFAIL: Clang-Metal
 
 # UNSUPPORTED: DXC-Vulkan
 


### PR DESCRIPTION
Closes #109.

Adds a test for `AddUint64` testing `UInt32` type. Values primarily pulled from [HLK tests](https://github.com/microsoft/DirectXShaderCompiler/blob/57177f77a4dc6996400ac97a0d618799c82374e8/tools/clang/unittests/HLSLExec/ShaderOpArithTable.xml#L4241).
Need to remove XFAILs after #292 and #344 are fixed.