### PR TITLE
Add `dot2add` test

### DIFF
--- a/test/Feature/HLSLLib/dot2add.test
+++ b/test/Feature/HLSLLib/dot2add.test
@@ -105,5 +105,5 @@ DescriptorSets:
 
 # REQUIRES: Half
 # RUN: split-file %s %t
-# RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -enable-16bit-types -Gis -HV 202x -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
Closes #177.

Adds test for `dot2add` testing `half`. Values pulled from [HLK tests](https://github.com/microsoft/DirectXShaderCompiler/blob/57177f77a4dc6996400ac97a0d618799c82374e8/tools/clang/unittests/HLSLExec/ShaderOpArithTable.xml#L4848), though I didn't use the last 4 since they were testing nan/inf/denorm (there are already too many tests).