### PR TITLE
Enable GetDimensions test for Clang & DirectX

### DIFF
--- a/test/Feature/ByteAddressBuffer/GetDimensions.test
+++ b/test/Feature/ByteAddressBuffer/GetDimensions.test
@@ -79,8 +79,8 @@ DescriptorSets:
 ...
 #--- end
 
-# Unimplemented https://github.com/llvm/wg-hlsl/issues/126
-# XFAIL: Clang
+# Unimplemented https://github.com/llvm/llvm-project/issues/164008
+# XFAIL: Clang && Vulkan
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/StructuredBuffer/GetDimensions.test
+++ b/test/Feature/StructuredBuffer/GetDimensions.test
@@ -131,8 +131,8 @@ DescriptorSets:
 ...
 #--- end
 
-# Unimplemented https://github.com/llvm/wg-hlsl/issues/126
-# XFAIL: Clang
+# Unimplemented https://github.com/llvm/llvm-project/issues/164008
+# XFAIL: Clang && Vulkan
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/TypedBuffer/GetDimensions.test
+++ b/test/Feature/TypedBuffer/GetDimensions.test
@@ -83,8 +83,8 @@ DescriptorSets:
 # Bug https://github.com/llvm/offload-test-suite/issues/469
 # XFAIL: DXC && Vulkan
 
-# Unimplemented https://github.com/llvm/wg-hlsl/issues/126
-# XFAIL: Clang
+# Unimplemented https://github.com/llvm/llvm-project/issues/164008
+# XFAIL: Clang && Vulkan
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl


### PR DESCRIPTION
These tests are now passing for DirectX. The SPIR-V backend does not yet support the intrinsic needed for this test, so the link now points to a new issue that is SPIR-V only.