### PR TITLE
Update Clang && Vulkan XFAIL in `Feature/HLSLLib/asdouble.32.test`

### DIFF
--- a/test/Feature/HLSLLib/asdouble.32.test
+++ b/test/Feature/HLSLLib/asdouble.32.test
@@ -82,8 +82,8 @@ DescriptorSets:
         Binding: 2
 #--- end
 
-# Bug https://github.com/llvm/llvm-project/issues/153513
-# XFAIL: Clang && Vulkan
+# Bug https://github.com/llvm/offload-test-suite/issues/594
+# XFAIL: AMD && Vulkan
 
 # Bug https://github.com/microsoft/DirectXShaderCompiler/issues/7699
 # XFAIL: DXC && Vulkan


### PR DESCRIPTION
The issue https://github.com/llvm/llvm-project/issues/153513 has been resolved, so the XFAIL should be removed.
However, the test fails on AMD:
- https://github.com/llvm/offload-test-suite/issues/594

So the `Clang && Vulkan` XFAIL has been changed to `AMD && Vulkan` and the issue link has been replaced.