### PR TITLE
Add AMD && DirectX XFAIL to countbits.64

### DIFF
--- a/test/Feature/HLSLLib/countbits.64.test
+++ b/test/Feature/HLSLLib/countbits.64.test
@@ -97,6 +97,9 @@ DescriptorSets:
 # https://github.com/llvm/llvm-project/issues/142677
 # UNSUPPORTED: Vulkan
 
+# Bug https://github.com/llvm/offload-test-suite/issues/331
+# XFAIL: AMD && DirectX
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
Adds an XFAIL to a test that has been failing on AMD for a while now with a known issue.
- #331