### PR TITLE
Add XFAIL for AMD in `Feature/StructuredBuffer/inc_counter_array.test`

### DIFF
--- a/test/Feature/StructuredBuffer/inc_counter_array.test
+++ b/test/Feature/StructuredBuffer/inc_counter_array.test
@@ -52,7 +52,7 @@ DescriptorSets:
 # Bug https://github.com/llvm/offload-test-suite/issues/376
 # XFAIL: Intel
 
-# Bug https://github.com/llvm/offload-test-suite/issues/552
+# Bug https://github.com/llvm/offload-test-suite/issues/337
 # XFAIL: AMD
 
 # RUN: split-file %s %t


### PR DESCRIPTION
Adds an XFAIL for AMD due to #552 