### PR TITLE
Remove XFAILS that are now passing

### DIFF
--- a/test/Feature/HLSLLib/atan2.16.test
+++ b/test/Feature/HLSLLib/atan2.16.test
@@ -69,9 +69,6 @@ DescriptorSets:
         Binding: 2
 #--- end
 
-# Bug https://github.com/microsoft/DirectXShaderCompiler/issues/7691
-# XFAIL: DXC-Vulkan
-
 # REQUIRES: Half
 # RUN: split-file %s %t
 # RUN: %dxc_target -enable-16bit-types -HV 202x -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/clamp.fp16.test
+++ b/test/Feature/HLSLLib/clamp.fp16.test
@@ -83,9 +83,6 @@ DescriptorSets:
         Binding: 3
 #--- end
 
-# Bug https://github.com/microsoft/DirectXShaderCompiler/issues/7691
-# XFAIL: DXC-Vulkan
-
 # REQUIRES: Half
 # RUN: split-file %s %t
 # RUN: %dxc_target -HV 202x -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/clamp.int16.test
+++ b/test/Feature/HLSLLib/clamp.int16.test
@@ -138,9 +138,6 @@ DescriptorSets:
         Binding: 7
 #--- end
 
-# Bug https://github.com/microsoft/DirectXShaderCompiler/issues/7691
-# XFAIL: DXC-Vulkan
-
 # REQUIRES: Int16
 # RUN: split-file %s %t
 # RUN: %dxc_target -HV 202x -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/lerp.16.test
+++ b/test/Feature/HLSLLib/lerp.16.test
@@ -83,9 +83,6 @@ DescriptorSets:
         Binding: 3
 #--- end
 
-# Bug https://github.com/microsoft/DirectXShaderCompiler/issues/7710
-# XFAIL: DXC-Vulkan
-
 # REQUIRES: Half
 # RUN: split-file %s %t
 # RUN: %dxc_target -enable-16bit-types -HV 202x -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/log.16.test
+++ b/test/Feature/HLSLLib/log.16.test
@@ -61,9 +61,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug https://github.com/microsoft/DirectXShaderCompiler/issues/7702
-# XFAIL: DXC-Vulkan
-
 # REQUIRES: Half
 # RUN: split-file %s %t
 # RUN: %dxc_target -Gis -HV 202x -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/max.int16.test
+++ b/test/Feature/HLSLLib/max.int16.test
@@ -117,9 +117,6 @@ DescriptorSets:
         Binding: 5
 #--- end
 
-# Bug https://github.com/microsoft/DirectXShaderCompiler/issues/7691
-# XFAIL: DXC-Vulkan
-
 # REQUIRES: Int16
 # RUN: split-file %s %t
 # RUN: %dxc_target -enable-16bit-types -HV 202x -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/min.int16.test
+++ b/test/Feature/HLSLLib/min.int16.test
@@ -117,9 +117,6 @@ DescriptorSets:
         Binding: 5
 #--- end
 
-# Bug https://github.com/microsoft/DirectXShaderCompiler/issues/7691
-# XFAIL: DXC-Vulkan
-
 # REQUIRES: Int16
 # RUN: split-file %s %t
 # RUN: %dxc_target -enable-16bit-types -HV 202x -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/pow.16.test
+++ b/test/Feature/HLSLLib/pow.16.test
@@ -70,9 +70,6 @@ DescriptorSets:
         Binding: 2
 #--- end
 
-# Bug https://github.com/microsoft/DirectXShaderCompiler/issues/7702
-# XFAIL: DXC-Vulkan
-
 # REQUIRES: Half
 # RUN: split-file %s %t
 # RUN: %dxc_target -enable-16bit-types -Gis -HV 202x -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/pow.32.test
+++ b/test/Feature/HLSLLib/pow.32.test
@@ -67,9 +67,6 @@ DescriptorSets:
         Binding: 2
 #--- end
 
-# Bug https://github.com/microsoft/DirectXShaderCompiler/issues/7702
-# XFAIL: DXC-Vulkan
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -Gis -HV 202x -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
The related DXC bugs have all been addressed and we're now seeing these passing on our CI.