### PR TITLE
[VK][DXC] Remove XFAIL for sign.32.test for DXC & Vulkan

### DIFF
--- a/test/Feature/HLSLLib/sign.32.test
+++ b/test/Feature/HLSLLib/sign.32.test
@@ -173,9 +173,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug https://github.com/microsoft/DirectXShaderCompiler/issues/7755
-# XFAIL: DXC && Vulkan
-
 # We're generating invalid SPIRV for this. I have _no_ idea why this isn't
 # failing on all Clang Vulkan tests.
 # Bug https://github.com/llvm/llvm-project/issues/149722


### PR DESCRIPTION
Issue is fixed by https://github.com/microsoft/DirectXShaderCompiler/pull/7845