### PR TITLE
Add AMD XFAIL to `Bugs/Adjacent-Partial-Writes.yaml`

### DIFF
--- a/test/Bugs/Adjacent-Partial-Writes.yaml
+++ b/test/Bugs/Adjacent-Partial-Writes.yaml
@@ -69,6 +69,9 @@ DescriptorSets:
 # https://github.com/llvm/llvm-project/issues/142677
 # UNSUPPORTED: Vulkan
 
+# Bug https://github.com/llvm/offload-test-suite/issues/330
+# XFAIL: AMD && DirectX
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
The `Bugs/Adjacent-Partial-Writes.yaml` test has been failing on AMD for a while now due to an existing and reported issue
- #330