### PR TITLE
XFAIL NV && DirectX in `firstbithigh.64` and `firstbitlow.64` tests

### DIFF
--- a/test/Feature/HLSLLib/firstbithigh.64.test
+++ b/test/Feature/HLSLLib/firstbithigh.64.test
@@ -92,6 +92,9 @@ DescriptorSets:
 # Bug https://github.com/llvm/llvm-project/issues/143171
 # XFAIL: Clang && Vulkan
 
+# Bug https://github.com/llvm/offload-test-suite/issues/324
+# XFAIL: NV && DirectX
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/firstbitlow.64.test
+++ b/test/Feature/HLSLLib/firstbitlow.64.test
@@ -86,6 +86,9 @@ DescriptorSets:
 # Bug https://github.com/llvm/llvm-project/issues/143003
 # XFAIL: Clang && Vulkan
 
+# Bug https://github.com/llvm/offload-test-suite/issues/324
+# XFAIL: NV && DirectX
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
Adds NV && DirectX XFAILs to the `firstbit*.64` tests since the the tests have been failing for a while now on a known issue.
- #324