### PR TITLE
Remove XFAIL from `WaveReadLaneAt.index.test`

### DIFF
--- a/test/WaveOps/WaveReadLaneAt.index.test
+++ b/test/WaveOps/WaveReadLaneAt.index.test
@@ -115,8 +115,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug https://github.com/llvm/llvm-project/issues/158129
-# XFAIL: Clang && Vulkan
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl


### PR DESCRIPTION
Removes the XFAIL from WaveReadLaneAt.index.test since the test appears to be passing on all machines.

```
╭────┬──────────────────────┬─────────────┬────────────────────────────────┬────────┬───────────────────────────────────╮
│  # │      timestamp       │   run-id    │            workflow            │ status │               test                │
├────┼──────────────────────┼─────────────┼────────────────────────────────┼────────┼───────────────────────────────────┤
│  0 │ 2025-11-28T23:05:58Z │ 19775415943 │ macOS Metal Clang              │ PASS   │ WaveOps/WaveReadLaneAt.index.test │
│  1 │ 2025-11-28T23:07:22Z │ 19775436498 │ macOS Metal DXC                │ PASS   │ WaveOps/WaveReadLaneAt.index.test │
│  2 │ 2025-11-28T18:05:56Z │ 19771052674 │ Windows D3D12 AMD Clang        │ PASS   │ WaveOps/WaveReadLaneAt.index.test │
│  3 │ 2025-11-28T18:03:22Z │ 19771005843 │ Windows D3D12 Warp Clang       │ PASS   │ WaveOps/WaveReadLaneAt.index.test │
│  4 │ 2025-11-28T18:01:00Z │ 19770962737 │ Windows D3D12 AMD DXC          │ PASS   │ WaveOps/WaveReadLaneAt.index.test │
│  5 │ 2025-11-28T18:05:50Z │ 19771050617 │ Windows Vulkan AMD DXC         │ PASS   │ WaveOps/WaveReadLaneAt.index.test │
│  6 │ 2025-11-28T18:08:36Z │ 19771099390 │ Windows D3D12 Warp DXC         │ PASS   │ WaveOps/WaveReadLaneAt.index.test │
│  7 │ 2025-11-28T20:03:54Z │ 19772898840 │ Windows D3D12 Intel Clang      │ PASS   │ WaveOps/WaveReadLaneAt.index.test │
│  8 │ 2025-11-28T22:00:55Z │ 19774566187 │ Windows D3D12 Intel DXC        │ PASS   │ WaveOps/WaveReadLaneAt.index.test │
│  9 │ 2025-11-28T22:01:55Z │ 19774580028 │ Windows Vulkan Intel DXC       │ PASS   │ WaveOps/WaveReadLaneAt.index.test │
│ 10 │ 2025-11-28T18:06:07Z │ 19771055797 │ Windows D3D12 NVIDIA Clang     │ PASS   │ WaveOps/WaveReadLaneAt.index.test │
│ 11 │ 2025-11-28T22:00:51Z │ 19774564659 │ Windows D3D12 QC Clang         │ PASS   │ WaveOps/WaveReadLaneAt.index.test │
│ 12 │ 2025-11-28T22:04:42Z │ 19774625191 │ Windows ARM64 D3D12 Warp Clang │ PASS   │ WaveOps/WaveReadLaneAt.index.test │
│ 13 │ 2025-11-28T22:05:58Z │ 19774644845 │ Windows D3D12 QC DXC           │ PASS   │ WaveOps/WaveReadLaneAt.index.test │
│ 14 │ 2025-11-28T22:00:47Z │ 19774563511 │ Windows ARM64 D3D12 Warp DXC   │ PASS   │ WaveOps/WaveReadLaneAt.index.test │
│ 15 │ 2025-11-28T02:35:49Z │ 19752462306 │ Windows Vulkan NVIDIA DXC      │ PASS   │ WaveOps/WaveReadLaneAt.index.test │
│ 16 │ 2025-11-28T06:03:54Z │ 19755547346 │ Windows D3D12 NVIDIA DXC       │ PASS   │ WaveOps/WaveReadLaneAt.index.test │
│ 17 │ 2025-11-28T18:02:29Z │ 19770990351 │ Windows Vulkan QC DXC          │ PASS   │ WaveOps/WaveReadLaneAt.index.test │
│ 18 │ 2025-11-28T18:06:34Z │ 19771064332 │ Windows Vulkan AMD Clang       │ XPASS  │ WaveOps/WaveReadLaneAt.index.test │
│ 19 │ 2025-11-28T20:04:28Z │ 19772907221 │ Windows Vulkan Intel Clang     │ XPASS  │ WaveOps/WaveReadLaneAt.index.test │
│ 20 │ 2025-11-28T22:06:03Z │ 19774646176 │ Windows Vulkan QC Clang        │ XPASS  │ WaveOps/WaveReadLaneAt.index.test │
│ 21 │ 2025-11-28T06:02:32Z │ 19755520578 │ Windows Vulkan NVIDIA Clang    │ XPASS  │ WaveOps/WaveReadLaneAt.index.test │
╰────┴──────────────────────┴─────────────┴────────────────────────────────┴────────┴───────────────────────────────────╯
```

Before merging this PR, check/update the status of the associated issue: https://github.com/llvm/llvm-project/issues/158129