### PR TITLE
Add XFAIL to tests that regressed on Vulkan after vector swizzle store fix

### DIFF
--- a/test/Basic/matrix_scalar_arithmetic.test
+++ b/test/Basic/matrix_scalar_arithmetic.test
@@ -83,6 +83,9 @@ DescriptorSets:
 ...
 #--- end
 
+# Bug https://github.com/llvm/offload-test-suite/issues/538
+# XFAIL: Clang && Vulkan
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s

--- a/test/Basic/matrix_scalar_constructor.test
+++ b/test/Basic/matrix_scalar_constructor.test
@@ -56,6 +56,9 @@ DescriptorSets:
 ...
 #--- end
 
+# Bug https://github.com/llvm/offload-test-suite/issues/538
+# XFAIL: Clang && Vulkan
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/WaveOps/WaveReadLaneAt.16.test
+++ b/test/WaveOps/WaveReadLaneAt.16.test
@@ -145,6 +145,9 @@ DescriptorSets:
 # Bug tracked by https://github.com/llvm/offload-test-suite/issues/396
 # XFAIL: DirectX && WARP
 
+# Bug https://github.com/llvm/offload-test-suite/issues/532
+# XFAIL: DirectX && QC
+
 # REQUIRES: Half, Int16
 
 # RUN: split-file %s %t

--- a/test/WaveOps/WaveReadLaneAt.Float.64.test
+++ b/test/WaveOps/WaveReadLaneAt.Float.64.test
@@ -62,6 +62,9 @@ DescriptorSets:
 # Bug https://github.com/llvm/llvm-project/issues/170241
 # XFAIL: Clang && Vulkan
 
+# Bug https://github.com/llvm/offload-test-suite/issues/533
+# XFAIL: DirectX && AMD
+
 # REQUIRES: Double
 
 # RUN: split-file %s %t

--- a/test/WaveOps/WaveReadLaneAt.Int.64.test
+++ b/test/WaveOps/WaveReadLaneAt.Int.64.test
@@ -103,6 +103,9 @@ DescriptorSets:
 # Bug https://github.com/llvm/llvm-project/issues/170241
 # XFAIL: Clang && Vulkan
 
+# Bug https://github.com/llvm/offload-test-suite/issues/533
+# XFAIL: DirectX && AMD
+
 # REQUIRES: Int64
 
 # RUN: split-file %s %t


### PR DESCRIPTION
Regressed after llvm/llvm-project#169090.

Issue tracing the fix for SPIRV is: llvm/llvm-project#170241