### PR TITLE
[Root Signature] Updating tests to follow the new yaml representation

### DIFF
--- a/test/Feature/RootSignatures/Defaults.test
+++ b/test/Feature/RootSignatures/Defaults.test
@@ -105,38 +105,38 @@ DescriptorSets:
 # OBJ-NEXT: Parameters:
 
 ## RootConstants(num32BitConstants = 4, b0)
-# OBJ-NEXT:   - ParameterType:   1
-# OBJ-NEXT:     ShaderVisibility: 0
+# OBJ-NEXT:   - ParameterType:   Constants32Bit
+# OBJ-NEXT:     ShaderVisibility: All
 # OBJ-NEXT:     Constants:
 # OBJ-NEXT:     Num32BitValues:  4
 # OBJ-NEXT:     RegisterSpace:   0
 # OBJ-NEXT:     ShaderRegister:  0
 
 ## DescriptorTable
-# OBJ:        - ParameterType:   0
-# OBJ-NEXT:     ShaderVisibility: 0
+# OBJ:        - ParameterType:   DescriptorTable
+# OBJ-NEXT:     ShaderVisibility: All
 # OBJ-NEXT:     Table:
 # OBJ-NEXT:     NumRanges:       2
 # OBJ-NEXT:     RangesOffset:    80
 # OBJ-NEXT:     Ranges:
 
 ## SRV(t0)
-# OBJ-NEXT:     - RangeType:       0
+# OBJ-NEXT:     - RangeType:       SRV
 # OBJ-NEXT:       NumDescriptors:  1
 # OBJ-NEXT:       BaseShaderRegister: 0
 # OBJ-NEXT:       RegisterSpace:   0
 # OBJ-NEXT:       OffsetInDescriptorsFromTableStart: 4294967295
 
 ## UAV(u1)
-# OBJ:          - RangeType:       1
+# OBJ:          - RangeType:       UAV
 # OBJ-NEXT:       NumDescriptors:  1
 # OBJ-NEXT:       BaseShaderRegister: 1
 # OBJ-NEXT:       RegisterSpace:   0
 # OBJ-NEXT:       OffsetInDescriptorsFromTableStart: 4294967295
 
 ## UAV(u2)
-# OBJ:          - ParameterType:   4
-# OBJ-NEXT:       ShaderVisibility: 0
+# OBJ:          - ParameterType:   UAV
+# OBJ-NEXT:       ShaderVisibility: All
 # OBJ-NEXT:       Descriptor:
 # OBJ-NEXT:       RegisterSpace:   0
 # OBJ-NEXT:       ShaderRegister:  2

--- a/test/Feature/RootSignatures/DescriptorTables.test
+++ b/test/Feature/RootSignatures/DescriptorTables.test
@@ -74,23 +74,23 @@ DescriptorSets:
 # OBJ-NEXT:     NumStaticSamplers: 0
 # OBJ-NEXT:     StaticSamplersOffset: 116
 # OBJ-NEXT:     Parameters:
-# OBJ-NEXT:     - ParameterType:   0
-# OBJ-NEXT:       ShaderVisibility: 0
+# OBJ-NEXT:     - ParameterType:   DescriptorTable
+# OBJ-NEXT:       ShaderVisibility: All
 # OBJ-NEXT:       Table:
 # OBJ-NEXT:       NumRanges:       3
 # OBJ-NEXT:       RangesOffset:    44
 # OBJ-NEXT:       Ranges:
-# OBJ-NEXT:       - RangeType:       0
+# OBJ-NEXT:       - RangeType:       SRV
 # OBJ-NEXT:         NumDescriptors:  1
 # OBJ-NEXT:         BaseShaderRegister: 2
 # OBJ-NEXT:         RegisterSpace:   0
 # OBJ-NEXT:         OffsetInDescriptorsFromTableStart: 4294967295
-# OBJ:            - RangeType:       1
+# OBJ:            - RangeType:       UAV
 # OBJ-NEXT:         NumDescriptors:  1
 # OBJ-NEXT:         BaseShaderRegister: 1
 # OBJ-NEXT:         RegisterSpace:   4
 # OBJ-NEXT:         OffsetInDescriptorsFromTableStart: 4294967295
-# OBJ:            - RangeType:       1
+# OBJ:            - RangeType:       UAV
 # OBJ-NEXT:         NumDescriptors:  1
 # OBJ-NEXT:         BaseShaderRegister: 2
 # OBJ-NEXT:         RegisterSpace:   4

