### PR TITLE
Updates for Clang 21.1

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,4 @@
-Checks: '-*,clang-diagnostic-*,llvm-*,misc-*,-misc-use-anonymous-namespace,-misc-include-cleaner,-misc-non-private-member-variables-in-classes,readability-identifier-naming,-misc-const-correctness'
+Checks: '-*,clang-diagnostic-*,llvm-*,misc-*,-misc-use-anonymous-namespace,-misc-include-cleaner,-misc-non-private-member-variables-in-classes,readability-identifier-naming'
 WarningsAsErrors: '*'
 CheckOptions:
   - key:             readability-identifier-naming.ClassCase

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -1818,7 +1818,7 @@ public:
         auto *DataIt = DataSet.begin();
         for (; ResRefIt != ResourceRef.end() && DataIt != DataSet.end();
              ++ResRefIt, ++DataIt) {
-          void *Mapped = nullptr;
+          void *Mapped = nullptr; // NOLINT(misc-const-correctness)
           vkMapMemory(IS.Device, ResRefIt->Host.Memory, 0, VK_WHOLE_SIZE, 0,
                       &Mapped);
           Range.memory = ResRefIt->Host.Memory;
@@ -1829,7 +1829,7 @@ public:
         if (R.HasCounter) {
           R.BufferPtr->Counters.clear();
           for (uint32_t I = 0; I < R.BufferPtr->ArraySize; ++I) {
-            uint32_t *Mapped = nullptr;
+            uint32_t *Mapped = nullptr; // NOLINT(misc-const-correctness)
             auto &CounterRef = IS.Resources[BufIdx].CounterResourceRefs[I];
             vkMapMemory(IS.Device, CounterRef.Host.Memory, 0, VK_WHOLE_SIZE, 0,
                         (void **)&Mapped);
@@ -1850,7 +1850,7 @@ public:
       Range.size = VK_WHOLE_SIZE;
       const ResourceRef &ResRef = IS.FrameBufferResource.ResourceRefs[0];
 
-      void *Mapped = nullptr;
+      void *Mapped = nullptr; // NOLINT(misc-const-correctness)
       vkMapMemory(IS.Device, ResRef.Host.Memory, 0, VK_WHOLE_SIZE, 0, &Mapped);
 
       Range.memory = ResRef.Host.Memory;


### PR DESCRIPTION
This change addresses new warnings introduced in Clang 21.1.
- Updates a function to be static instead of being in anonymous namespace.
- Disables `-misc-const-correctness` warning in 3 cases where it is reported on a variable that cannot be made `const`.