### PR TITLE
Add REQUIRES Double and XFAIL AMD to WaveActiveMax.fp64

### DIFF
--- a/test/WaveOps/WaveActiveMax.test
+++ b/test/WaveOps/WaveActiveMax.test
@@ -89,9 +89,6 @@ DescriptorSets:
 
 # XFAIL: DirectX && WARP
 
-# Bug https://github.com/llvm/offload-test-suite/issues/543
-# XFAIL: Vulkan && NV
-
 # CHECK: Name: Nans
 # CHECK-NEXT: Format: Float32
 # METAL-NEXT: Data: [ 0, 0, 0, 0 ]


### PR DESCRIPTION
AMD (#541) XFAIL on DirectX.
Add a REQUIRES: Double to fix #542, since the QC machine doesn't appear to support fp64
```
╭────┬──────────────────────┬─────────────┬──────────────────────────────┬────────┬─────────────────────────────────╮
│  # │      timestamp       │   run-id    │           workflow           │ status │              test               │
├────┼──────────────────────┼─────────────┼──────────────────────────────┼────────┼─────────────────────────────────┤
│  0 │ 2025-12-02T12:01:06Z │ 19857858903 │ Windows D3D12 AMD DXC        │ FAIL   │ WaveOps/WaveActiveMax.fp64.test │
│  1 │ 2025-12-02T16:08:39Z │ 19865261556 │ Windows D3D12 QC DXC         │ FAIL   │ WaveOps/WaveActiveMax.fp64.test │
│  2 │ 2025-12-02T18:02:48Z │ 19868627852 │ Windows Vulkan QC DXC        │ FAIL   │ WaveOps/WaveActiveMax.fp64.test │
│  3 │ 2025-12-02T12:11:34Z │ 19858143265 │ Windows D3D12 Warp DXC       │ PASS   │ WaveOps/WaveActiveMax.fp64.test │
│  4 │ 2025-12-02T16:01:35Z │ 19865037929 │ Windows D3D12 Intel DXC      │ PASS   │ WaveOps/WaveActiveMax.fp64.test │
│  5 │ 2025-12-02T16:03:51Z │ 19865110582 │ Windows D3D12 NVIDIA DXC     │ PASS   │ WaveOps/WaveActiveMax.fp64.test │
│  6 │ 2025-12-02T16:00:59Z │ 19865018538 │ Windows ARM64 D3D12 Warp DXC │ PASS   │ WaveOps/WaveActiveMax.fp64.test │
│  7 │ 2025-12-02T12:07:36Z │ 19858035043 │ Windows Vulkan AMD DXC       │ PASS   │ WaveOps/WaveActiveMax.fp64.test │
│  8 │ 2025-12-02T16:02:15Z │ 19865059004 │ Windows Vulkan Intel DXC     │ PASS   │ WaveOps/WaveActiveMax.fp64.test │
│  9 │ 2025-12-02T16:07:41Z │ 19865230599 │ Windows Vulkan NVIDIA DXC    │ PASS   │ WaveOps/WaveActiveMax.fp64.test │
│ 10 │ 2025-12-02T17:09:41Z │ 19867100359 │ macOS Metal DXC              │ XFAIL  │ WaveOps/WaveActiveMax.fp64.test │
╰────┴──────────────────────┴─────────────┴──────────────────────────────┴────────┴─────────────────────────────────╯
```