--- a/test/Feature/RootSignatures/Flags.test
+++ b/test/Feature/RootSignatures/Flags.test
@@ -115,15 +115,15 @@ DescriptorSets:
 # OBJ-NEXT: Parameters:
 
 ## Descriptor Table
-# OBJ-NEXT:   - ParameterType:   0
-# OBJ-NEXT:     ShaderVisibility: 0
+# OBJ-NEXT:   - ParameterType:   DescriptorTable
+# OBJ-NEXT:     ShaderVisibility: All
 # OBJ-NEXT:     Table:
 # OBJ-NEXT:     NumRanges:       4
 # OBJ-NEXT:     RangesOffset:    44
 # OBJ-NEXT:     Ranges:
 
 ## SRV(t0, flags = DATA_STATIC)
-# OBJ-NEXT:     - RangeType:       0
+# OBJ-NEXT:     - RangeType:       SRV
 # OBJ-NEXT:       NumDescriptors:  1
 # OBJ-NEXT:       BaseShaderRegister: 0
 # OBJ-NEXT:       RegisterSpace:   0
@@ -132,7 +132,7 @@ DescriptorSets:
 # OBJ-NEXT:       DATA_STATIC:     true
 
 ## SRV(t1, flags = DATA_STATIC_WHILE_SET_AT_EXECUTE)
-# OBJ-NEXT:     - RangeType:       0
+# OBJ-NEXT:     - RangeType:       SRV
 # OBJ-NEXT:       NumDescriptors:  1
 # OBJ-NEXT:       BaseShaderRegister: 1
 # OBJ-NEXT:       RegisterSpace:   0
@@ -141,7 +141,7 @@ DescriptorSets:
 # OBJ-NEXT:       DATA_STATIC_WHILE_SET_AT_EXECUTE: true
 
 ## UAV(u1, flags = DESCRIPTORS_VOLATILE | DATA_VOLATILE)
-# OBJ-NEXT:     - RangeType:       1
+# OBJ-NEXT:     - RangeType:       UAV
 # OBJ-NEXT:       NumDescriptors:  1
 # OBJ-NEXT:       BaseShaderRegister: 1
 # OBJ-NEXT:       RegisterSpace:   0
@@ -151,7 +151,7 @@ DescriptorSets:
 # OBJ-NEXT:       DATA_VOLATILE:   true
 
 ## UAV(u2, flags = 0)
-# OBJ-NEXT:     - RangeType:       1
+# OBJ-NEXT:     - RangeType:       UAV
 # OBJ-NEXT:       NumDescriptors:  1
 # OBJ-NEXT:       BaseShaderRegister: 2
 # OBJ-NEXT:       RegisterSpace:   0

--- a/test/Feature/RootSignatures/ManualDescriptors.test
+++ b/test/Feature/RootSignatures/ManualDescriptors.test
@@ -110,15 +110,15 @@ DescriptorSets:
 # OBJ-NEXT:     Parameters:
 
 ## DescriptorTable
-# OBJ-NEXT:     - ParameterType:   0
-# OBJ-NEXT:       ShaderVisibility: 0
+# OBJ-NEXT:     - ParameterType:   DescriptorTable
+# OBJ-NEXT:       ShaderVisibility: All
 # OBJ-NEXT:       Table:
 # OBJ-NEXT:       NumRanges:       3
 # OBJ-NEXT:       RangesOffset:    44
 # OBJ-NEXT:       Ranges:
 
 ## UAV(u2, offset = 3, numDescriptors = unbounded)
-# OBJ:            - RangeType:       1
+# OBJ:            - RangeType:       UAV
 ## Ensure unbounded descriptors
 # OBJ-NEXT:         NumDescriptors:  -1
 # OBJ-NEXT:         BaseShaderRegister: 2
@@ -127,7 +127,7 @@ DescriptorSets:
 # OBJ-NEXT:         OffsetInDescriptorsFromTableStart: 3
 
 ## SRV(t0, offset = 0, numDescriptors = 2)
-# OBJ:            - RangeType:       0
+# OBJ:            - RangeType:       SRV
 ## Ensure 2 descriptors
 # OBJ-NEXT:         NumDescriptors:  2
 # OBJ-NEXT:         BaseShaderRegister: 0
