### PR TITLE
XFAIL Clang && Vulkan in `matrix_scalar_arithmetic` and `matrix_scalar_constructor` tests

### DIFF
--- a/test/Basic/matrix_scalar_arithmetic.test
+++ b/test/Basic/matrix_scalar_arithmetic.test
@@ -83,6 +83,9 @@ DescriptorSets:
 ...
 #--- end
 
+# Bug https://github.com/llvm/offload-test-suite/issues/538
+# XFAIL: Clang && Vulkan
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s

--- a/test/Basic/matrix_scalar_constructor.test
+++ b/test/Basic/matrix_scalar_constructor.test
@@ -56,6 +56,9 @@ DescriptorSets:
 ...
 #--- end
 
+# Bug https://github.com/llvm/offload-test-suite/issues/538
+# XFAIL: Clang && Vulkan
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
As observed in #538 the tests `Basic/matrix_scalar_arithmetic.test` and `Basic/matrix_scalar_constructor.test` are failing on all runners under Vulkan+Clang. 

Until the issue is fixed, it shall be XFAILed to make the badges green.