### PR TITLE
[VK][Darwin] XFAIL 64-bit shuffle test

### DIFF
--- a/test/WaveOps/WaveReadLaneAt.Int.64.test
+++ b/test/WaveOps/WaveReadLaneAt.Int.64.test
@@ -97,8 +97,11 @@ DescriptorSets:
 ...
 #--- end
 
-Tracked by https://github.com/llvm/offload-test-suite/issues/355
+# Tracked by https://github.com/llvm/offload-test-suite/issues/355
 # XFAIL: Metal
+# Tracked by https://github.com/KhronosGroup/SPIRV-Cross/issues/2538
+# XFAIL: Vulkan-Darwin
+
 
 # REQUIRES: Int64
 


### PR DESCRIPTION
SPIRV-Cross currently mis-translates 64-bit subgroup operations into Metal as invalid `simd_shuffle` operations.

Tracking issue: https://github.com/KhronosGroup/SPIRV-Cross/issues/2538