### PR TITLE
Add `select` non-boolean vector condition tests

### DIFF
--- a/test/Feature/HLSLLib/select.32.test
+++ b/test/Feature/HLSLLib/select.32.test
@@ -6,24 +6,28 @@
 //   - Vector condition, scalar true value, vector false value
 //   - Vector condition, vector true value, scalar false value
 //   - Vector condition, scalar true/false values
+//   - Non-boolean vector condition, vector true/false values
 // For each vector condition scenario, there are tests for vec4, vec3, and vec2.
 // For the scalar condition scenario, there are four tests. One uses the buffers 
 // for inputs and the other three use constants.
 
 StructuredBuffer<bool> Cond : register(t0);
-StructuredBuffer<float4> TrueVal0 : register(t1);
-StructuredBuffer<float4> FalseVal0 : register(t2);
-StructuredBuffer<int4> TrueVal1 : register(t3);
-StructuredBuffer<int4> FalseVal1 : register(t4);
-StructuredBuffer<uint4> TrueVal2 : register(t5);
-StructuredBuffer<uint4> FalseVal2 : register(t6);
-StructuredBuffer<bool> TrueVal3 : register(t7);
-StructuredBuffer<bool> FalseVal3 : register(t8);
+StructuredBuffer<float4> FloatCond : register(t1);
+StructuredBuffer<float4> TrueVal0 : register(t2);
+StructuredBuffer<float4> FalseVal0 : register(t3);
+StructuredBuffer<int4> IntCond : register(t4);
+StructuredBuffer<int4> TrueVal1 : register(t5);
+StructuredBuffer<int4> FalseVal1 : register(t6);
+StructuredBuffer<uint4> UIntCond : register(t7);
+StructuredBuffer<uint4> TrueVal2 : register(t8);
+StructuredBuffer<uint4> FalseVal2 : register(t9);
+StructuredBuffer<bool> TrueVal3 : register(t10);
+StructuredBuffer<bool> FalseVal3 : register(t11);
 
-RWStructuredBuffer<float4> Out0 : register(u9);
-RWStructuredBuffer<int4> Out1 : register(u10);
-RWStructuredBuffer<uint4> Out2 : register(u11);
-RWStructuredBuffer<bool4> Out3 : register(u12);
+RWStructuredBuffer<float4> Out0 : register(u12);
+RWStructuredBuffer<int4> Out1 : register(u13);
+RWStructuredBuffer<uint4> Out2 : register(u14);
+RWStructuredBuffer<bool4> Out3 : register(u15);
 
 
 [numthreads(1,1,1)]
