### PR TITLE
Add `max` tests

### DIFF
--- a/test/Feature/HLSLLib/max.32.test
+++ b/test/Feature/HLSLLib/max.32.test
@@ -170,5 +170,5 @@ DescriptorSets:
 
 
 # RUN: split-file %s %t
-# RUN: %dxc_target  -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -HV 202x -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/max.fp16.test
+++ b/test/Feature/HLSLLib/max.fp16.test
@@ -72,5 +72,5 @@ DescriptorSets:
 
 # REQUIRES: Half
 # RUN: split-file %s %t
-# RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -enable-16bit-types -HV 202x -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/max.fp64.test
+++ b/test/Feature/HLSLLib/max.fp64.test
@@ -69,5 +69,5 @@ DescriptorSets:
 
 # REQUIRES: Double
 # RUN: split-file %s %t
-# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -HV 202x -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/max.int16.test
+++ b/test/Feature/HLSLLib/max.int16.test
@@ -122,5 +122,5 @@ DescriptorSets:
 
 # REQUIRES: Int16
 # RUN: split-file %s %t
-# RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -enable-16bit-types -HV 202x -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/max.int64.test
+++ b/test/Feature/HLSLLib/max.int64.test
@@ -119,5 +119,5 @@ DescriptorSets:
 
 # REQUIRES: Int64
 # RUN: split-file %s %t
-# RUN: %dxc_target  -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -HV 202x -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
Closes #148.

Adds tests for `max` testing 16 bit int types, half, 32 bit types, 64 bit int types, and double. Most values for 16 bit int and 32 bit int pulled from [HLK tests](https://github.com/microsoft/DirectXShaderCompiler/blob/57177f77a4dc6996400ac97a0d618799c82374e8/tools/clang/unittests/HLSLExec/ShaderOpArithTable.xml#L3125). Didn't use HLK test inputs for half and float because they were mostly nan/inf/denorm values. No HLK tests for 64 bit int and double.
Need to remove XFAIL after [#7691](https://github.com/microsoft/DirectXShaderCompiler/issues/7691) is fixed.