### PR TITLE
Add fwidth graphics test

### DIFF
--- a/test/Graphics/fwidth.test
+++ b/test/Graphics/fwidth.test
@@ -62,7 +62,7 @@ Buffers:
     OutputProps:
       Height: 256
       Width: 256
-      Depth: 16
+      Depth: 1
 Bindings:
   VertexBuffer: VertexData
   VertexAttributes:


### PR DESCRIPTION
Adds a Graphics test for the fwidth intrinsic. The test uses fwidth to provide a blur around the edge of a circle projected on a screensized quad.

I can't see a related issue open for this, but I'm providing it in-line with https://github.com/llvm/llvm-project/pull/161378

Relies on https://github.com/llvm/offload-golden-images/pull/4