### PR TITLE
[Vulkan] Change non-uniform index test to succeed for `Clang && Vulkan`.

### DIFF
--- a/test/Feature/ResourceArrays/unbounded-array-nuri.test
+++ b/test/Feature/ResourceArrays/unbounded-array-nuri.test
@@ -64,7 +64,7 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/llvm-project/issues/159679
-# XFAIL: Clang
+# XFAIL: Clang && DirectX
 
 # Resource arrays are not yet supported on Metal
 # UNSUPPORTED: Metal


### PR DESCRIPTION
Verified the test is succeeding from the the fix in https://github.com/llvm/llvm-project/pull/162540