### PR TITLE
Update XFAIL conditions of `matrix_elementwise_vector_cast` and `matrix_trunc_cast` to match runner results

### DIFF
--- a/test/Basic/Matrix/matrix_elementwise_vector_cast.test
+++ b/test/Basic/Matrix/matrix_elementwise_vector_cast.test
@@ -73,7 +73,7 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug https://github.com/llvm/llvm-project/issues/170538
+# Bug https://github.com/llvm/offload-test-suite/issues/599
 # XFAIL: Intel && Vulkan && Clang
 
 # RUN: split-file %s %t

--- a/test/Basic/Matrix/matrix_trunc_cast.test
+++ b/test/Basic/Matrix/matrix_trunc_cast.test
@@ -56,7 +56,7 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug https://github.com/llvm/llvm-project/issues/170538
+# Bug https://github.com/llvm/offload-test-suite/issues/599
 # XFAIL: Intel && Vulkan && Clang
 
 # RUN: split-file %s %t


### PR DESCRIPTION
The two tests are XPASSing on all machines except Intel under Vulkan with Clang. See:
- https://github.com/llvm/offload-test-suite/issues/591
- https://github.com/llvm/offload-test-suite/issues/592

But I believe the existing linked issue for the XFAIL is still the most relevant one so I did not change the linked bug. 
https://github.com/llvm/offload-test-suite/issues/591 and https://github.com/llvm/offload-test-suite/issues/592 can probably be closed as duplicates of https://github.com/llvm/offload-test-suite/issues/599.