### PR TITLE
Update XFAILs of WaveActiveSum tests

### DIFF
--- a/test/WaveOps/WaveActiveSum.fp16.test
+++ b/test/WaveOps/WaveActiveSum.fp16.test
@@ -175,10 +175,10 @@ DescriptorSets:
 # XFAIL: WARP && Clang
 
 # Bug https://github.com/llvm/offload-test-suite/issues/525
-# XFAIL: NV && Clang
+# XFAIL: NV && Clang && DirectX
 
 # Bug https://github.com/llvm/offload-test-suite/issues/528
-# XFAIL: QC && Clang
+# XFAIL: QC && Clang && DirectX
 
 # Bug https://github.com/llvm/offload-test-suite/issues/393
 # XFAIL: Metal

--- a/test/WaveOps/WaveActiveSum.fp32.test
+++ b/test/WaveOps/WaveActiveSum.fp32.test
@@ -175,7 +175,7 @@ DescriptorSets:
 # XFAIL: WARP && Clang
 
 # Bug https://github.com/llvm/offload-test-suite/issues/525
-# XFAIL: NV && Clang
+# XFAIL: NV && Clang && DirectX
 
 # Bug https://github.com/llvm/offload-test-suite/issues/526
 # XFAIL: Metal && Clang

--- a/test/WaveOps/WaveActiveSum.fp64.test
+++ b/test/WaveOps/WaveActiveSum.fp64.test
@@ -175,7 +175,7 @@ DescriptorSets:
 # XFAIL: WARP && Clang
 
 # Bug https://github.com/llvm/offload-test-suite/issues/525
-# XFAIL: NV && Clang
+# XFAIL: NV && Clang & DirectX
 
 # REQUIRES: Double
 

--- a/test/WaveOps/WaveActiveSum.int16.test
+++ b/test/WaveOps/WaveActiveSum.int16.test
@@ -329,7 +329,7 @@ DescriptorSets:
 # XFAIL: WARP && Clang
 
 # Bug https://github.com/llvm/offload-test-suite/issues/525
-# XFAIL: NV && Clang
+# XFAIL: NV && Clang && DirectX
 
 # Bug https://github.com/llvm/offload-test-suite/issues/393
 # XFAIL: Metal

--- a/test/WaveOps/WaveActiveSum.int32.test
+++ b/test/WaveOps/WaveActiveSum.int32.test
@@ -330,7 +330,7 @@ DescriptorSets:
 # XFAIL: WARP && Clang
 
 # Bug https://github.com/llvm/offload-test-suite/issues/525
-# XFAIL: NV && Clang
+# XFAIL: NV && Clang && DirectX
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/WaveOps/WaveActiveSum.int64.test
+++ b/test/WaveOps/WaveActiveSum.int64.test
@@ -329,7 +329,7 @@ DescriptorSets:
 # XFAIL: WARP && Clang
 
 # Bug https://github.com/llvm/offload-test-suite/issues/525
-# XFAIL: NV && Clang
+# XFAIL: NV && Clang && DirectX
 
 # Bug https://github.com/llvm/offload-test-suite/issues/355
 # XFAIL: Metal


