### PR TITLE
Update XFAILs of Feature/MaximalReconvergence/loop_peeling.test

### DIFF
--- a/test/Feature/MaximalReconvergence/loop_peeling.test
+++ b/test/Feature/MaximalReconvergence/loop_peeling.test
@@ -36,14 +36,17 @@ DescriptorSets:
 #--- end
 # UNSUPPORTED: Vulkan && !VK_KHR_shader_maximal_reconvergence
 
-# BUG: https://github.com/llvm/llvm-project/issues/164496
-# XFAIL: Clang && Vulkan
-
 # BUG: https://github.com/llvm/offload-test-suite/issues/490
 # XFAIL: WARP && DirectX && Clang
 
 # BUG: https://github.com/llvm/llvm-project/issues/165288
 # XFAIL: !WARP && Clang && (DirectX || Metal)
+
+# BUG: https://github.com/llvm/offload-test-suite/issues/520
+# XFAIL: QC
+
+# BUG: https://github.com/llvm/offload-test-suite/issues/521
+# XFAIL: NV && DirectX
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -fspv-enable-maximal-reconvergence -Fo %t.o %t/source.hlsl


### PR DESCRIPTION
This PR updates the XFAILs of the test Feature/MaximalReconvergence/loop_peeling.test according to the latest test results.

The original issue tied to the Clang && Vulkan XFAIL (https://github.com/llvm/llvm-project/issues/164496) has been closed.

Results from scheduled runs today (2025-11-28):
```
╭────┬──────────────────────┬─────────────┬────────────────────────────────┬─────────────┬────────────────────────────────────────────────╮
│  # │      timestamp       │   run-id    │            workflow            │   status    │                      test                      │
├────┼──────────────────────┼─────────────┼────────────────────────────────┼─────────────┼────────────────────────────────────────────────┤
│  0 │ 2025-11-28T22:05:58Z │ 19774644845 │ Windows D3D12 QC DXC           │ FAIL        │ Feature/MaximalReconvergence/loop_peeling.test │
│  1 │ 2025-11-28T06:03:54Z │ 19755547346 │ Windows D3D12 NVIDIA DXC       │ FAIL        │ Feature/MaximalReconvergence/loop_peeling.test │
│  2 │ 2025-11-28T18:02:29Z │ 19770990351 │ Windows Vulkan QC DXC          │ FAIL        │ Feature/MaximalReconvergence/loop_peeling.test │
│  3 │ 2025-11-28T23:07:22Z │ 19775436498 │ macOS Metal DXC                │ PASS        │ Feature/MaximalReconvergence/loop_peeling.test │
│  4 │ 2025-11-28T18:01:00Z │ 19770962737 │ Windows D3D12 AMD DXC          │ PASS        │ Feature/MaximalReconvergence/loop_peeling.test │
│  5 │ 2025-11-28T18:05:50Z │ 19771050617 │ Windows Vulkan AMD DXC         │ PASS        │ Feature/MaximalReconvergence/loop_peeling.test │
│  6 │ 2025-11-28T18:08:36Z │ 19771099390 │ Windows D3D12 Warp DXC         │ PASS        │ Feature/MaximalReconvergence/loop_peeling.test │
│  7 │ 2025-11-28T22:00:55Z │ 19774566187 │ Windows D3D12 Intel DXC        │ PASS        │ Feature/MaximalReconvergence/loop_peeling.test │
│  8 │ 2025-11-28T22:00:47Z │ 19774563511 │ Windows ARM64 D3D12 Warp DXC   │ PASS        │ Feature/MaximalReconvergence/loop_peeling.test │
│  9 │ 2025-11-28T02:35:49Z │ 19752462306 │ Windows Vulkan NVIDIA DXC      │ PASS        │ Feature/MaximalReconvergence/loop_peeling.test │
│ 10 │ 2025-11-28T20:04:28Z │ 19772907221 │ Windows Vulkan Intel Clang     │ UNSUPPORTED │ Feature/MaximalReconvergence/loop_peeling.test │
│ 11 │ 2025-11-28T22:01:55Z │ 19774580028 │ Windows Vulkan Intel DXC       │ UNSUPPORTED │ Feature/MaximalReconvergence/loop_peeling.test │
│ 12 │ 2025-11-28T23:05:58Z │ 19775415943 │ macOS Metal Clang              │ XFAIL       │ Feature/MaximalReconvergence/loop_peeling.test │
│ 13 │ 2025-11-28T18:05:56Z │ 19771052674 │ Windows D3D12 AMD Clang        │ XFAIL       │ Feature/MaximalReconvergence/loop_peeling.test │
│ 14 │ 2025-11-28T18:03:22Z │ 19771005843 │ Windows D3D12 Warp Clang       │ XFAIL       │ Feature/MaximalReconvergence/loop_peeling.test │
│ 15 │ 2025-11-28T20:03:54Z │ 19772898840 │ Windows D3D12 Intel Clang      │ XFAIL       │ Feature/MaximalReconvergence/loop_peeling.test │
│ 16 │ 2025-11-28T18:06:07Z │ 19771055797 │ Windows D3D12 NVIDIA Clang     │ XFAIL       │ Feature/MaximalReconvergence/loop_peeling.test │
│ 17 │ 2025-11-28T22:00:51Z │ 19774564659 │ Windows D3D12 QC Clang         │ XFAIL       │ Feature/MaximalReconvergence/loop_peeling.test │
│ 18 │ 2025-11-28T22:06:03Z │ 19774646176 │ Windows Vulkan QC Clang        │ XFAIL       │ Feature/MaximalReconvergence/loop_peeling.test │
│ 19 │ 2025-11-28T22:04:42Z │ 19774625191 │ Windows ARM64 D3D12 Warp Clang │ XFAIL       │ Feature/MaximalReconvergence/loop_peeling.test │
│ 20 │ 2025-11-28T18:06:34Z │ 19771064332 │ Windows Vulkan AMD Clang       │ XPASS       │ Feature/MaximalReconvergence/loop_peeling.test │
│ 21 │ 2025-11-28T06:02:32Z │ 19755520578 │ Windows Vulkan NVIDIA Clang    │ XPASS       │ Feature/MaximalReconvergence/loop_peeling.test │
╰────┴──────────────────────┴─────────────┴────────────────────────────────┴─────────────┴────────────────────────────────────────────────╯
```