### PR TITLE
Remove XFAIL from wave active sum tests

### DIFF
--- a/test/WaveOps/WaveActiveSum.fp16.test
+++ b/test/WaveOps/WaveActiveSum.fp16.test
@@ -174,7 +174,7 @@ DescriptorSets:
 # REQUIRES: Half
 
 # Bug https://github.com/llvm/llvm-project/issues/156775
-# XFAIL: !(Clang && DirectX && Intel)
+# XFAIL: !(Intel || QC)
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/WaveOps/WaveActiveSum.fp32.test
+++ b/test/WaveOps/WaveActiveSum.fp32.test
@@ -169,7 +169,7 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/llvm-project/issues/156775
-# XFAIL: !(Clang && DirectX && Intel)
+# XFAIL: !(Intel || QC)
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/WaveOps/WaveActiveSum.fp64.test
+++ b/test/WaveOps/WaveActiveSum.fp64.test
@@ -171,7 +171,7 @@ DescriptorSets:
 # REQUIRES: Double
 
 # Bug https://github.com/llvm/llvm-project/issues/156775
-# XFAIL: !(Clang && DirectX && Intel)
+# XFAIL: !(Intel || QC)
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/WaveOps/WaveActiveSum.int16.test
+++ b/test/WaveOps/WaveActiveSum.int16.test
@@ -323,7 +323,7 @@ DescriptorSets:
 # REQUIRES: Int16
 
 # Bug https://github.com/llvm/llvm-project/issues/156775
-# XFAIL: !(Clang && DirectX && Intel)
+# XFAIL: !(Intel || QC)
 
 # Bug https://github.com/llvm/offload-test-suite/issues/393
 # XFAIL: Metal

--- a/test/WaveOps/WaveActiveSum.int32.test
+++ b/test/WaveOps/WaveActiveSum.int32.test
@@ -320,7 +320,7 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/llvm-project/issues/156775
-# XFAIL: !(Clang && DirectX && Intel)
+# XFAIL: !(Intel || QC)
 
 # Bug https://github.com/llvm/offload-test-suite/issues/393
 # XFAIL: Metal

--- a/test/WaveOps/WaveActiveSum.int64.test
+++ b/test/WaveOps/WaveActiveSum.int64.test
@@ -323,7 +323,7 @@ DescriptorSets:
 # REQUIRES: Int64
 
 # Bug https://github.com/llvm/llvm-project/issues/156775
-# XFAIL: !(Clang && DirectX && Intel)
+# XFAIL: !(Intel || QC)
 
 # Bug https://github.com/llvm/offload-test-suite/issues/355
 # XFAIL: Metal


### PR DESCRIPTION
This PR removes the XFAIL and the linked issue from the wave active sum tests.
https://github.com/llvm/llvm-project/issues/156775