### PR TITLE
Add Qualcomm-Vulkan XFAIL to `unbounded-array-*` tests

### DIFF
--- a/test/Feature/ResourceArrays/unbounded-array-nuri.test
+++ b/test/Feature/ResourceArrays/unbounded-array-nuri.test
@@ -66,6 +66,9 @@ DescriptorSets:
 # Resource arrays are not yet supported on Metal
 # UNSUPPORTED: Metal
 
+# Bug https://github.com/llvm/offload-test-suite/issues/556
+# XFAIL: Vulkan && QC
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/ResourceArrays/unbounded-array.test
+++ b/test/Feature/ResourceArrays/unbounded-array.test
@@ -57,6 +57,9 @@ DescriptorSets:
 # Unimplemented https://github.com/llvm/offload-test-suite/issues/305
 # XFAIL: Metal
 
+# Bug https://github.com/llvm/offload-test-suite/issues/556
+# XFAIL: Vulkan && QC
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
Adds a Vulkan && QC XFAIL to `Feature/ResourceArrays/unbounded-array.test` and `Feature/ResourceArrays/unbounded-array-nuri.test` for #556 