### PR TITLE
Add AMD && Vulkan XFAIL to asin.32

### DIFF
--- a/test/Feature/HLSLLib/asin.32.test
+++ b/test/Feature/HLSLLib/asin.32.test
@@ -61,6 +61,8 @@ DescriptorSets:
 ...
 #--- end
 
+# Bug https://github.com/llvm/offload-test-suite/issues/578
+# XFAIL: AMD && Vulkan
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl


### PR DESCRIPTION
Forgot to include asin.32 in the last PR that added an XFAIL to asin.16. This PR adds the XFAIL for asin.32.
- #578