@@ -139,7 +139,7 @@ DescriptorSets:
 ##  offset = DESCRIPTOR_RANGE_OFFSET_APPEND,
 ##  numDescriptors = 1
 ## )
-# OBJ:            - RangeType:       1
+# OBJ:            - RangeType:       UAV
 ## Ensure 1 descriptor
 # OBJ-NEXT:         NumDescriptors:  1
 # OBJ-NEXT:         BaseShaderRegister: 1

--- a/test/Feature/RootSignatures/NumberParameters.test
+++ b/test/Feature/RootSignatures/NumberParameters.test
@@ -110,8 +110,8 @@ DescriptorSets:
 # OBJ-NEXT: Parameters:
 
 ## RootConstants(num32BitConstants = +61, b0)
-# OBJ-NEXT:     - ParameterType:   1
-# OBJ-NEXT:       ShaderVisibility: 0
+# OBJ-NEXT:     - ParameterType:   Constants32Bit
+# OBJ-NEXT:       ShaderVisibility: All
 # OBJ-NEXT:       Constants:
 ## Check positively signed integer
 # OBJ-NEXT:       Num32BitValues:  61
@@ -119,15 +119,15 @@ DescriptorSets:
 # OBJ-NEXT:       ShaderRegister:  0
 
 ## DescriptorTable
-# OBJ-NEXT:     - ParameterType:   0
-# OBJ-NEXT:       ShaderVisibility: 0
+# OBJ-NEXT:     - ParameterType:   DescriptorTable
+# OBJ-NEXT:       ShaderVisibility: All
 # OBJ-NEXT:       Table:
 # OBJ-NEXT:       NumRanges:       2
 # OBJ-NEXT:       RangesOffset:    80
 # OBJ-NEXT:       Ranges:
 
 ## SRV(t4294967294)
-# OBJ-NEXT:       - RangeType:       0
+# OBJ-NEXT:       - RangeType:       SRV
 # OBJ-NEXT:         NumDescriptors:  1
 ## Check edge-case
 # OBJ-NEXT:         BaseShaderRegister: 4294967294
@@ -135,7 +135,7 @@ DescriptorSets:
 # OBJ-NEXT:         OffsetInDescriptorsFromTableStart: 4294967295
 
 ## UAV(u1, space = 4294967279)
-# OBJ:            - RangeType:       1
+# OBJ:            - RangeType:       UAV
 # OBJ-NEXT:         NumDescriptors:  1
 # OBJ-NEXT:         BaseShaderRegister: 1
 ## Check edge-case
@@ -143,8 +143,8 @@ DescriptorSets:
 # OBJ-NEXT:         OffsetInDescriptorsFromTableStart: 4294967295
 
 ## UAV(u2)
-# OBJ:            - ParameterType:   4
-# OBJ-NEXT:         ShaderVisibility: 0
+# OBJ:            - ParameterType:   UAV
+# OBJ-NEXT:         ShaderVisibility: All
 # OBJ-NEXT:         Descriptor:
 # OBJ-NEXT:         RegisterSpace:   0
 # OBJ-NEXT:         ShaderRegister:  2

--- a/test/Feature/RootSignatures/ParameterInsensitivity.test
+++ b/test/Feature/RootSignatures/ParameterInsensitivity.test
@@ -92,25 +92,25 @@ DescriptorSets:
 # OBJ-NEXT:     NumStaticSamplers: 0
 # OBJ-NEXT:     StaticSamplersOffset: 116
 # OBJ-NEXT:     Parameters:
-# OBJ-NEXT:       - ParameterType:   1
-# OBJ-NEXT:         ShaderVisibility: 0
+# OBJ-NEXT:       - ParameterType:   Constants32Bit
+# OBJ-NEXT:         ShaderVisibility: All
 # OBJ-NEXT:         Constants:
 # OBJ-NEXT:           Num32BitValues:  4
 # OBJ-NEXT:           RegisterSpace:   2
 # OBJ-NEXT:           ShaderRegister:  0
-# OBJ-NEXT:       - ParameterType:   0
-# OBJ-NEXT:         ShaderVisibility: 0
+# OBJ-NEXT:       - ParameterType:   DescriptorTable
+# OBJ-NEXT:         ShaderVisibility: All
 # OBJ-NEXT:         Table:
 # OBJ-NEXT:           NumRanges:       2
 # OBJ-NEXT:           RangesOffset:    68
 # OBJ-NEXT:           Ranges:
