### PR TITLE
Add XFAIL for Qualcomm + Vulkan + Clang to WaveActiveCountBits

### DIFF
--- a/test/Feature/WaveOps/WaveActiveCountBits.test
+++ b/test/Feature/WaveOps/WaveActiveCountBits.test
@@ -64,6 +64,9 @@ DescriptorSets:
 ...
 #--- end
 
+# Bug https://github.com/llvm/offload-test-suite/issues/549
+# XFAIL: QC && Vulkan && Clang
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
Adds an XFAIL for Qualcomm under Vulkan + Clang due to #549
