### PR TITLE
Remove XFAILs for unsigned `abs` and update the issue for unsigned `sign`

### DIFF
--- a/test/Feature/HLSLLib/abs.32.test
+++ b/test/Feature/HLSLLib/abs.32.test
@@ -134,9 +134,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug https://github.com/microsoft/DirectXShaderCompiler/issues/7512
-# XFAIL: DXC-Vulkan
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/abs.int16.test
+++ b/test/Feature/HLSLLib/abs.int16.test
@@ -94,9 +94,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug https://github.com/microsoft/DirectXShaderCompiler/issues/7512
-# XFAIL: DXC-Vulkan
-
 # REQUIRES: Int16
 # RUN: split-file %s %t
 # RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/abs.int64.test
+++ b/test/Feature/HLSLLib/abs.int64.test
@@ -94,9 +94,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug https://github.com/microsoft/DirectXShaderCompiler/issues/7512
-# XFAIL: DXC-Vulkan
-
 # REQUIRES: Int64
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/sign.32.test
+++ b/test/Feature/HLSLLib/sign.32.test
@@ -173,7 +173,7 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug https://github.com/microsoft/DirectXShaderCompiler/issues/7512
+# Bug https://github.com/microsoft/DirectXShaderCompiler/issues/7755
 # XFAIL: DXC-Vulkan
 
 # We're generating invalid SPIRV for this. I have _no_ idea why this isn't

--- a/test/Feature/HLSLLib/sign.int16.test
+++ b/test/Feature/HLSLLib/sign.int16.test
@@ -94,7 +94,7 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug https://github.com/microsoft/DirectXShaderCompiler/issues/7512
+# Bug https://github.com/microsoft/DirectXShaderCompiler/issues/7755
 # XFAIL: DXC-Vulkan
 
 # REQUIRES: Int16

--- a/test/Feature/HLSLLib/sign.int64.test
+++ b/test/Feature/HLSLLib/sign.int64.test
@@ -94,7 +94,7 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug https://github.com/microsoft/DirectXShaderCompiler/issues/7512
+# Bug https://github.com/microsoft/DirectXShaderCompiler/issues/7755
 # XFAIL: DXC-Vulkan
 
 # REQUIRES: Int64


### PR DESCRIPTION
Update tests now that microsoft/DirectXShaderCompiler#7512 is resolved, but note that the `sign` failures were incorrectly attributed to that issue.