-# OBJ-NEXT:             - RangeType:       0
+# OBJ-NEXT:             - RangeType:       SRV
 # OBJ-NEXT:               NumDescriptors:  1
 # OBJ-NEXT:               BaseShaderRegister: 0
 # OBJ-NEXT:               RegisterSpace:   0
 # OBJ-NEXT:               OffsetInDescriptorsFromTableStart: 4294967295
 # OBJ-NEXT:               DATA_STATIC:     true
-# OBJ-NEXT:             - RangeType:       1
+# OBJ-NEXT:             - RangeType:       UAV
 # OBJ-NEXT:               NumDescriptors:  -1
 # OBJ-NEXT:               BaseShaderRegister: 1
 # OBJ-NEXT:               RegisterSpace:   0

--- a/test/Feature/RootSignatures/RootConstants.test
+++ b/test/Feature/RootSignatures/RootConstants.test
@@ -73,24 +73,24 @@ DescriptorSets:
 # OBJ-NEXT:     NumStaticSamplers: 0
 # OBJ-NEXT:     StaticSamplersOffset: 116
 # OBJ-NEXT:     Parameters:
-# OBJ-NEXT:     - ParameterType:   1
-# OBJ-NEXT:       ShaderVisibility: 0
+# OBJ-NEXT:     - ParameterType:   Constants32Bit
+# OBJ-NEXT:       ShaderVisibility: All
 # OBJ-NEXT:       Constants:
 # OBJ-NEXT:       Num32BitValues:  4
 # OBJ-NEXT:       RegisterSpace:   0
 # OBJ-NEXT:       ShaderRegister:  2
-# OBJ:          - ParameterType:   0
-# OBJ-NEXT:       ShaderVisibility: 0
+# OBJ:          - ParameterType:   DescriptorTable
+# OBJ-NEXT:       ShaderVisibility: All
 # OBJ-NEXT:       Table:
 # OBJ-NEXT:       NumRanges:       2
 # OBJ-NEXT:       RangesOffset:    68
 # OBJ-NEXT:       Ranges:
-# OBJ:            - RangeType:       0
+# OBJ:            - RangeType:       SRV
 # OBJ-NEXT:         NumDescriptors:  1
 # OBJ-NEXT:         BaseShaderRegister: 2
 # OBJ-NEXT:         RegisterSpace:   0
 # OBJ-NEXT:         OffsetInDescriptorsFromTableStart: 4294967295
-# OBJ:            - RangeType:       1
+# OBJ:            - RangeType:       UAV
 # OBJ-NEXT:         NumDescriptors:  1
 # OBJ-NEXT:         BaseShaderRegister: 1
 # OBJ-NEXT:         RegisterSpace:   4

--- a/test/Feature/RootSignatures/RootDescriptorAndTables.test
+++ b/test/Feature/RootSignatures/RootDescriptorAndTables.test
@@ -78,24 +78,24 @@ DescriptorSets:
 # OBJ-NEXT:     NumStaticSamplers: 0
 # OBJ-NEXT:     StaticSamplersOffset: 116
 # OBJ-NEXT:     Parameters:
-# OBJ-NEXT:     - ParameterType:   2
-# OBJ-NEXT:       ShaderVisibility: 0
+# OBJ-NEXT:     - ParameterType:   CBV
+# OBJ-NEXT:       ShaderVisibility: All
 # OBJ-NEXT:       Descriptor:
 # OBJ-NEXT:       RegisterSpace:   0
 # OBJ-NEXT:       ShaderRegister:  2
-# OBJ:          - ParameterType:   0
-# OBJ-NEXT:       ShaderVisibility: 0
+# OBJ:          - ParameterType:   DescriptorTable
+# OBJ-NEXT:       ShaderVisibility: All
 # OBJ-NEXT:       Table:
 # OBJ-NEXT:       NumRanges:       1
 # OBJ-NEXT:       RangesOffset:    80
 # OBJ-NEXT:       Ranges:
-# OBJ-NEXT:       - RangeType:       0
+# OBJ-NEXT:       - RangeType:       SRV
 # OBJ-NEXT:         NumDescriptors:  1
 # OBJ-NEXT:         BaseShaderRegister: 2
 # OBJ-NEXT:         RegisterSpace:   0
 # OBJ-NEXT:         OffsetInDescriptorsFromTableStart: 4294967295
