### PR TITLE
Test coverage for arrays in cbuffers

### DIFF
--- a/test/Feature/CBuffer/array-dynamic-index.test
+++ b/test/Feature/CBuffer/array-dynamic-index.test
@@ -78,8 +78,8 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug https://github.com/llvm/llvm-project/issues/144573
-# XFAIL: Clang
+# Unimplemented https://github.com/llvm/llvm-project/issues/159602
+# XFAIL: Clang && Vulkan
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -fvk-use-dx-layout -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/CBuffer/array-of-structs.test
+++ b/test/Feature/CBuffer/array-of-structs.test
@@ -74,8 +74,8 @@ DescriptorSets:
 ...
 #--- end
 
-# Unimplemented https://github.com/llvm/llvm-project/issues/147352
-# XFAIL: Clang
+# Unimplemented https://github.com/llvm/llvm-project/issues/159602
+# XFAIL: Clang && Vulkan
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -fvk-use-dx-layout -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/CBuffer/array-vec-index.test
+++ b/test/Feature/CBuffer/array-vec-index.test
@@ -43,20 +43,18 @@ DescriptorSets:
       DirectXBinding:
         Register: 0
         Space: 0
+      VulkanBinding:
+        Binding: 0
     - Name: Out
       Kind: RWStructuredBuffer
       DirectXBinding:
         Register: 1
         Space: 0
+      VulkanBinding:
+        Binding: 1
 ...
 #--- end
 
-# DXC's vulkan support does not layout cbuffers compatibly with DXIL
-# UNSUPPORTED: Vulkan
-
-# Bug https://github.com/llvm/llvm-project/issues/156084
-# XFAIL: Clang
-
 # RUN: split-file %s %t
-# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -fvk-use-dx-layout -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/CBuffer/arrays-16bit.test
+++ b/test/Feature/CBuffer/arrays-16bit.test
@@ -85,8 +85,8 @@ DescriptorSets:
 
 # REQUIRES: Half, Int16
 
-# Bug https://github.com/llvm/llvm-project/issues/138996
-# XFAIL: Clang
+# Unimplemented https://github.com/llvm/llvm-project/issues/159602
+# XFAIL: Clang && Vulkan
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -fvk-use-dx-layout -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/CBuffer/arrays.test
+++ b/test/Feature/CBuffer/arrays.test
@@ -94,9 +94,9 @@ DescriptorSets:
 #--- end
 
 # Bug: https://github.com/microsoft/DirectXShaderCompiler/issues/7819
-# XFAIL: Vulkan
-# Unimplemented https://github.com/llvm/llvm-project/issues/147352
-# XFAIL: Clang
+# XFAIL: DXC && Vulkan
+# Unimplemented https://github.com/llvm/llvm-project/issues/159602
+# XFAIL: Clang && Vulkan
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -fvk-use-dx-layout -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/CBuffer/dynamic-struct.test
+++ b/test/Feature/CBuffer/dynamic-struct.test
@@ -107,7 +107,7 @@ DescriptorSets:
 ...
 #--- end
 
-# Unimplemented https://github.com/llvm/llvm-project/issues/147352
+# Bug https://github.com/llvm/llvm-project/issues/164517
 # XFAIL: Clang
 
 # RUN: split-file %s %t

--- a/test/Feature/CBuffer/vectors-16bit.test
+++ b/test/Feature/CBuffer/vectors-16bit.test
@@ -57,6 +57,9 @@ DescriptorSets:
 ...
 #--- end
 
+# Unimplemented https://github.com/llvm/llvm-project/issues/159602
+# XFAIL: Clang && Vulkan
+
 # REQUIRES: Half, Int16
 
 # RUN: split-file %s %t


### PR DESCRIPTION
This adds for arrays of various shapes in cbuffers that were failing before llvm/llvm-project#147352 was implemented, and updates XFAILs appropriately for that change.