### PR TITLE
Add LIT capabilibies for vulkan extensions

### DIFF
--- a/test/Feature/HLSLLib/D3DCOLORtoUBYTE4.test
+++ b/test/Feature/HLSLLib/D3DCOLORtoUBYTE4.test
@@ -52,7 +52,7 @@ DescriptorSets:
 
 
 # https://github.com/llvm/llvm-project/issues/149561
-# XFAIL: Clang-Vulkan
+# XFAIL: Clang-Vulkan && !VK_KHR_shader_float_controls2
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -HV 202x -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/dot.32.test
+++ b/test/Feature/HLSLLib/dot.32.test
@@ -190,7 +190,7 @@ DescriptorSets:
 #--- end
 
 # https://github.com/llvm/llvm-project/issues/149561
-# XFAIL: Clang-Vulkan
+# XFAIL: Clang-Vulkan && !VK_KHR_shader_float_controls2
 
 # RUN: split-file %s %t
 # RUN: %dxc_target  -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/dot.fp16.test
+++ b/test/Feature/HLSLLib/dot.fp16.test
@@ -48,8 +48,8 @@ Buffers:
     # [ 8.20125, 8.20125, 0.35125, 0.35125, 5.57625, 5.57625, -17.61125, -17.61125 ]
 Results:
   - Result: Test1
-    Rule: BufferFloatEpsilon
-    Epsilon: 0.008
+    Rule: BufferFloatULP
+    ULPT: 30
     Actual: Out
     Expected: ExpectedOut
 DescriptorSets:
@@ -77,10 +77,14 @@ DescriptorSets:
         Binding: 2
 #--- end
 
+# DXC is producing a compile-time value at a significantly higher precision than
+# runtime computed values for case 3 (clang will likely do the same once it
+# learns to constant evaluate `dot`).
+
 # https://github.com/llvm/llvm-project/issues/149561
-# XFAIL: Clang-Vulkan
+# XFAIL: Clang-Vulkan && !VK_KHR_shader_float_controls2
 
 # REQUIRES: Half
 # RUN: split-file %s %t
-# RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -enable-16bit-types -HV 202x -Gis -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/dot.fp64.test
+++ b/test/Feature/HLSLLib/dot.fp64.test
@@ -75,7 +75,7 @@ DescriptorSets:
 #--- end
 
 # https://github.com/llvm/llvm-project/issues/149561
-# XFAIL: Clang-Vulkan
+# XFAIL: Clang-Vulkan && !VK_KHR_shader_float_controls2
 
 # REQUIRES: Double
 # RUN: split-file %s %t

--- a/test/Feature/HLSLLib/fmod.16.test
+++ b/test/Feature/HLSLLib/fmod.16.test
@@ -70,7 +70,7 @@ DescriptorSets:
 #--- end
  
 # https://github.com/llvm/llvm-project/issues/149561 
-# XFAIL: Clang-Vulkan
+# XFAIL: Clang-Vulkan && !VK_KHR_shader_float_controls2
 
 # REQUIRES: Half
 # RUN: split-file %s %t

--- a/test/Feature/HLSLLib/fmod.32.test
+++ b/test/Feature/HLSLLib/fmod.32.test
@@ -67,7 +67,7 @@ DescriptorSets:
 #--- end
 
 # https://github.com/llvm/llvm-project/issues/149561
-# XFAIL: Clang-Vulkan
+# XFAIL: Clang-Vulkan && !VK_KHR_shader_float_controls2
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -Gis -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/rcp.16.test
+++ b/test/Feature/HLSLLib/rcp.16.test
@@ -63,7 +63,7 @@ DescriptorSets:
 #--- end
 
 # https://github.com/llvm/llvm-project/issues/149561
-# XFAIL: Clang-Vulkan
+# XFAIL: Clang-Vulkan && !VK_KHR_shader_float_controls2
 
 # REQUIRES: Half
 # RUN: split-file %s %t

--- a/test/Feature/HLSLLib/rcp.32.test
+++ b/test/Feature/HLSLLib/rcp.32.test
@@ -61,7 +61,7 @@ DescriptorSets:
 #--- end
 
 # https://github.com/llvm/llvm-project/issues/149561
-# XFAIL: Clang-Vulkan
+# XFAIL: Clang-Vulkan && !VK_KHR_shader_float_controls2
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/rcp.64.test
+++ b/test/Feature/HLSLLib/rcp.64.test
@@ -61,7 +61,7 @@ DescriptorSets:
 #--- end
 
 # https://github.com/llvm/llvm-project/issues/149561
-# XFAIL: Clang-Vulkan
+# XFAIL: Clang-Vulkan && !VK_KHR_shader_float_controls2
 
 # REQUIRES: Double
 # RUN: split-file %s %t

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -98,6 +98,10 @@ def setDeviceFeatures(config, device, compiler):
         if device["Features"].get("shaderInt64", False):
             config.available_features.add("Int64")
 
+        # Add supported extensions.
+        for Extension in device["Extensions"]:
+            config.available_features.add(Extension["ExtensionName"])
+
 
 if config.offloadtest_test_warp:
     tools.append(


### PR DESCRIPTION
This adds the ability to conditionalize tests based on available vulkan extensions. Since a set of our tests depend on float_controls2 when compiled with Clang, this allows those tests to pass if run on a device with flaot_controls2 support.

The one additional tweak in this PR is to adjust the dot.fp16 test to have a wider tolerance range. DXC constant evaluates at a higher accuracy than the hardware evaluates at and our test assumes constant folded computation for the expected value. An ULP of 30 is wide enough to handle both the fp16 "correct" value and the wider computed value with rounding errors compounded.