### PR TITLE
[VK] Fix handling of vk descriptor binding

### DIFF
--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -655,7 +655,7 @@ public:
         VkWriteDescriptorSet WDS = {};
         WDS.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
         WDS.dstSet = IS.DescriptorSets[SetIdx];
-        WDS.dstBinding = RIdx;
+        WDS.dstBinding = R.VKBinding->Binding;
         WDS.descriptorCount = 1;
         WDS.descriptorType = getDescriptorType(R.Kind);
         if (IsRawOrUniform)

--- a/test/Feature/StructuredBuffer/simple.test
+++ b/test/Feature/StructuredBuffer/simple.test
@@ -52,7 +52,6 @@ DescriptorSets:
 #--- end
 
 # UNSUPPORTED: Clang-Vulkan
-# XFAIL: DXC-Vulkan
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl


### PR DESCRIPTION
This should fix handling for bindings which was oddly always broken.