### PR TITLE
Add WaveActiveMax tests

### DIFF
--- a/test/WaveOps/WaveActiveMax.fp16.test
+++ b/test/WaveOps/WaveActiveMax.fp16.test
@@ -93,23 +93,23 @@ Buffers:
     Format: Float16
     Stride: 2
     # 1 half is 2 bytes, * 4 halves for 4 threads, * 4 thread masks, * 2 value sets
-    ZeroInitSize: 64  
+    FillSize: 64  
   - Name: Out2
     Format: Float16
     Stride: 4
-    ZeroInitSize: 128
+    FillSize: 128
   - Name: Out3
     Format: Float16
     Stride: 8
-    ZeroInitSize: 256
+    FillSize: 256
   - Name: Out4
     Format: Float16
     Stride: 8
-    ZeroInitSize: 256
+    FillSize: 256
   - Name: Out5
     Format: Float16
     Stride: 8
-    ZeroInitSize: 8
+    FillSize: 8
   - Name: Masks
     Format: Int32
     Stride: 16

--- a/test/WaveOps/WaveActiveMax.fp32.test
+++ b/test/WaveOps/WaveActiveMax.fp32.test
@@ -93,23 +93,23 @@ Buffers:
     Format: Float32
     Stride: 4
     # 1 float is 4 bytes, * 4 halves for 4 threads, * 4 thread masks, * 2 value sets
-    ZeroInitSize: 128  
+    FillSize: 128  
   - Name: Out2
     Format: Float32
     Stride: 8
-    ZeroInitSize: 256
+    FillSize: 256
   - Name: Out3
     Format: Float32
     Stride: 16
-    ZeroInitSize: 512
+    FillSize: 512
   - Name: Out4
     Format: Float32
     Stride: 16
-    ZeroInitSize: 512
+    FillSize: 512
   - Name: Out5
     Format: Float32
     Stride: 16
-    ZeroInitSize: 16
+    FillSize: 16
   - Name: Masks
     Format: Int32
     Stride: 16

--- a/test/WaveOps/WaveActiveMax.fp64.test
+++ b/test/WaveOps/WaveActiveMax.fp64.test
@@ -93,23 +93,23 @@ Buffers:
     Format: Float64
     Stride: 4
     # 1 double is 8 bytes, * 4 halves for 4 threads, * 4 thread masks, * 2 value sets
-    ZeroInitSize: 256  
+    FillSize: 256  
   - Name: Out2
     Format: Float64
     Stride: 8
-    ZeroInitSize: 512
+    FillSize: 512
   - Name: Out3
     Format: Float64
     Stride: 16
-    ZeroInitSize: 1024
+    FillSize: 1024
   - Name: Out4
     Format: Float64
     Stride: 16
-    ZeroInitSize: 1024
+    FillSize: 1024
   - Name: Out5
     Format: Float64
     Stride: 32
-    ZeroInitSize: 32
+    FillSize: 32
   - Name: Masks
     Format: Int32
     Stride: 16

--- a/test/WaveOps/WaveActiveMax.int16.test
+++ b/test/WaveOps/WaveActiveMax.int16.test
@@ -93,23 +93,23 @@ Buffers:
     Format: Int16
     Stride: 2
     # 1 int16_t is 2 bytes, * 4 halves for 4 threads, * 4 thread masks, * 2 value sets
-    ZeroInitSize: 64  
+    FillSize: 64  
   - Name: Out2
     Format: Int16
     Stride: 4
-    ZeroInitSize: 128
+    FillSize: 128
   - Name: Out3
     Format: Int16
     Stride: 8
-    ZeroInitSize: 256
+    FillSize: 256
   - Name: Out4
     Format: Int16
     Stride: 8
-    ZeroInitSize: 256
+    FillSize: 256
   - Name: Out5
     Format: Int16
     Stride: 8
-    ZeroInitSize: 8
+    FillSize: 8
   - Name: Masks
     Format: Int32
     Stride: 16

--- a/test/WaveOps/WaveActiveMax.int32.test
+++ b/test/WaveOps/WaveActiveMax.int32.test
@@ -93,23 +93,23 @@ Buffers:
     Format: Int32
     Stride: 4
     # 1 int is 4 bytes, * 4 halves for 4 threads, * 4 thread masks, * 2 value sets
-    ZeroInitSize: 128  
+    FillSize: 128  
   - Name: Out2
     Format: Int32
     Stride: 8
-    ZeroInitSize: 256
+    FillSize: 256
   - Name: Out3
     Format: Int32
     Stride: 16
-    ZeroInitSize: 512
+    FillSize: 512
   - Name: Out4
     Format: Int32
     Stride: 16
-    ZeroInitSize: 512
+    FillSize: 512
   - Name: Out5
     Format: Int32
     Stride: 16
-    ZeroInitSize: 16
+    FillSize: 16
   - Name: Masks
     Format: Int32
     Stride: 16

--- a/test/WaveOps/WaveActiveMax.int64.test
+++ b/test/WaveOps/WaveActiveMax.int64.test
@@ -93,23 +93,23 @@ Buffers:
     Format: Int64
     Stride: 8
     # 1 int is 8 bytes, * 4 ints for 4 threads, * 4 thread masks, * 2 value sets
-    ZeroInitSize: 256
+    FillSize: 256
   - Name: Out2
     Format: Int64
     Stride: 16
-    ZeroInitSize: 512
+    FillSize: 512
   - Name: Out3
     Format: Int64
     Stride: 32
-    ZeroInitSize: 1024
+    FillSize: 1024
   - Name: Out4
     Format: Int64
     Stride: 32
-    ZeroInitSize: 1024
+    FillSize: 1024
   - Name: Out5
     Format: Int64
     Stride: 32
-    ZeroInitSize: 32
+    FillSize: 32
   - Name: Masks
     Format: Int32
     Stride: 16


### PR DESCRIPTION
Adds WaveActiveMax  tests.
Fixes https://github.com/llvm/offload-test-suite/issues/122

