### PR TITLE
Disable Clang WARP preview builder and re-enable DXC WARP (LKG) builder

### DIFF
--- a/.github/workflows/windows-amd-clang-warp-preview-d3d12.yaml
+++ b/.github/workflows/windows-amd-clang-warp-preview-d3d12.yaml
@@ -6,8 +6,6 @@ permissions:
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '0 */2 * * *' # run every 2 hours
 
 jobs:
   Windows-D3D12-Warp-Clang:

--- a/.github/workflows/windows-amd-dxc-warp-preview-d3d12.yaml
+++ b/.github/workflows/windows-amd-dxc-warp-preview-d3d12.yaml
@@ -6,8 +6,6 @@ permissions:
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '0 */2 * * *' # run every 2 hours
 
 jobs:
   Windows-D3D12-Warp-DXC:


### PR DESCRIPTION
#375 did not disable the WARP preview builder for Clang, and also disabled the LKG WARP builder for DXC.

This PR disables the WARP preview builder for Clang and re-enables the LKG WARP builder for DXC.