### PR DESCRIPTION
Changes the Clang XFAIL to a Vulkan && Clang XFAIL since the related issue (https://github.com/llvm/llvm-project/issues/156775) appears to only be related to SPIR-V.

Also adds additional XFAILs for machines that still fail the tests.

Confirmed all Vulkan && Clang workflows XFAIL:
```
╭────┬──────────────────────┬─────────────┬─────────────────────────────┬─────────────┬──────────────────────────────────╮
│  # │      timestamp       │   run-id    │          workflow           │   status    │               test               │
├────┼──────────────────────┼─────────────┼─────────────────────────────┼─────────────┼──────────────────────────────────┤
│  0 │ 2025-11-28T22:06:03Z │ 19774646176 │ Windows Vulkan QC Clang     │ UNSUPPORTED │ WaveOps/WaveActiveSum.fp64.test  │
│  1 │ 2025-11-28T18:06:34Z │ 19771064332 │ Windows Vulkan AMD Clang    │ XFAIL       │ WaveOps/WaveActiveSum.fp16.test  │
│  2 │ 2025-11-28T18:06:34Z │ 19771064332 │ Windows Vulkan AMD Clang    │ XFAIL       │ WaveOps/WaveActiveSum.fp32.test  │
│  3 │ 2025-11-28T18:06:34Z │ 19771064332 │ Windows Vulkan AMD Clang    │ XFAIL       │ WaveOps/WaveActiveSum.fp64.test  │
│  4 │ 2025-11-28T18:06:34Z │ 19771064332 │ Windows Vulkan AMD Clang    │ XFAIL       │ WaveOps/WaveActiveSum.int32.test │
│  5 │ 2025-11-28T18:06:34Z │ 19771064332 │ Windows Vulkan AMD Clang    │ XFAIL       │ WaveOps/WaveActiveSum.int16.test │
│  6 │ 2025-11-28T18:06:34Z │ 19771064332 │ Windows Vulkan AMD Clang    │ XFAIL       │ WaveOps/WaveActiveSum.int64.test │
│  7 │ 2025-11-28T20:04:28Z │ 19772907221 │ Windows Vulkan Intel Clang  │ XFAIL       │ WaveOps/WaveActiveSum.fp32.test  │
│  8 │ 2025-11-28T20:04:28Z │ 19772907221 │ Windows Vulkan Intel Clang  │ XFAIL       │ WaveOps/WaveActiveSum.fp16.test  │
│  9 │ 2025-11-28T20:04:28Z │ 19772907221 │ Windows Vulkan Intel Clang  │ XFAIL       │ WaveOps/WaveActiveSum.fp64.test  │
│ 10 │ 2025-11-28T20:04:28Z │ 19772907221 │ Windows Vulkan Intel Clang  │ XFAIL       │ WaveOps/WaveActiveSum.int16.test │
│ 11 │ 2025-11-28T20:04:28Z │ 19772907221 │ Windows Vulkan Intel Clang  │ XFAIL       │ WaveOps/WaveActiveSum.int32.test │
│ 12 │ 2025-11-28T20:04:28Z │ 19772907221 │ Windows Vulkan Intel Clang  │ XFAIL       │ WaveOps/WaveActiveSum.int64.test │
│ 13 │ 2025-11-28T22:06:03Z │ 19774646176 │ Windows Vulkan QC Clang     │ XFAIL       │ WaveOps/WaveActiveSum.fp16.test  │
│ 14 │ 2025-11-28T22:06:03Z │ 19774646176 │ Windows Vulkan QC Clang     │ XFAIL       │ WaveOps/WaveActiveSum.fp32.test  │
│ 15 │ 2025-11-28T22:06:03Z │ 19774646176 │ Windows Vulkan QC Clang     │ XFAIL       │ WaveOps/WaveActiveSum.int16.test │
│ 16 │ 2025-11-28T22:06:03Z │ 19774646176 │ Windows Vulkan QC Clang     │ XFAIL       │ WaveOps/WaveActiveSum.int32.test │
│ 17 │ 2025-11-28T22:06:03Z │ 19774646176 │ Windows Vulkan QC Clang     │ XFAIL       │ WaveOps/WaveActiveSum.int64.test │
│ 18 │ 2025-11-28T06:02:32Z │ 19755520578 │ Windows Vulkan NVIDIA Clang │ XFAIL       │ WaveOps/WaveActiveSum.fp64.test  │
│ 19 │ 2025-11-28T06:02:32Z │ 19755520578 │ Windows Vulkan NVIDIA Clang │ XFAIL       │ WaveOps/WaveActiveSum.fp32.test  │
│ 20 │ 2025-11-28T06:02:32Z │ 19755520578 │ Windows Vulkan NVIDIA Clang │ XFAIL       │ WaveOps/WaveActiveSum.fp16.test  │
│ 21 │ 2025-11-28T06:02:32Z │ 19755520578 │ Windows Vulkan NVIDIA Clang │ XFAIL       │ WaveOps/WaveActiveSum.int16.test │
│ 22 │ 2025-11-28T06:02:32Z │ 19755520578 │ Windows Vulkan NVIDIA Clang │ XFAIL       │ WaveOps/WaveActiveSum.int32.test │
│ 23 │ 2025-11-28T06:02:32Z │ 19755520578 │ Windows Vulkan NVIDIA Clang │ XFAIL       │ WaveOps/WaveActiveSum.int64.test │
╰────┴──────────────────────┴─────────────┴─────────────────────────────┴─────────────┴──────────────────────────────────╯
```

The remaining XFAILs are under D3D12 with Clang, mostly on NVIDIA and WARP. Most of the Metal XFAILs are expected except fp32 because fp32 passes with DXC.
```
╭────┬──────────────────────┬─────────────┬────────────────────────────────┬─────────────┬──────────────────────────────────╮
│  # │      timestamp       │   run-id    │            workflow            │   status    │               test               │
├────┼──────────────────────┼─────────────┼────────────────────────────────┼─────────────┼──────────────────────────────────┤
│  0 │ 2025-11-28T23:05:58Z │ 19775415943 │ macOS Metal Clang              │ UNSUPPORTED │ WaveOps/WaveActiveSum.fp64.test  │
│  1 │ 2025-11-28T22:00:51Z │ 19774564659 │ Windows D3D12 QC Clang         │ UNSUPPORTED │ WaveOps/WaveActiveSum.fp64.test  │
│  2 │ 2025-11-28T23:05:58Z │ 19775415943 │ macOS Metal Clang              │ XFAIL       │ WaveOps/WaveActiveSum.fp32.test  │
│  3 │ 2025-11-28T23:05:58Z │ 19775415943 │ macOS Metal Clang              │ XFAIL       │ WaveOps/WaveActiveSum.int64.test │
│  4 │ 2025-11-28T23:05:58Z │ 19775415943 │ macOS Metal Clang              │ XFAIL       │ WaveOps/WaveActiveSum.fp16.test  │
│  5 │ 2025-11-28T23:05:58Z │ 19775415943 │ macOS Metal Clang              │ XFAIL       │ WaveOps/WaveActiveSum.int16.test │
│  6 │ 2025-11-28T23:05:58Z │ 19775415943 │ macOS Metal Clang              │ XFAIL       │ WaveOps/WaveActiveSum.int32.test │
│  7 │ 2025-11-28T18:03:22Z │ 19771005843 │ Windows D3D12 Warp Clang       │ XFAIL       │ WaveOps/WaveActiveSum.fp16.test  │
│  8 │ 2025-11-28T18:03:22Z │ 19771005843 │ Windows D3D12 Warp Clang       │ XFAIL       │ WaveOps/WaveActiveSum.fp64.test  │
│  9 │ 2025-11-28T18:03:22Z │ 19771005843 │ Windows D3D12 Warp Clang       │ XFAIL       │ WaveOps/WaveActiveSum.fp32.test  │
│ 10 │ 2025-11-28T18:03:22Z │ 19771005843 │ Windows D3D12 Warp Clang       │ XFAIL       │ WaveOps/WaveActiveSum.int16.test │
│ 11 │ 2025-11-28T18:03:22Z │ 19771005843 │ Windows D3D12 Warp Clang       │ XFAIL       │ WaveOps/WaveActiveSum.int32.test │
│ 12 │ 2025-11-28T18:03:22Z │ 19771005843 │ Windows D3D12 Warp Clang       │ XFAIL       │ WaveOps/WaveActiveSum.int64.test │
│ 13 │ 2025-11-28T18:06:07Z │ 19771055797 │ Windows D3D12 NVIDIA Clang     │ XFAIL       │ WaveOps/WaveActiveSum.fp16.test  │
│ 14 │ 2025-11-28T18:06:07Z │ 19771055797 │ Windows D3D12 NVIDIA Clang     │ XFAIL       │ WaveOps/WaveActiveSum.int32.test │
│ 15 │ 2025-11-28T18:06:07Z │ 19771055797 │ Windows D3D12 NVIDIA Clang     │ XFAIL       │ WaveOps/WaveActiveSum.fp64.test  │
│ 16 │ 2025-11-28T18:06:07Z │ 19771055797 │ Windows D3D12 NVIDIA Clang     │ XFAIL       │ WaveOps/WaveActiveSum.int16.test │
│ 17 │ 2025-11-28T18:06:07Z │ 19771055797 │ Windows D3D12 NVIDIA Clang     │ XFAIL       │ WaveOps/WaveActiveSum.fp32.test  │
│ 18 │ 2025-11-28T18:06:07Z │ 19771055797 │ Windows D3D12 NVIDIA Clang     │ XFAIL       │ WaveOps/WaveActiveSum.int64.test │
│ 19 │ 2025-11-28T22:00:51Z │ 19774564659 │ Windows D3D12 QC Clang         │ XFAIL       │ WaveOps/WaveActiveSum.fp16.test  │
│ 20 │ 2025-11-28T22:04:42Z │ 19774625191 │ Windows ARM64 D3D12 Warp Clang │ XFAIL       │ WaveOps/WaveActiveSum.fp32.test  │
│ 21 │ 2025-11-28T22:04:42Z │ 19774625191 │ Windows ARM64 D3D12 Warp Clang │ XFAIL       │ WaveOps/WaveActiveSum.fp16.test  │
│ 22 │ 2025-11-28T22:04:42Z │ 19774625191 │ Windows ARM64 D3D12 Warp Clang │ XFAIL       │ WaveOps/WaveActiveSum.int32.test │
│ 23 │ 2025-11-28T22:04:42Z │ 19774625191 │ Windows ARM64 D3D12 Warp Clang │ XFAIL       │ WaveOps/WaveActiveSum.int16.test │
│ 24 │ 2025-11-28T22:04:42Z │ 19774625191 │ Windows ARM64 D3D12 Warp Clang │ XFAIL       │ WaveOps/WaveActiveSum.int64.test │
│ 25 │ 2025-11-28T22:04:42Z │ 19774625191 │ Windows ARM64 D3D12 Warp Clang │ XFAIL       │ WaveOps/WaveActiveSum.fp64.test  │
│ 26 │ 2025-11-28T18:05:56Z │ 19771052674 │ Windows D3D12 AMD Clang        │ XPASS       │ WaveOps/WaveActiveSum.fp16.test  │
│ 27 │ 2025-11-28T18:05:56Z │ 19771052674 │ Windows D3D12 AMD Clang        │ XPASS       │ WaveOps/WaveActiveSum.fp64.test  │
│ 28 │ 2025-11-28T18:05:56Z │ 19771052674 │ Windows D3D12 AMD Clang        │ XPASS       │ WaveOps/WaveActiveSum.int32.test │
│ 29 │ 2025-11-28T18:05:56Z │ 19771052674 │ Windows D3D12 AMD Clang        │ XPASS       │ WaveOps/WaveActiveSum.fp32.test  │
│ 30 │ 2025-11-28T18:05:56Z │ 19771052674 │ Windows D3D12 AMD Clang        │ XPASS       │ WaveOps/WaveActiveSum.int16.test │
│ 31 │ 2025-11-28T18:05:56Z │ 19771052674 │ Windows D3D12 AMD Clang        │ XPASS       │ WaveOps/WaveActiveSum.int64.test │
│ 32 │ 2025-11-28T20:03:54Z │ 19772898840 │ Windows D3D12 Intel Clang      │ XPASS       │ WaveOps/WaveActiveSum.fp32.test  │
│ 33 │ 2025-11-28T20:03:54Z │ 19772898840 │ Windows D3D12 Intel Clang      │ XPASS       │ WaveOps/WaveActiveSum.fp16.test  │
│ 34 │ 2025-11-28T20:03:54Z │ 19772898840 │ Windows D3D12 Intel Clang      │ XPASS       │ WaveOps/WaveActiveSum.int32.test │
│ 35 │ 2025-11-28T20:03:54Z │ 19772898840 │ Windows D3D12 Intel Clang      │ XPASS       │ WaveOps/WaveActiveSum.int16.test │
│ 36 │ 2025-11-28T20:03:54Z │ 19772898840 │ Windows D3D12 Intel Clang      │ XPASS       │ WaveOps/WaveActiveSum.fp64.test  │
│ 37 │ 2025-11-28T20:03:54Z │ 19772898840 │ Windows D3D12 Intel Clang      │ XPASS       │ WaveOps/WaveActiveSum.int64.test │
│ 38 │ 2025-11-28T22:00:51Z │ 19774564659 │ Windows D3D12 QC Clang         │ XPASS       │ WaveOps/WaveActiveSum.fp32.test  │
│ 39 │ 2025-11-28T22:00:51Z │ 19774564659 │ Windows D3D12 QC Clang         │ XPASS       │ WaveOps/WaveActiveSum.int16.test │
│ 40 │ 2025-11-28T22:00:51Z │ 19774564659 │ Windows D3D12 QC Clang         │ XPASS       │ WaveOps/WaveActiveSum.int32.test │
│ 41 │ 2025-11-28T22:00:51Z │ 19774564659 │ Windows D3D12 QC Clang         │ XPASS       │ WaveOps/WaveActiveSum.int64.test │
├────┼──────────────────────┼─────────────┼────────────────────────────────┼─────────────┼──────────────────────────────────┤
│  # │      timestamp       │   run-id    │            workflow            │   status    │               test               │
╰────┴──────────────────────┴─────────────┴────────────────────────────────┴─────────────┴──────────────────────────────────╯
```