### PR TITLE
Update XFAILS for clang-vulkan

### DIFF
--- a/test/Feature/HLSLLib/mad.32.test
+++ b/test/Feature/HLSLLib/mad.32.test
@@ -207,9 +207,6 @@ DescriptorSets:
         Binding: 11
 #--- end
 
-# Bug https://github.com/llvm/llvm-project/issues/140095
-# XFAIL: Clang-Vulkan
-
 # Bug https://github.com/microsoft/DirectXShaderCompiler/issues/7706
 # XFAIL: DXC-Vulkan
 

--- a/test/WaveOps/WaveReadLaneAt.index.test
+++ b/test/WaveOps/WaveReadLaneAt.index.test
@@ -115,6 +115,9 @@ DescriptorSets:
 ...
 #--- end
 
+# Bug https://github.com/llvm/llvm-project/issues/158129
+# XFAIL: Clang-Vulkan
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
This removes an xfail on the mad.32 test which is now succeeding, and adds an XFAIL on the WaveREadLaneAt.index test which is failig on Clang Vulkan generating invalid SPIRV.