### PR TITLE
Add Graphics tests for ddx/y_fine

### DIFF
--- a/test/Graphics/ddx_fine.test
+++ b/test/Graphics/ddx_fine.test
@@ -63,7 +63,7 @@ Buffers:
     OutputProps:
       Height: 256
       Width: 256
-      Depth: 16
+      Depth: 1
 Bindings:
   VertexBuffer: VertexData
   VertexAttributes:

--- a/test/Graphics/ddy_fine.test
+++ b/test/Graphics/ddy_fine.test
@@ -63,7 +63,7 @@ Buffers:
     OutputProps:
       Height: 256
       Width: 256
-      Depth: 16
+      Depth: 1
 Bindings:
   VertexBuffer: VertexData
   VertexAttributes:


### PR DESCRIPTION
Relies on https://github.com/llvm/offload-golden-images/pull/5

Adds Graphics tests for ddx_coarse and ddy_coarse intrinsics. The tests use the dd_coarse intrinsics to apply a very basic anti-aliasing style blur to the edges of a circle in either the X or Y dimension.