-# OBJ:            - ParameterType:   4
-# OBJ-NEXT:         ShaderVisibility: 0
+# OBJ:            - ParameterType:   UAV
+# OBJ-NEXT:         ShaderVisibility: All
 # OBJ-NEXT:         Descriptor:
 # OBJ-NEXT:         RegisterSpace:   4
 # OBJ-NEXT:         ShaderRegister:  1

--- a/test/Feature/RootSignatures/RootDescriptors.test
+++ b/test/Feature/RootSignatures/RootDescriptors.test
@@ -75,18 +75,18 @@ DescriptorSets: []
 # OBJ-NEXT:     NumStaticSamplers: 0
 # OBJ-NEXT:     StaticSamplersOffset: 96
 # OBJ-NEXT:     Parameters:
-# OBJ-NEXT:     - ParameterType:   2
-# OBJ-NEXT:       ShaderVisibility: 0
+# OBJ-NEXT:     - ParameterType: CBV
+# OBJ-NEXT:       ShaderVisibility: All
 # OBJ-NEXT:       Descriptor:
 # OBJ-NEXT:       RegisterSpace:   0
 # OBJ-NEXT:       ShaderRegister:  2
-# OBJ:          - ParameterType:   3
-# OBJ-NEXT:       ShaderVisibility: 0
+# OBJ:          - ParameterType:   SRV
+# OBJ-NEXT:       ShaderVisibility: All
 # OBJ-NEXT:       Descriptor:
 # OBJ-NEXT:       RegisterSpace:   0
 # OBJ-NEXT:       ShaderRegister:  2
-# OBJ:          - ParameterType:   4
-# OBJ-NEXT:       ShaderVisibility: 0
+# OBJ:          - ParameterType:   UAV
+# OBJ-NEXT:       ShaderVisibility: All
 # OBJ-NEXT:       Descriptor:
 # OBJ-NEXT:       RegisterSpace:   4
 # OBJ-NEXT:       ShaderRegister:  1

--- a/test/Feature/RootSignatures/StaticSamplers.test
+++ b/test/Feature/RootSignatures/StaticSamplers.test
@@ -152,22 +152,22 @@ DescriptorSets:
 # OBJ-NEXT:     Parameters:
 
 ## Descriptor Table
-# OBJ:          - ParameterType:   0
-# OBJ-NEXT:       ShaderVisibility: 0
+# OBJ:          - ParameterType:   DescriptorTable
+# OBJ-NEXT:       ShaderVisibility: All
 # OBJ-NEXT:       Table:
 # OBJ-NEXT:       NumRanges:       2
 # OBJ-NEXT:       RangesOffset:    44
 # OBJ-NEXT:       Ranges:
 
 ## SRV(t0)
-# OBJ:            - RangeType:       0
+# OBJ:            - RangeType:       SRV
 # OBJ-NEXT:         NumDescriptors:  1
 # OBJ-NEXT:         BaseShaderRegister: 0
 # OBJ-NEXT:         RegisterSpace:   0
 # OBJ-NEXT:         OffsetInDescriptorsFromTableStart: 4294967295
 
 ## UAV(u1, numDescriptors = 2)
-# OBJ-NEXT:       - RangeType:       1
+# OBJ-NEXT:       - RangeType:       UAV
 # OBJ-NEXT:         NumDescriptors:  2
 # OBJ-NEXT:         BaseShaderRegister: 1
 # OBJ-NEXT:         RegisterSpace:   0
@@ -177,19 +177,19 @@ DescriptorSets:
 
 ## StaticSampler(s0)
 ## Ensures the defaults are set as expected
-# OBJ-NEXT:     - Filter:          85
-# OBJ-NEXT:       AddressU:        1
-# OBJ-NEXT:       AddressV:        1
-# OBJ-NEXT:       AddressW:        1
+# OBJ-NEXT:     - Filter:          Anisotropic
+# OBJ-NEXT:       AddressU:        Wrap
+# OBJ-NEXT:       AddressV:        Wrap
+# OBJ-NEXT:       AddressW:        Wrap
 # OBJ-NEXT:       MipLODBias:      0
 # OBJ-NEXT:       MaxAnisotropy:   16
-# OBJ-NEXT:       ComparisonFunc:  4
-# OBJ-NEXT:       BorderColor:     2
+# OBJ-NEXT:       ComparisonFunc:  LessEqual
+# OBJ-NEXT:       BorderColor:     OpaqueWhite
 # OBJ-NEXT:       MinLOD:          0
 # OBJ-NEXT:       MaxLOD:          3.40282e+38
 # OBJ-NEXT:       ShaderRegister:  0
 # OBJ-NEXT:       RegisterSpace:   0
