### PR TITLE
Speed up the dot2add test with some parallelism

### DIFF
--- a/test/Feature/HLSLLib/dot2add.test
+++ b/test/Feature/HLSLLib/dot2add.test
@@ -10,10 +10,13 @@ RWStructuredBuffer<float> Out : register(u3);
 void main(uint3 DTID : SV_DispatchThreadID) {
   Out[DTID.x] = dot2add(A[DTID.x], B[DTID.x], Acc[DTID.x]);
 
-  Out[12] = dot2add(half2(1, 2), half2(3, 4), float(0));
-  Out[13] = dot2add(half2(-1, 2), half2(3, -4), float(10));
-  Out[14] = dot2add(half2(65504, 1), half2(1, 65504), float(0));
-  Out[15] = dot2add(half2(1, -65504), half2(-65504, 1), float(-10000000));
+  if (DTID.x == 0) {
+    // The constant cases are independent of thread id
+    Out[12] = dot2add(half2(1, 2), half2(3, 4), float(0));
+    Out[13] = dot2add(half2(-1, 2), half2(3, -4), float(10));
+    Out[14] = dot2add(half2(65504, 1), half2(1, 65504), float(0));
+    Out[15] = dot2add(half2(1, -65504), half2(-65504, 1), float(-10000000));
+  }
 }
 //--- pipeline.yaml
 


### PR DESCRIPTION
This test was running extremely slowly under warp for me, with the dxc version taking 15-20s and the clang version taking around 45-50s. Some parallelism reduces these both to under 2s on my machine, without really affecting the timing of any of the actual GPU versions of the test.

Shaves nearly 30s off of `ninja check-hlsl` locally.