### PR TITLE
Remove Clang && Vulkan XFAIL from Feature/CBuffer/array-dynamic-index.test

### DIFF
--- a/test/Feature/CBuffer/array-dynamic-index.test
+++ b/test/Feature/CBuffer/array-dynamic-index.test
@@ -78,9 +78,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Unimplemented https://github.com/llvm/llvm-project/issues/159602
-# XFAIL: Clang && Vulkan
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -fvk-use-dx-layout -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
This PR removes the Clang && Vulkan XFAIL from Feature/CBuffer/array-dynamic-index.test since the test now XPASSes on all runners:

```
╭───┬──────────────────────┬─────────────┬─────────────────────────────┬────────┬──────────────────────────────────────────╮
│ # │      timestamp       │   run-id    │          workflow           │ status │                   test                   │
├───┼──────────────────────┼─────────────┼─────────────────────────────┼────────┼──────────────────────────────────────────┤
│ 0 │ 2025-11-28T12:08:27Z │ 19763375140 │ Windows Vulkan AMD Clang    │ XPASS  │ Feature/CBuffer/array-dynamic-index.test │
│ 1 │ 2025-11-28T18:05:22Z │ 19771042891 │ Windows Vulkan Intel Clang  │ XPASS  │ Feature/CBuffer/array-dynamic-index.test │
│ 2 │ 2025-11-28T04:03:18Z │ 19753735507 │ Windows Vulkan NVIDIA Clang │ XPASS  │ Feature/CBuffer/array-dynamic-index.test │
│ 3 │ 2025-11-28T18:09:04Z │ 19771107957 │ Windows Vulkan QC Clang     │ XPASS  │ Feature/CBuffer/array-dynamic-index.test │
╰───┴──────────────────────┴─────────────┴─────────────────────────────┴────────┴──────────────────────────────────────────╯
```

- [Windows Vulkan AMD Clang](https://github.com/llvm/offload-test-suite/actions/runs/19763375140)
- [Windows Vulkan Intel Clang](https://github.com/llvm/offload-test-suite/actions/runs/19771042891)
- [Windows Vulkan NVIDIA Clang](https://github.com/llvm/offload-test-suite/actions/runs/19753735507)
- [Windows Vulkan QC Clang](https://github.com/llvm/offload-test-suite/actions/runs/19771107957)

Before merging this PR, check/update the status of the original issue associated with the XFAIL: https://github.com/llvm/llvm-project/issues/159602