### PR TITLE
Remove XFAILs from `firstbithigh` tests for Clang && DirectX

### DIFF
--- a/test/Feature/HLSLLib/firstbithigh.16.test
+++ b/test/Feature/HLSLLib/firstbithigh.16.test
@@ -87,9 +87,6 @@ DescriptorSets:
 # Bug: Fails with 'gpu-exec: error: Failed to materializeAll.:'
 # XFAIL: Clang && Metal
 
-# Bug https://github.com/llvm/llvm-project/issues/145752
-# XFAIL: Clang && DirectX
-
 # 16/64 bit firstbithigh doesn't have a DXC-Vulkan lowering
 # Unsupported https://github.com/microsoft/DirectXShaderCompiler/blob/main/tools/clang/test/CodeGenSPIRV/intrinsics.firstbitlow.64bit.hlsl
 # UNSUPPORTED: DXC && Vulkan

--- a/test/Feature/HLSLLib/firstbithigh.32.test
+++ b/test/Feature/HLSLLib/firstbithigh.32.test
@@ -80,9 +80,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug https://github.com/llvm/llvm-project/issues/145752
-# XFAIL: Clang && (DirectX || Metal)
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/firstbithigh.64.test
+++ b/test/Feature/HLSLLib/firstbithigh.64.test
@@ -92,9 +92,6 @@ DescriptorSets:
 # Bug https://github.com/llvm/llvm-project/issues/143171
 # XFAIL: Clang && Vulkan
 
-# Bug https://github.com/llvm/llvm-project/issues/145752
-# XFAIL: Clang && DirectX
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
The corresponding issue https://github.com/llvm/llvm-project/issues/145752 was fixed.