### PR TITLE
Update XFAILs of `reversebits` tests for Vulkan

### DIFF
--- a/test/Feature/HLSLLib/reversebits.16.test
+++ b/test/Feature/HLSLLib/reversebits.16.test
@@ -57,8 +57,8 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug https://github.com/llvm/llvm-project/issues/152049
-# XFAIL: Clang && Vulkan
+# Bug https://github.com/llvm/offload-test-suite/issues/518
+# XFAIL: Clang && Vulkan && QC
 
 # REQUIRES: Int16
 # RUN: split-file %s %t

--- a/test/Feature/HLSLLib/reversebits.32.test
+++ b/test/Feature/HLSLLib/reversebits.32.test
@@ -57,9 +57,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug https://github.com/llvm/llvm-project/issues/152049
-# XFAIL: Clang && Vulkan
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/reversebits.64.test
+++ b/test/Feature/HLSLLib/reversebits.64.test
@@ -57,9 +57,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug https://github.com/llvm/llvm-project/issues/152049
-# XFAIL: Clang && Vulkan
-
 # REQUIRES: Int64
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl


### PR DESCRIPTION
This PR removes the XFAILs from the reversebits tests, and adds a new XFAIL on the 16-bit reversebits test with issue #518 tracking it.

Test results from scheduled runs today (2025-11-28):
```
╭────┬──────────────────────┬─────────────┬─────────────────────────────┬────────┬─────────────────────────────────────╮
│  # │      timestamp       │   run-id    │          workflow           │ status │                test                 │
├────┼──────────────────────┼─────────────┼─────────────────────────────┼────────┼─────────────────────────────────────┤
│  0 │ 2025-11-28T18:05:50Z │ 19771050617 │ Windows Vulkan AMD DXC      │ PASS   │ Feature/HLSLLib/reversebits.16.test │
│  1 │ 2025-11-28T18:05:50Z │ 19771050617 │ Windows Vulkan AMD DXC      │ PASS   │ Feature/HLSLLib/reversebits.32.test │
│  2 │ 2025-11-28T18:05:50Z │ 19771050617 │ Windows Vulkan AMD DXC      │ PASS   │ Feature/HLSLLib/reversebits.64.test │
│  3 │ 2025-11-28T22:01:55Z │ 19774580028 │ Windows Vulkan Intel DXC    │ PASS   │ Feature/HLSLLib/reversebits.16.test │
│  4 │ 2025-11-28T22:01:55Z │ 19774580028 │ Windows Vulkan Intel DXC    │ PASS   │ Feature/HLSLLib/reversebits.64.test │
│  5 │ 2025-11-28T22:01:55Z │ 19774580028 │ Windows Vulkan Intel DXC    │ PASS   │ Feature/HLSLLib/reversebits.32.test │
│  6 │ 2025-11-28T02:35:49Z │ 19752462306 │ Windows Vulkan NVIDIA DXC   │ PASS   │ Feature/HLSLLib/reversebits.16.test │
│  7 │ 2025-11-28T02:35:49Z │ 19752462306 │ Windows Vulkan NVIDIA DXC   │ PASS   │ Feature/HLSLLib/reversebits.64.test │
│  8 │ 2025-11-28T02:35:49Z │ 19752462306 │ Windows Vulkan NVIDIA DXC   │ PASS   │ Feature/HLSLLib/reversebits.32.test │
│  9 │ 2025-11-28T18:02:29Z │ 19770990351 │ Windows Vulkan QC DXC       │ PASS   │ Feature/HLSLLib/reversebits.16.test │
│ 10 │ 2025-11-28T18:02:29Z │ 19770990351 │ Windows Vulkan QC DXC       │ PASS   │ Feature/HLSLLib/reversebits.32.test │
│ 11 │ 2025-11-28T18:02:29Z │ 19770990351 │ Windows Vulkan QC DXC       │ PASS   │ Feature/HLSLLib/reversebits.64.test │
│ 12 │ 2025-11-28T22:06:03Z │ 19774646176 │ Windows Vulkan QC Clang     │ XFAIL  │ Feature/HLSLLib/reversebits.16.test │
│ 13 │ 2025-11-28T18:06:34Z │ 19771064332 │ Windows Vulkan AMD Clang    │ XPASS  │ Feature/HLSLLib/reversebits.16.test │
│ 14 │ 2025-11-28T18:06:34Z │ 19771064332 │ Windows Vulkan AMD Clang    │ XPASS  │ Feature/HLSLLib/reversebits.32.test │
│ 15 │ 2025-11-28T18:06:34Z │ 19771064332 │ Windows Vulkan AMD Clang    │ XPASS  │ Feature/HLSLLib/reversebits.64.test │
│ 16 │ 2025-11-28T20:04:28Z │ 19772907221 │ Windows Vulkan Intel Clang  │ XPASS  │ Feature/HLSLLib/reversebits.64.test │
│ 17 │ 2025-11-28T20:04:28Z │ 19772907221 │ Windows Vulkan Intel Clang  │ XPASS  │ Feature/HLSLLib/reversebits.16.test │
│ 18 │ 2025-11-28T20:04:28Z │ 19772907221 │ Windows Vulkan Intel Clang  │ XPASS  │ Feature/HLSLLib/reversebits.32.test │
│ 19 │ 2025-11-28T22:06:03Z │ 19774646176 │ Windows Vulkan QC Clang     │ XPASS  │ Feature/HLSLLib/reversebits.64.test │
│ 20 │ 2025-11-28T22:06:03Z │ 19774646176 │ Windows Vulkan QC Clang     │ XPASS  │ Feature/HLSLLib/reversebits.32.test │
│ 21 │ 2025-11-28T06:02:32Z │ 19755520578 │ Windows Vulkan NVIDIA Clang │ XPASS  │ Feature/HLSLLib/reversebits.32.test │
│ 22 │ 2025-11-28T06:02:32Z │ 19755520578 │ Windows Vulkan NVIDIA Clang │ XPASS  │ Feature/HLSLLib/reversebits.16.test │
│ 23 │ 2025-11-28T06:02:32Z │ 19755520578 │ Windows Vulkan NVIDIA Clang │ XPASS  │ Feature/HLSLLib/reversebits.64.test │
╰────┴──────────────────────┴─────────────┴─────────────────────────────┴────────┴─────────────────────────────────────╯
```

Before merging this PR, check/update the status of the issue tied with the original XFAILs: https://github.com/llvm/llvm-project/issues/152049