### PR TITLE
Fix the source pipeline stage in the `vkCmdPipelineBarrier` call for the Compute Shader -> Transfer stage

### DIFF
--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -1647,7 +1647,7 @@ public:
 
       for (auto &ResRef : R.ResourceRefs) {
         ImageBarrier.image = ResRef.Image.Image;
-        vkCmdPipelineBarrier(IS.CmdBuffer, VK_PIPELINE_STAGE_HOST_BIT,
+        vkCmdPipelineBarrier(IS.CmdBuffer, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
                              VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0,
                              nullptr, 1, &ImageBarrier);
       }


### PR DESCRIPTION
Fixes #329 and #328

The source pipeline stage being incorrect was causing the windows-amd machine to read 0s from the output buffer for image resources.