@@ -47,6 +51,9 @@ void main() {
   // vec2
   Out0[8] = float4(select(Cond2, TrueVal0[2].xy, FalseVal0[2].xy), select(Cond3, TrueVal0[2].z, FalseVal0[2].zw));
   Out0[9] = float4(select(Cond2, TrueVal0[2].xy, FalseVal0[2].x), select(Cond3, TrueVal0[2].z, FalseVal0[2].z));
+  // non-bool vector condition
+  Out0[10] = select(FloatCond[0], TrueVal0[0], FalseVal0[0]);
+  Out0[11] = select(FloatCond[0] == FloatCond[1], TrueVal0[0], FalseVal0[0]);
 
   // int
   // vec4
@@ -62,6 +69,9 @@ void main() {
   // vec2
   Out1[8] = int4(select(Cond2, TrueVal1[2].xy, FalseVal1[2].xy), select(Cond3, TrueVal1[2].z, FalseVal1[2].zw));
   Out1[9] = int4(select(Cond2, TrueVal1[2].xy, FalseVal1[2].x), select(Cond3, TrueVal1[2].z, FalseVal1[2].z));
+  // non-bool vector condition
+  Out1[10] = select(IntCond[0], TrueVal1[0], FalseVal1[0]);
+  Out1[11] = select(IntCond[0] == IntCond[1], TrueVal1[0], FalseVal1[0]);
 
   // uint
   // vec4
@@ -77,6 +87,9 @@ void main() {
   // vec2
   Out2[8] = uint4(select(Cond2, TrueVal2[2].xy, FalseVal2[2].xy), select(Cond3, TrueVal2[2].z, FalseVal2[2].zw));
   Out2[9] = uint4(select(Cond2, TrueVal2[2].xy, FalseVal2[2].x), select(Cond3, TrueVal2[2].z, FalseVal2[2].z));
+  // non-bool vector condition
+  Out2[10] = select(UIntCond[0], TrueVal2[0], FalseVal2[0]);
+  Out2[11] = select(UIntCond[0] == UIntCond[1], TrueVal2[0], FalseVal2[0]);
 
   // bool
   // vec4
@@ -109,6 +122,10 @@ Buffers:
     Format: Bool
     Stride: 4
     Data: [ 1, 0, 1, 0, 1, 1, 0, 0, 1, 0, 0, 1 ]
+  - Name: FloatCond
+    Format: Float32
+    Stride: 16
+    Data: [ 10, 0, 20, 0, 1, -10, 20, 0 ]
   - Name: TrueVal0
     Format: Float32
     Stride: 16
@@ -117,6 +134,10 @@ Buffers:
     Format: Float32
     Stride: 16
     Data: [ -1, -2, -3, -4, 7.7, 8.8, -9.9, 0.01, 100, 200, -15, 25 ]
+  - Name: IntCond
+    Format: Int32
+    Stride: 16
+    Data: [ 10, 0, 20, 0, 1, -10, 20, 0 ]
   - Name: TrueVal1
     Format: Int32
     Stride: 16
@@ -125,6 +146,10 @@ Buffers:
     Format: Int32
     Stride: 16
     Data: [ -1, -2, -3, -4, 7, 8, -9, 1, 100, 200, -15, 25 ]
+  - Name: UIntCond
+    Format: UInt32
+    Stride: 16
+    Data: [ 10, 0, 20, 0, 1, 10, 20, 0 ]
   - Name: TrueVal2
     Format: UInt32
     Stride: 16
@@ -144,38 +169,41 @@ Buffers:
   - Name: Out0
     Format: Float32
     Stride: 16
-    FillSize: 160
+    FillSize: 192
   - Name: ExpectedOut0
     Format: Float32
     Stride: 16
     Data: [ 
       1, -2, 3, -4, 1, -2, 1, -4, 1, -1, 3, -1, 1, -1, 1, -1,
       4.4, -5.5, -9.9, 0.01, 4.4, 4.4, -9.9, 1, 4.4, -5.5, 7.7, -2, 4.4, 4.4, 7.7, 3,
-      -10, 200, -15, 15, -10, 100, -15, 15
+      -10, 200, -15, 15, -10, 100, -15, 15,
+      1, -2, 3, -4, -1, -2, 3, 4
     ]
   - Name: Out1
     Format: Int32
     Stride: 16
-    FillSize: 160
+    FillSize: 192
   - Name: ExpectedOut1
     Format: Int32
     Stride: 16
     Data: [
       1, -2, 3, -4, 1, -2, 1, -4, 1, -1, 3, -1, 1, -1, 1, -1,
       4, -5, -9, 1, 4, 4, -9, 1, 4, -5, 7, -2, 4, 4, 7, 3,
-      -10, 200, -15, 15, -10, 100, -15, 15
+      -10, 200, -15, 15, -10, 100, -15, 15,
+      1, -2, 3, -4, -1, -2, 3, 4
     ]
   - Name: Out2
     Format: UInt32
     Stride: 16
-    FillSize: 160
+    FillSize: 192
   - Name: ExpectedOut2
     Format: UInt32
     Stride: 16
     Data: [
       1, 20, 3, 40, 1, 20, 1, 40, 1, 10, 3, 10, 1, 10, 1, 10,
       4, 5, 9, 1, 4, 4, 9, 1, 4, 5, 7, 20, 4, 4, 7, 3,
-      10, 200, 150, 15, 10, 100, 150, 15
+      10, 200, 150, 15, 10, 100, 150, 15,
+      1, 20, 3, 40, 10, 20, 3, 4
     ]
   - Name: Out3
     Format: Bool
@@ -215,91 +243,115 @@ DescriptorSets:
         Space: 0
       VulkanBinding:
         Binding: 0
-    - Name: TrueVal0
+    - Name: FloatCond
       Kind: StructuredBuffer
       DirectXBinding:
         Register: 1
         Space: 0
       VulkanBinding:
         Binding: 1
-    - Name: FalseVal0
+    - Name: TrueVal0
       Kind: StructuredBuffer
       DirectXBinding:
         Register: 2
         Space: 0
       VulkanBinding:
         Binding: 2
-    - Name: TrueVal1
+    - Name: FalseVal0
       Kind: StructuredBuffer
       DirectXBinding:
         Register: 3
         Space: 0
       VulkanBinding:
         Binding: 3
-    - Name: FalseVal1
+    - Name: IntCond
       Kind: StructuredBuffer
       DirectXBinding:
         Register: 4
         Space: 0
       VulkanBinding:
         Binding: 4
-    - Name: TrueVal2
+    - Name: TrueVal1
       Kind: StructuredBuffer
       DirectXBinding:
         Register: 5
         Space: 0
       VulkanBinding:
         Binding: 5
-    - Name: FalseVal2
+    - Name: FalseVal1
       Kind: StructuredBuffer
       DirectXBinding:
         Register: 6
         Space: 0
       VulkanBinding:
         Binding: 6
-    - Name: TrueVal3
+    - Name: UIntCond
       Kind: StructuredBuffer
       DirectXBinding:
         Register: 7
         Space: 0
       VulkanBinding:
         Binding: 7
-    - Name: FalseVal3
+    - Name: TrueVal2
       Kind: StructuredBuffer
       DirectXBinding:
         Register: 8
         Space: 0
       VulkanBinding:
         Binding: 8
-    - Name: Out0
-      Kind: RWStructuredBuffer
+    - Name: FalseVal2
+      Kind: StructuredBuffer
       DirectXBinding:
         Register: 9
         Space: 0
       VulkanBinding:
         Binding: 9
-    - Name: Out1
-      Kind: RWStructuredBuffer
+    - Name: TrueVal3
+      Kind: StructuredBuffer
       DirectXBinding:
         Register: 10
         Space: 0
       VulkanBinding:
         Binding: 10
-    - Name: Out2
-      Kind: RWStructuredBuffer
+    - Name: FalseVal3
+      Kind: StructuredBuffer
       DirectXBinding:
         Register: 11
         Space: 0
       VulkanBinding:
         Binding: 11
-    - Name: Out3
+    - Name: Out0
       Kind: RWStructuredBuffer
       DirectXBinding:
         Register: 12
         Space: 0
       VulkanBinding:
         Binding: 12
+    - Name: Out1
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 13
+        Space: 0
+      VulkanBinding:
+        Binding: 13
+    - Name: Out2
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 14
+        Space: 0
+      VulkanBinding:
+        Binding: 14
+    - Name: Out3
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 15
+        Space: 0
+      VulkanBinding:
+        Binding: 15
 #--- end
+
+# Bug https://github.com/llvm/llvm-project/issues/164018
+# XFAIL: Clang
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -HV 202x -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/select.fp16.test
+++ b/test/Feature/HLSLLib/select.fp16.test
@@ -6,15 +6,17 @@
 //   - Vector condition, scalar true value, vector false value
 //   - Vector condition, vector true value, scalar false value
 //   - Vector condition, scalar true/false values
+//   - Non-boolean vector condition, vector true/false values
 // For each vector condition scenario, there are tests for vec4, vec3, and vec2.
 // For the scalar condition scenario, there are four tests. One uses the buffers 
 // for inputs and the other three use constants.
 
 StructuredBuffer<bool> Cond : register(t0);
-StructuredBuffer<half4> TrueVal : register(t1);
-StructuredBuffer<half4> FalseVal : register(t2);
+StructuredBuffer<half4> HalfCond : register(t1);
+StructuredBuffer<half4> TrueVal : register(t2);
+StructuredBuffer<half4> FalseVal : register(t3);
 
-RWStructuredBuffer<half4> Out : register(u3);
+RWStructuredBuffer<half4> Out : register(u4);
 
 
 [numthreads(1,1,1)]
@@ -37,6 +39,9 @@ void main() {
   // vec2
   Out[8] = half4(select(Cond2, TrueVal[2].xy, FalseVal[2].xy), select(Cond3, TrueVal[2].z, FalseVal[2].zw));
   Out[9] = half4(select(Cond2, TrueVal[2].xy, FalseVal[2].x), select(Cond3, TrueVal[2].z, FalseVal[2].z));
+  // non-bool vector condition
+  Out[10] = select(HalfCond[0], TrueVal[0], FalseVal[0]);
+  Out[11] = select(HalfCond[0] == HalfCond[1], TrueVal[0], FalseVal[0]);
 }
 //--- pipeline.yaml
 
@@ -50,6 +55,11 @@ Buffers:
     Format: Bool
     Stride: 4
     Data: [ 1, 0, 1, 0, 1, 1, 0, 0, 1, 0, 0, 1 ]
+  - Name: HalfCond
+    Format: Float16
+    Stride: 8
+    Data: [ 0x4900, 0x0000, 0x4d00, 0x0000, 0x3c00, 0xc900, 0x4d00, 0x0000 ]
+    # 10, 0, 20, 0, 1, -10, 20, 0
   - Name: TrueVal
     Format: Float16
     Stride: 8
@@ -63,18 +73,20 @@ Buffers:
   - Name: Out
     Format: Float16
     Stride: 8
-    FillSize: 80
+    FillSize: 96
   - Name: ExpectedOut
     Format: Float16
     Stride: 8
     Data: [ 
       0x3c00, 0xc000, 0x4200, 0xc400, 0x3c00, 0xc000, 0x3c00, 0xc400, 0x3c00, 0xbc00, 0x4200, 0xbc00, 0x3c00, 0xbc00, 0x3c00, 0xbc00,
       0x4466, 0xc580, 0xc8f3, 0x211f, 0x4466, 0x4466, 0xc8f3, 0x3c00, 0x4466, 0xc580, 0x47b3, 0xc000, 0x4466, 0x4466, 0x47b3, 0x4200,
-      0xc900, 0x5a40, 0xcb80, 0x4b80, 0xc900, 0x5640, 0xcb80, 0x4b80
+      0xc900, 0x5a40, 0xcb80, 0x4b80, 0xc900, 0x5640, 0xcb80, 0x4b80,
+      0x3c00, 0xc000, 0x4200, 0xc400, 0xbc00, 0xc000, 0x4200, 0x4400
     ]
     # 1, -2, 3, -4, 1, -2, 1, -4, 1, -1, 3, -1, 1, -1, 1, -1,
     # 4.4, -5.5, -9.9, 0.01, 4.4, 4.4, -9.9, 1, 4.4, -5.5, 7.7, -2, 4.4, 4.4, 7.7, 3,
     # -10, 200, -15, 15, -10, 100, -15, 15
+    # 1, -2, 3, -4, -1, -2, 3, 4
 Results:
   - Result: Test0
     Rule: BufferExact
@@ -89,28 +101,38 @@ DescriptorSets:
         Space: 0
       VulkanBinding:
         Binding: 0
-    - Name: TrueVal
+    - Name: HalfCond
       Kind: StructuredBuffer
       DirectXBinding:
         Register: 1
         Space: 0
       VulkanBinding:
         Binding: 1
-    - Name: FalseVal
+    - Name: TrueVal
       Kind: StructuredBuffer
       DirectXBinding:
         Register: 2
         Space: 0
       VulkanBinding:
         Binding: 2
-    - Name: Out
-      Kind: RWStructuredBuffer
+    - Name: FalseVal
+      Kind: StructuredBuffer
       DirectXBinding:
         Register: 3
         Space: 0
       VulkanBinding:
         Binding: 3
+    - Name: Out
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 4
+        Space: 0
+      VulkanBinding:
+        Binding: 4
 #--- end
+
+# Bug https://github.com/llvm/llvm-project/issues/164018
+# XFAIL: Clang
 
 # REQUIRES: Half
 # RUN: split-file %s %t

--- a/test/Feature/HLSLLib/select.fp64.test
+++ b/test/Feature/HLSLLib/select.fp64.test
@@ -6,15 +6,17 @@
 //   - Vector condition, scalar true value, vector false value
 //   - Vector condition, vector true value, scalar false value
 //   - Vector condition, scalar true/false values
+//   - Non-boolean vector condition, vector true/false values
 // For each vector condition scenario, there are tests for vec4, vec3, and vec2.
 // For the scalar condition scenario, there are four tests. One uses the buffers 
 // for inputs and the other three use constants.
 
 StructuredBuffer<bool> Cond : register(t0);
-StructuredBuffer<double4> TrueVal : register(t1);
-StructuredBuffer<double4> FalseVal : register(t2);
+StructuredBuffer<double4> DoubleCond : register(t1);
+StructuredBuffer<double4> TrueVal : register(t2);
+StructuredBuffer<double4> FalseVal : register(t3);
 
-RWStructuredBuffer<double4> Out : register(u3);
+RWStructuredBuffer<double4> Out : register(u4);
 
 
 [numthreads(1,1,1)]
@@ -37,6 +39,9 @@ void main() {
   // vec2
   Out[8] = double4(select(Cond2, TrueVal[2].xy, FalseVal[2].xy), select(Cond3, TrueVal[2].z, FalseVal[2].zw));
   Out[9] = double4(select(Cond2, TrueVal[2].xy, FalseVal[2].x), select(Cond3, TrueVal[2].z, FalseVal[2].z));
+  // non-bool vector condition
+  Out[10] = select(DoubleCond[0], TrueVal[0], FalseVal[0]);
+  Out[11] = select(DoubleCond[0] == DoubleCond[1], TrueVal[0], FalseVal[0]);
 }
 //--- pipeline.yaml
 
@@ -50,6 +55,10 @@ Buffers:
     Format: Bool
     Stride: 4
     Data: [ 1, 0, 1, 0, 1, 1, 0, 0, 1, 0, 0, 1 ]
+  - Name: DoubleCond
+    Format: Float64
+    Stride: 32
+    Data: [ 10, 0, 20, 0, 1, -10, 20, 0 ]
   - Name: TrueVal
     Format: Float64
     Stride: 32
@@ -61,14 +70,15 @@ Buffers:
   - Name: Out
     Format: Float64
     Stride: 32
-    FillSize: 320
+    FillSize: 384
   - Name: ExpectedOut
     Format: Float64
     Stride: 32
     Data: [ 
       1, -2, 3, -4, 1, -2, 1, -4, 1, -1, 3, -1, 1, -1, 1, -1,
       4.4, -5.5, -9.9, 0.01, 4.4, 4.4, -9.9, 1, 4.4, -5.5, 7.7, -2, 4.4, 4.4, 7.7, 3,
-      -10, 200, -15, 15, -10, 100, -15, 15
+      -10, 200, -15, 15, -10, 100, -15, 15,
+      1, -2, 3, -4, -1, -2, 3, 4
     ]
 Results:
   - Result: Test0
@@ -84,28 +94,38 @@ DescriptorSets:
         Space: 0
       VulkanBinding:
         Binding: 0
-    - Name: TrueVal
+    - Name: DoubleCond
       Kind: StructuredBuffer
       DirectXBinding:
         Register: 1
         Space: 0
       VulkanBinding:
         Binding: 1
-    - Name: FalseVal
+    - Name: TrueVal
       Kind: StructuredBuffer
       DirectXBinding:
         Register: 2
         Space: 0
       VulkanBinding:
         Binding: 2
-    - Name: Out
-      Kind: RWStructuredBuffer
+    - Name: FalseVal
+      Kind: StructuredBuffer
       DirectXBinding:
         Register: 3
         Space: 0
       VulkanBinding:
         Binding: 3
+    - Name: Out
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 4
+        Space: 0
+      VulkanBinding:
+        Binding: 4
 #--- end
+
+# Bug https://github.com/llvm/llvm-project/issues/164018
+# XFAIL: Clang
 
 # REQUIRES: Double
 # RUN: split-file %s %t

--- a/test/Feature/HLSLLib/select.int16.test
+++ b/test/Feature/HLSLLib/select.int16.test
@@ -6,18 +6,21 @@
 //   - Vector condition, scalar true value, vector false value
 //   - Vector condition, vector true value, scalar false value
 //   - Vector condition, scalar true/false values
+//   - Non-boolean vector condition, vector true/false values
 // For each vector condition scenario, there are tests for vec4, vec3, and vec2.
 // For the scalar condition scenario, there are four tests. One uses the buffers 
 // for inputs and the other three use constants.
 
 StructuredBuffer<bool> Cond : register(t0);
-StructuredBuffer<int16_t4> TrueVal0 : register(t1);
-StructuredBuffer<int16_t4> FalseVal0 : register(t2);
-StructuredBuffer<uint16_t4> TrueVal1 : register(t3);
-StructuredBuffer<uint16_t4> FalseVal1 : register(t4);
+StructuredBuffer<int16_t4> IntCond : register(t1);
+StructuredBuffer<int16_t4> TrueVal0 : register(t2);
+StructuredBuffer<int16_t4> FalseVal0 : register(t3);
+StructuredBuffer<uint16_t4> UIntCond : register(t4);
+StructuredBuffer<uint16_t4> TrueVal1 : register(t5);
+StructuredBuffer<uint16_t4> FalseVal1 : register(t6);
 
-RWStructuredBuffer<int16_t4> Out0 : register(u5);
-RWStructuredBuffer<uint16_t4> Out1 : register(u6);
+RWStructuredBuffer<int16_t4> Out0 : register(u7);
+RWStructuredBuffer<uint16_t4> Out1 : register(u8);
 
 
 [numthreads(1,1,1)]
@@ -41,6 +44,9 @@ void main() {
   // vec2
   Out0[8] = int16_t4(select(Cond2, TrueVal0[2].xy, FalseVal0[2].xy), select(Cond3, TrueVal0[2].z, FalseVal0[2].zw));
   Out0[9] = int16_t4(select(Cond2, TrueVal0[2].xy, FalseVal0[2].x), select(Cond3, TrueVal0[2].z, FalseVal0[2].z));
+  // non-bool vector condition
+  Out0[10] = select(IntCond[0], TrueVal0[0], FalseVal0[0]);
+  Out0[11] = select(IntCond[0] == IntCond[1], TrueVal0[0], FalseVal0[0]);
 
   // uint16_t
   // vec4
@@ -56,6 +62,9 @@ void main() {
   // vec2
   Out1[8] = uint16_t4(select(Cond2, TrueVal1[2].xy, FalseVal1[2].xy), select(Cond3, TrueVal1[2].z, FalseVal1[2].zw));
   Out1[9] = uint16_t4(select(Cond2, TrueVal1[2].xy, FalseVal1[2].x), select(Cond3, TrueVal1[2].z, FalseVal1[2].z));
+  // non-bool vector condition
+  Out1[10] = select(UIntCond[0], TrueVal1[0], FalseVal1[0]);
+  Out1[11] = select(UIntCond[0] == UIntCond[1], TrueVal1[0], FalseVal1[0]);
 }
 //--- pipeline.yaml
 
@@ -69,6 +78,10 @@ Buffers:
     Format: Bool
     Stride: 4
     Data: [ 1, 0, 1, 0, 1, 1, 0, 0, 1, 0, 0, 1 ]
+  - Name: IntCond
+    Format: Int16
+    Stride: 8
+    Data: [ 10, 0, 20, 0, 1, -10, 20, 0 ]
   - Name: TrueVal0
     Format: Int16
     Stride: 8
@@ -77,6 +90,10 @@ Buffers:
     Format: Int16
     Stride: 8
     Data: [ -1, -2, -3, -4, 7, 8, -9, 1, 100, 200, -15, 25 ]
+  - Name: UIntCond
+    Format: UInt16
+    Stride: 8
+    Data: [ 10, 0, 20, 0, 1, 10, 20, 0 ]
   - Name: TrueVal1
     Format: UInt16
     Stride: 8
@@ -88,26 +105,28 @@ Buffers:
   - Name: Out0
     Format: Int16
     Stride: 8
-    FillSize: 80
+    FillSize: 96
   - Name: ExpectedOut0
     Format: Int16
     Stride: 8
     Data: [
       1, -2, 3, -4, 1, -2, 1, -4, 1, -1, 3, -1, 1, -1, 1, -1,
       4, -5, -9, 1, 4, 4, -9, 1, 4, -5, 7, -2, 4, 4, 7, 3,
-      -10, 200, -15, 15, -10, 100, -15, 15
+      -10, 200, -15, 15, -10, 100, -15, 15,
+      1, -2, 3, -4, -1, -2, 3, 4
     ]
   - Name: Out1
     Format: Int16
     Stride: 8
-    FillSize: 80
+    FillSize: 96
   - Name: ExpectedOut1
     Format: Int16
     Stride: 8
     Data: [
       1, 20, 3, 40, 1, 20, 1, 40, 1, 10, 3, 10, 1, 10, 1, 10,
       4, 5, 9, 1, 4, 4, 9, 1, 4, 5, 7, 20, 4, 4, 7, 3,
-      10, 200, 150, 15, 10, 100, 150, 15
+      10, 200, 150, 15, 10, 100, 150, 15,
+      1, 20, 3, 40, 10, 20, 3, 4
     ]
 Results:
   - Result: Test0
@@ -127,49 +146,66 @@ DescriptorSets:
         Space: 0
       VulkanBinding:
         Binding: 0
-    - Name: TrueVal0
+    - Name: IntCond
       Kind: StructuredBuffer
       DirectXBinding:
         Register: 1
         Space: 0
       VulkanBinding:
         Binding: 1
-    - Name: FalseVal0
+    - Name: TrueVal0
       Kind: StructuredBuffer
       DirectXBinding:
         Register: 2
         Space: 0
       VulkanBinding:
         Binding: 2
-    - Name: TrueVal1
+    - Name: FalseVal0
       Kind: StructuredBuffer
       DirectXBinding:
         Register: 3
         Space: 0
       VulkanBinding:
         Binding: 3
-    - Name: FalseVal1
+    - Name: UIntCond
       Kind: StructuredBuffer
       DirectXBinding:
         Register: 4
         Space: 0
       VulkanBinding:
         Binding: 4
-    - Name: Out0
-      Kind: RWStructuredBuffer
+    - Name: TrueVal1
+      Kind: StructuredBuffer
       DirectXBinding:
         Register: 5
         Space: 0
       VulkanBinding:
         Binding: 5
-    - Name: Out1
-      Kind: RWStructuredBuffer
+    - Name: FalseVal1
+      Kind: StructuredBuffer
       DirectXBinding:
         Register: 6
         Space: 0
       VulkanBinding:
         Binding: 6
+    - Name: Out0
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 7
+        Space: 0
+      VulkanBinding:
+        Binding: 7
+    - Name: Out1
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 8
+        Space: 0
+      VulkanBinding:
+        Binding: 8
 #--- end
+
+# Bug https://github.com/llvm/llvm-project/issues/164018
+# XFAIL: Clang
 
 # REQUIRES: Int16
 # RUN: split-file %s %t

--- a/test/Feature/HLSLLib/select.int64.test
+++ b/test/Feature/HLSLLib/select.int64.test
@@ -6,19 +6,21 @@
 //   - Vector condition, scalar true value, vector false value
 //   - Vector condition, vector true value, scalar false value
 //   - Vector condition, scalar true/false values
+//   - Non-boolean vector condition, vector true/false values
 // For each vector condition scenario, there are tests for vec4, vec3, and vec2.
 // For the scalar condition scenario, there are four tests. One uses the buffers 
 // for inputs and the other three use constants.
 
 StructuredBuffer<bool> Cond : register(t0);
-StructuredBuffer<int64_t4> TrueVal0 : register(t1);
-StructuredBuffer<int64_t4> FalseVal0 : register(t2);
-StructuredBuffer<uint64_t4> TrueVal1 : register(t3);
-StructuredBuffer<uint64_t4> FalseVal1 : register(t4);
+StructuredBuffer<int64_t4> IntCond : register(t1);
+StructuredBuffer<int64_t4> TrueVal0 : register(t2);
+StructuredBuffer<int64_t4> FalseVal0 : register(t3);
+StructuredBuffer<uint64_t4> UIntCond : register(t4);
+StructuredBuffer<uint64_t4> TrueVal1 : register(t5);
+StructuredBuffer<uint64_t4> FalseVal1 : register(t6);
 
-RWStructuredBuffer<int64_t4> Out0 : register(u5);
-RWStructuredBuffer<uint64_t4> Out1 : register(u6);
-
+RWStructuredBuffer<int64_t4> Out0 : register(u7);
+RWStructuredBuffer<uint64_t4> Out1 : register(u8);
 
 [numthreads(1,1,1)]
 void main() {
@@ -41,6 +43,9 @@ void main() {
   // vec2
   Out0[8] = int64_t4(select(Cond2, TrueVal0[2].xy, FalseVal0[2].xy), select(Cond3, TrueVal0[2].z, FalseVal0[2].zw));
   Out0[9] = int64_t4(select(Cond2, TrueVal0[2].xy, FalseVal0[2].x), select(Cond3, TrueVal0[2].z, FalseVal0[2].z));
+  // non-bool vector condition
+  Out0[10] = select(IntCond[0], TrueVal0[0], FalseVal0[0]);
+  Out0[11] = select(IntCond[0] == IntCond[1], TrueVal0[0], FalseVal0[0]);
 
   // uint64_t
   // vec4
@@ -56,6 +61,9 @@ void main() {
   // vec2
   Out1[8] = uint64_t4(select(Cond2, TrueVal1[2].xy, FalseVal1[2].xy), select(Cond3, TrueVal1[2].z, FalseVal1[2].zw));
   Out1[9] = uint64_t4(select(Cond2, TrueVal1[2].xy, FalseVal1[2].x), select(Cond3, TrueVal1[2].z, FalseVal1[2].z));
+  // non-bool vector condition
+  Out1[10] = select(UIntCond[0], TrueVal1[0], FalseVal1[0]);
+  Out1[11] = select(UIntCond[0] == UIntCond[1], TrueVal1[0], FalseVal1[0]);
 }
 //--- pipeline.yaml
 
@@ -69,6 +77,10 @@ Buffers:
     Format: Bool
     Stride: 4
     Data: [ 1, 0, 1, 0, 1, 1, 0, 0, 1, 0, 0, 1 ]
+  - Name: IntCond
+    Format: Int64
+    Stride: 32
+    Data: [ 10, 0, 20, 0, 1, -10, 20, 0 ]
   - Name: TrueVal0
     Format: Int64
     Stride: 32
@@ -77,6 +89,10 @@ Buffers:
     Format: Int64
     Stride: 32
     Data: [ -1, -2, -3, -4, 7, 8, -9, 1, 100, 200, -15, 25 ]
+  - Name: UIntCond
+    Format: UInt64
+    Stride: 32
+    Data: [ 10, 0, 20, 0, 1, 10, 20, 0 ]
   - Name: TrueVal1
     Format: UInt64
     Stride: 32
@@ -88,26 +104,28 @@ Buffers:
   - Name: Out0
     Format: Int64
     Stride: 32
-    FillSize: 320
+    FillSize: 384
   - Name: ExpectedOut0
     Format: Int64
     Stride: 32
     Data: [
       1, -2, 3, -4, 1, -2, 1, -4, 1, -1, 3, -1, 1, -1, 1, -1,
       4, -5, -9, 1, 4, 4, -9, 1, 4, -5, 7, -2, 4, 4, 7, 3,
-      -10, 200, -15, 15, -10, 100, -15, 15
+      -10, 200, -15, 15, -10, 100, -15, 15,
+      1, -2, 3, -4, -1, -2, 3, 4
     ]
   - Name: Out1
     Format: UInt64
     Stride: 32
-    FillSize: 320
+    FillSize: 384
   - Name: ExpectedOut1
     Format: UInt64
     Stride: 32
     Data: [
       1, 20, 3, 40, 1, 20, 1, 40, 1, 10, 3, 10, 1, 10, 1, 10,
       4, 5, 9, 1, 4, 4, 9, 1, 4, 5, 7, 20, 4, 4, 7, 3,
-      10, 200, 150, 15, 10, 100, 150, 15
+      10, 200, 150, 15, 10, 100, 150, 15,
+      1, 20, 3, 40, 10, 20, 3, 4
     ]
 Results:
   - Result: Test0
@@ -127,49 +145,66 @@ DescriptorSets:
         Space: 0
       VulkanBinding:
         Binding: 0
-    - Name: TrueVal0
+    - Name: IntCond
       Kind: StructuredBuffer
       DirectXBinding:
         Register: 1
         Space: 0
       VulkanBinding:
         Binding: 1
-    - Name: FalseVal0
+    - Name: TrueVal0
       Kind: StructuredBuffer
       DirectXBinding:
         Register: 2
         Space: 0
       VulkanBinding:
         Binding: 2
-    - Name: TrueVal1
+    - Name: FalseVal0
       Kind: StructuredBuffer
       DirectXBinding:
         Register: 3
         Space: 0
       VulkanBinding:
         Binding: 3
-    - Name: FalseVal1
+    - Name: UIntCond
       Kind: StructuredBuffer
       DirectXBinding:
         Register: 4
         Space: 0
       VulkanBinding:
         Binding: 4
-    - Name: Out0
-      Kind: RWStructuredBuffer
+    - Name: TrueVal1
+      Kind: StructuredBuffer
       DirectXBinding:
         Register: 5
         Space: 0
       VulkanBinding:
         Binding: 5
-    - Name: Out1
-      Kind: RWStructuredBuffer
+    - Name: FalseVal1
+      Kind: StructuredBuffer
       DirectXBinding:
         Register: 6
         Space: 0
       VulkanBinding:
         Binding: 6
+    - Name: Out0
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 7
+        Space: 0
+      VulkanBinding:
+        Binding: 7
+    - Name: Out1
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 8
+        Space: 0
+      VulkanBinding:
+        Binding: 8
 #--- end
+
+# Bug https://github.com/llvm/llvm-project/issues/164018
+# XFAIL: Clang
 
 # REQUIRES: Int64
 # RUN: split-file %s %t


### PR DESCRIPTION
This PR is the first part of the fix for [#164018](https://github.com/llvm/llvm-project/issues/164018). Adds non-boolean vector condition tests to the `select` tests.