### PR TITLE
Fix StructuredBuffer layout and stride tests

### DIFF
--- a/test/Feature/StructuredBuffer/layout.test
+++ b/test/Feature/StructuredBuffer/layout.test
@@ -19,7 +19,7 @@ RWStructuredBuffer<A> BufA : register(u1);
 RWStructuredBuffer<B> BufB : register(u2);
 RWStructuredBuffer<C> BufC : register(u3);
 
-[numthreads(1,1,4)]
+[numthreads(4,1,1)]
 void main(uint GI : SV_GroupIndex) {
   BufA[GI].a = In[GI].x;
   BufA[GI].b = In[GI].y;
@@ -40,7 +40,7 @@ Shaders:
 Buffers:
   - Name: In
     Format: Float32
-    Stride: 32
+    Stride: 16
     Data: [ 1, 2, 3, 0, 4, 5, 6, 0, 7, 8, 9, 0, 10, 11, 12, 0 ]
   - Name: BufA
     Format: Float32

--- a/test/Feature/StructuredBuffer/stride.test
+++ b/test/Feature/StructuredBuffer/stride.test
@@ -19,11 +19,11 @@ Shaders:
 Buffers:
   - Name: In
     Format: Float32
-    Stride: 32
+    Stride: 16
     Data: [ 1, 2, 3, 4, 5, 6, 7, 8 ]
   - Name: Out
     Format: Float32
-    Stride: 4
+    Stride: 16
     ZeroInitSize: 32
 DescriptorSets:
   - Resources:


### PR DESCRIPTION
These two tests are failing on some of the new hardware we're bringing online and since the strides are wrong I'm not sure why they aren't failing everywhere...

Fixes #334, Fixes #333