### PR TITLE
Add XFAIL to tests that regressed on Vulkan after vector swizzle store fix

### DIFF
--- a/test/Feature/HLSLLib/abs.32.test
+++ b/test/Feature/HLSLLib/abs.32.test
@@ -134,6 +134,9 @@ DescriptorSets:
 ...
 #--- end
 
+# Bug https://github.com/llvm/llvm-project/issues/170241
+# XFAIL: Clang && Vulkan
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/abs.int16.test
+++ b/test/Feature/HLSLLib/abs.int16.test
@@ -94,6 +94,9 @@ DescriptorSets:
 ...
 #--- end
 
+# Bug https://github.com/llvm/llvm-project/issues/170241
+# XFAIL: Clang && Vulkan
+
 # REQUIRES: Int16
 # RUN: split-file %s %t
 # RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/abs.int64.test
+++ b/test/Feature/HLSLLib/abs.int64.test
@@ -94,6 +94,9 @@ DescriptorSets:
 ...
 #--- end
 
+# Bug https://github.com/llvm/llvm-project/issues/170241
+# XFAIL: Clang && Vulkan
+
 # REQUIRES: Int64
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/countbits.32.test
+++ b/test/Feature/HLSLLib/countbits.32.test
@@ -90,6 +90,9 @@ DescriptorSets:
 ...
 #--- end
 
+# Bug https://github.com/llvm/llvm-project/issues/170241
+# XFAIL: Clang && Vulkan
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/isinf.16.test
+++ b/test/Feature/HLSLLib/isinf.16.test
@@ -55,6 +55,9 @@ DescriptorSets:
 ...
 #--- end
 
+# Bug https://github.com/llvm/llvm-project/issues/170241
+# XFAIL: Clang && Vulkan
+
 # A bug in the Metal Shader Converter caused it to mis-translate this operation.
 # Version 3 fixes this issue.
 # UNSUPPORTED: Clang && Metal && !metal-shaderconverter-3.0.0-or-later

--- a/test/Feature/HLSLLib/isinf.32.test
+++ b/test/Feature/HLSLLib/isinf.32.test
@@ -55,6 +55,9 @@ DescriptorSets:
 ...
 #--- end
 
+# Bug https://github.com/llvm/llvm-project/issues/170241
+# XFAIL: Clang && Vulkan
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/saturate.32.test
+++ b/test/Feature/HLSLLib/saturate.32.test
@@ -46,6 +46,9 @@ DescriptorSets:
 ...
 #--- end
 
+# Bug https://github.com/llvm/llvm-project/issues/170241
+# XFAIL: Clang && Vulkan
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s

--- a/test/Feature/HLSLLib/sign.32.test
+++ b/test/Feature/HLSLLib/sign.32.test
@@ -173,6 +173,9 @@ DescriptorSets:
 ...
 #--- end
 
+# Bug https://github.com/llvm/llvm-project/issues/170241
+# XFAIL: Clang && Vulkan
+
 # We're generating invalid SPIRV for this. I have _no_ idea why this isn't
 # failing on all Clang Vulkan tests.
 # Bug https://github.com/llvm/llvm-project/issues/149722

--- a/test/Feature/HLSLLib/sign.fp16.test
+++ b/test/Feature/HLSLLib/sign.fp16.test
@@ -97,6 +97,9 @@ DescriptorSets:
 ...
 #--- end
 
+# Bug https://github.com/llvm/llvm-project/issues/170241
+# XFAIL: Clang && Vulkan
+
 # REQUIRES: Half
 # RUN: split-file %s %t
 # RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/sign.fp64.test
+++ b/test/Feature/HLSLLib/sign.fp64.test
@@ -92,6 +92,9 @@ DescriptorSets:
 ...
 #--- end
 
+# Bug https://github.com/llvm/llvm-project/issues/170241
+# XFAIL: Clang && Vulkan
+
 # REQUIRES: Double
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/sign.int16.test
+++ b/test/Feature/HLSLLib/sign.int16.test
@@ -94,6 +94,9 @@ DescriptorSets:
 ...
 #--- end
 
+# Bug https://github.com/llvm/llvm-project/issues/170241
+# XFAIL: Clang && Vulkan
+
 # Bug https://github.com/microsoft/DirectXShaderCompiler/issues/7755
 # XFAIL: DXC && Vulkan
 

--- a/test/Feature/HLSLLib/sign.int64.test
+++ b/test/Feature/HLSLLib/sign.int64.test
@@ -94,6 +94,9 @@ DescriptorSets:
 ...
 #--- end
 
+# Bug https://github.com/llvm/llvm-project/issues/170241
+# XFAIL: Clang && Vulkan
+
 # Bug https://github.com/microsoft/DirectXShaderCompiler/issues/7755
 # XFAIL: DXC && Vulkan
 

--- a/test/Feature/StructuredBuffer/layout.test
+++ b/test/Feature/StructuredBuffer/layout.test
@@ -87,6 +87,9 @@ DescriptorSets:
 ...
 #--- end
 
+# Bug https://github.com/llvm/llvm-project/issues/170241
+# XFAIL: Clang && Vulkan
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 %if Vulkan %{ -fvk-use-dx-layout %} -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s

--- a/test/WaveOps/WaveReadLaneAt.16.test
+++ b/test/WaveOps/WaveReadLaneAt.16.test
@@ -135,6 +135,10 @@ DescriptorSets:
         Binding: 5
 ...
 #--- end
+
+# Bug https://github.com/llvm/llvm-project/issues/170241
+# XFAIL: Clang && Vulkan
+
 # Bug https://github.com/llvm/offload-test-suite/issues/351
 # XFAIL: Metal
 

--- a/test/WaveOps/WaveReadLaneAt.32.test
+++ b/test/WaveOps/WaveReadLaneAt.32.test
@@ -175,6 +175,8 @@ DescriptorSets:
 # Bug https://github.com/llvm/offload-test-suite/issues/351
 # XFAIL: Metal
 
+# Bug https://github.com/llvm/llvm-project/issues/170241
+# XFAIL: Clang && Vulkan
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Gis -Fo %t.o %t/source.hlsl

--- a/test/WaveOps/WaveReadLaneAt.Float.64.test
+++ b/test/WaveOps/WaveReadLaneAt.Float.64.test
@@ -59,6 +59,9 @@ DescriptorSets:
 ...
 #--- end
 
+# Bug https://github.com/llvm/llvm-project/issues/170241
+# XFAIL: Clang && Vulkan
+
 # REQUIRES: Double
 
 # RUN: split-file %s %t

--- a/test/WaveOps/WaveReadLaneAt.Int.64.test
+++ b/test/WaveOps/WaveReadLaneAt.Int.64.test
@@ -100,6 +100,9 @@ DescriptorSets:
 # Tracked by https://github.com/llvm/offload-test-suite/issues/355
 # UNSUPPORTED: Metal
 
+# Bug https://github.com/llvm/llvm-project/issues/170241
+# XFAIL: Clang && Vulkan
+
 # REQUIRES: Int64
 
 # RUN: split-file %s %t


### PR DESCRIPTION
Regressed after llvm/llvm-project#169090.

Issue tracing the fix for SPIRV is: llvm/llvm-project#170241