-# OBJ-NEXT:       ShaderVisibility: 0
+# OBJ-NEXT:       ShaderVisibility: All
 
 ## StaticSampler(s1,
 ##   mipLODBias = -15.99,
@@ -199,16 +199,16 @@ DescriptorSets:
 ##   filter = FILTER_MAXIMUM_MIN_MAG_MIP_POINT
 ## )
 ## Ensures the specified values are set as expected
-# OBJ:          - Filter:          384
-# OBJ-NEXT:       AddressU:        1
-# OBJ-NEXT:       AddressV:        2
-# OBJ-NEXT:       AddressW:        1
+# OBJ:          - Filter:          MaximumMinMagMipPoint
+# OBJ-NEXT:       AddressU:        Wrap
+# OBJ-NEXT:       AddressV:        Mirror
+# OBJ-NEXT:       AddressW:        Wrap
 # OBJ-NEXT:       MipLODBias:      -15.99
 # OBJ-NEXT:       MaxAnisotropy:   16
-# OBJ-NEXT:       ComparisonFunc:  4
-# OBJ-NEXT:       BorderColor:     2
+# OBJ-NEXT:       ComparisonFunc:  LessEqual
+# OBJ-NEXT:       BorderColor:     OpaqueWhite
 # OBJ-NEXT:       MinLOD:          32
 # OBJ-NEXT:       MaxLOD:          32
 # OBJ-NEXT:       ShaderRegister:  1
 # OBJ-NEXT:       RegisterSpace:   0
-# OBJ-NEXT:       ShaderVisibility: 0
+# OBJ-NEXT:       ShaderVisibility: All

--- a/test/Feature/RootSignatures/TwoDescriptorTables.test
+++ b/test/Feature/RootSignatures/TwoDescriptorTables.test
@@ -75,29 +75,29 @@ DescriptorSets:
 # OBJ-NEXT:     NumStaticSamplers: 0
 # OBJ-NEXT:     StaticSamplersOffset: 136
 # OBJ-NEXT:     Parameters:
-# OBJ-NEXT:     - ParameterType:   0
-# OBJ-NEXT:       ShaderVisibility: 0
+# OBJ-NEXT:     - ParameterType:   DescriptorTable
+# OBJ-NEXT:       ShaderVisibility: All
 # OBJ-NEXT:       Table:
 # OBJ-NEXT:       NumRanges:       2
 # OBJ-NEXT:       RangesOffset:    56
 # OBJ-NEXT:       Ranges:
-# OBJ:          - RangeType:       0
+# OBJ:          - RangeType:       SRV
 # OBJ-NEXT:       NumDescriptors:  1
 # OBJ-NEXT:       BaseShaderRegister: 2
 # OBJ-NEXT:       RegisterSpace:   0
 # OBJ-NEXT:       OffsetInDescriptorsFromTableStart: 4294967295
-# OBJ:          - RangeType:       1
+# OBJ:          - RangeType:       UAV
 # OBJ-NEXT:       NumDescriptors:  1
 # OBJ-NEXT:       BaseShaderRegister: 1
 # OBJ-NEXT:       RegisterSpace:   4
 # OBJ-NEXT:       OffsetInDescriptorsFromTableStart: 4294967295
-# OBJ:          - ParameterType:   0
-# OBJ-NEXT:       ShaderVisibility: 0
+# OBJ:          - ParameterType:   DescriptorTable
+# OBJ-NEXT:       ShaderVisibility: All
 # OBJ-NEXT:       Table:
 # OBJ-NEXT:       NumRanges:       1
 # OBJ-NEXT:       RangesOffset:    112
 # OBJ-NEXT:       Ranges:
-# OBJ:          - RangeType:       1
+# OBJ:          - RangeType:       UAV
 # OBJ-NEXT:       NumDescriptors:  1
 # OBJ-NEXT:       BaseShaderRegister: 2
 # OBJ-NEXT:       RegisterSpace:   4


### PR DESCRIPTION
This patch updates the Root Signature tests to enums, instead of numbers, to represent certain fields in root signatures. This is required since we changed Root Signature's yaml representation recently in this pr: [llvm/llvm-project#154827](https://github.com/llvm/llvm-project/pull/154827)