### PR TITLE
Remove XFAIL from isinf.16 test

### DIFF
--- a/test/Feature/HLSLLib/isinf.16.test
+++ b/test/Feature/HLSLLib/isinf.16.test
@@ -55,9 +55,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug https://github.com/llvm/llvm-project/issues/145571
-# XFAIL: Clang && DirectX-NV
-
 # A bug in the Metal Shader Converter caused it to mis-translate this operation.
 # Version 3 fixes this issue.
 # UNSUPPORTED: Clang-Metal && !metal-shaderconverter-3.0.0-or-later


### PR DESCRIPTION
This was fixed by llvm/llvm-project#156932