### PR TITLE
Remove XFAILs from `select` tests

### DIFF
--- a/test/Feature/HLSLLib/select.32.test
+++ b/test/Feature/HLSLLib/select.32.test
@@ -350,6 +350,9 @@ DescriptorSets:
         Binding: 15
 #--- end
 
+# Bug https://github.com/llvm/llvm-project/issues/166642
+# XFAIL: Clang && Vulkan
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -HV 202x -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/select.fp16.test
+++ b/test/Feature/HLSLLib/select.fp16.test
@@ -131,6 +131,9 @@ DescriptorSets:
         Binding: 4
 #--- end
 
+# Bug https://github.com/llvm/llvm-project/issues/166642
+# XFAIL: Clang && Vulkan
+
 # REQUIRES: Half
 # RUN: split-file %s %t
 # RUN: %dxc_target -enable-16bit-types -HV 202x -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/select.fp64.test
+++ b/test/Feature/HLSLLib/select.fp64.test
@@ -124,6 +124,9 @@ DescriptorSets:
         Binding: 4
 #--- end
 
+# Bug https://github.com/llvm/llvm-project/issues/166642
+# XFAIL: Clang && Vulkan
+
 # REQUIRES: Double
 # RUN: split-file %s %t
 # RUN: %dxc_target -HV 202x -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/select.int16.test
+++ b/test/Feature/HLSLLib/select.int16.test
@@ -204,6 +204,9 @@ DescriptorSets:
         Binding: 8
 #--- end
 
+# Bug https://github.com/llvm/llvm-project/issues/166642
+# XFAIL: Clang && Vulkan
+
 # REQUIRES: Int16
 # RUN: split-file %s %t
 # RUN: %dxc_target -enable-16bit-types -HV 202x -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/select.int64.test
+++ b/test/Feature/HLSLLib/select.int64.test
@@ -203,6 +203,9 @@ DescriptorSets:
         Binding: 8
 #--- end
 
+# Bug https://github.com/llvm/llvm-project/issues/166642
+# XFAIL: Clang && Vulkan
+
 # REQUIRES: Int64
 # RUN: split-file %s %t
 # RUN: %dxc_target -HV 202x -T cs_6_5 -Fo %t.o %t/source.hlsl


### PR DESCRIPTION
These were fixed by https://github.com/llvm/llvm-project/pull/166279.