### PR TITLE
Update Clang && Vulkan XFAIL in dot2add test

### DIFF
--- a/test/Feature/HLSLLib/dot2add.test
+++ b/test/Feature/HLSLLib/dot2add.test
@@ -89,8 +89,8 @@ DescriptorSets:
 # Bug https://github.com/llvm/offload-test-suite/issues/341
 # XFAIL: Metal
 
-# Bug https://github.com/llvm/llvm-project/issues/149561
-# XFAIL: Clang && Vulkan && !VK_KHR_shader_float_controls2
+# Bug https://github.com/llvm/llvm-project/issues/149561 and https://github.com/llvm/offload-test-suite/issues/568
+# XFAIL: Clang && Vulkan
 
 # REQUIRES: Half
 # RUN: split-file %s %t


### PR DESCRIPTION
Updates dot2add Clang && Vulkan XFAIL to XFAIL regardless of `VK_KHR_shader_float_controls2` because the test fails regardless.
- #568