### PR TITLE
Update Metal XFAIL in `Feature/HLSLLib/firstbithigh.16.test`

### DIFF
--- a/test/Feature/HLSLLib/firstbithigh.16.test
+++ b/test/Feature/HLSLLib/firstbithigh.16.test
@@ -82,10 +82,8 @@ DescriptorSets:
 
 # REQUIRES: Int16
 
-# Bug: No bit set terminal is returned as 4294901776 instead of 4294967295
-# XFAIL: DXC && Metal
-# Bug: Fails with 'gpu-exec: error: Failed to materializeAll.:'
-# XFAIL: Clang && Metal
+# Bug https://github.com/llvm/offload-test-suite/issues/602
+# XFAIL: Metal
 
 # 16/64 bit firstbithigh doesn't have a DXC-Vulkan lowering
 # Unsupported https://github.com/microsoft/DirectXShaderCompiler/blob/main/tools/clang/test/CodeGenSPIRV/intrinsics.firstbitlow.64bit.hlsl


### PR DESCRIPTION
The XFAIL in `Feature/HLSLLib/firstbithigh.16.test` for Metal didn't have a linked issue, and also the Clang-specific error doesn't appear anymore, so I changed the XFAIL to be a generic `XFAIL: Metal` and created+linked a corresponding issue.
- #602 