### PR TITLE
XFAIL CBuffer/structs.test for DXC Vulkan

### DIFF
--- a/test/Feature/CBuffer/structs.test
+++ b/test/Feature/CBuffer/structs.test
@@ -102,6 +102,9 @@ DescriptorSets:
 # Bug https://github.com/llvm/llvm-project/issues/123968
 # XFAIL: Clang
 
+# Bug https://github.com/microsoft/DirectXShaderCompiler/issues/7968
+# XFAIL: DXC && Vulkan
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -fvk-use-dx-layout -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s


### PR DESCRIPTION
This started failing recently, see microsoft/DirectXShaderCompiler#7968