### PR TITLE
Remove XFAILs for succeeding tests

### DIFF
--- a/test/Feature/WaveOps/WaveActiveAllTrue.test
+++ b/test/Feature/WaveOps/WaveActiveAllTrue.test
@@ -63,9 +63,6 @@ DescriptorSets:
 ...
 #--- end
 
-# https://github.com/llvm/llvm-project/issues/145513
-# XFAIL: Clang-Vulkan
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/WaveOps/WaveIsFirstLane.test
+++ b/test/Feature/WaveOps/WaveIsFirstLane.test
@@ -65,9 +65,6 @@ DescriptorSets:
 ...
 #--- end
 
-# https://github.com/llvm/llvm-project/issues/145513
-# XFAIL: Clang-Vulkan
-
 # XFAIL: NV-Reconvergence-Issue-320
 
 # RUN: split-file %s %t


### PR DESCRIPTION
This removes a few XFAILs for tests that are passing now with Clang.