### PR TITLE
Replace "Fails with 'gpu-exec: error: Failed to materializeAll.:'" with links to GitHub issue in firstbithigh/low Metal XFAILs

### DIFF
--- a/test/Feature/HLSLLib/firstbithigh.64.test
+++ b/test/Feature/HLSLLib/firstbithigh.64.test
@@ -82,7 +82,7 @@ DescriptorSets:
 
 # REQUIRES: Int64
 
-# Bug: Fails with 'gpu-exec: error: Failed to materializeAll.:'
+# Bug https://github.com/llvm/offload-test-suite/issues/605
 # XFAIL: Metal
 
 # 16/64 bit firstbithigh doesn't have a DXC-Vulkan lowering

--- a/test/Feature/HLSLLib/firstbitlow.16.test
+++ b/test/Feature/HLSLLib/firstbitlow.16.test
@@ -76,7 +76,7 @@ DescriptorSets:
 
 # REQUIRES: Int16
 
-# Fails with 'gpu-exec: error: Failed to materializeAll.:'
+# Bug https://github.com/llvm/offload-test-suite/issues/605
 # XFAIL: Metal
 
 # 16/64 bit firstbitlow doesn't have a DXC-Vulkan lowering

--- a/test/Feature/HLSLLib/firstbitlow.64.test
+++ b/test/Feature/HLSLLib/firstbitlow.64.test
@@ -76,7 +76,7 @@ DescriptorSets:
 
 # REQUIRES: Int64
 
-# Fails with 'gpu-exec: error: Failed to materializeAll.:'
+# Bug https://github.com/llvm/offload-test-suite/issues/605
 # XFAIL: Metal
 
 # 16/64 bit firstbitlow doesn't have a DXC-Vulkan lowering


### PR DESCRIPTION
These XFAILs didn't have an issue tracking them. So I created an issue and made this PR to replace the XFAIL descriptions with a link to the issue so it can be tracked.
- https://github.com/llvm/offload-test-suite/issues/605