### PR TITLE
Remove NV-Reconvergence-Issue-320 XFAIL from `Feature/WaveOps/WaveIsFirstLane.test`

### DIFF
--- a/test/Feature/WaveOps/WaveIsFirstLane.test
+++ b/test/Feature/WaveOps/WaveIsFirstLane.test
@@ -65,9 +65,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug https://github.com/llvm/offload-test-suite/issues/320
-# XFAIL: NV-Reconvergence-Issue-320
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -74,10 +74,6 @@ def setDeviceFeatures(config, device, compiler):
             config.available_features.add("Intel-Memory-Coherence-Issue-226")
     if "NVIDIA" in device["Description"]:
         config.available_features.add("NV")
-        NV50SeriesRegex = re.compile("NVIDIA GeForce [A-Z]+ 50[0-9]+")
-        NV50SeriesMatch = NV50SeriesRegex.match(device["Description"])
-        if NV50SeriesMatch and API == "DirectX":
-            config.available_features.add("NV-Reconvergence-Issue-320")
     if "AMD" in device["Description"]:
         config.available_features.add("AMD")
     if "Qualcomm" in device["Description"]:


### PR DESCRIPTION
The NVIDIA Reconvergence issue appears to be fixed with driver version 591.44 and the test now XPASSes. So this PR removes the XFAIL and the corresponding feature from the lit.cfg
- (Windows D3D12 NVIDIA DXC) https://github.com/llvm/offload-test-suite/actions/runs/19971666348/job/57277691724#step:12:539
- (Windows D3D12 NVIDIA Clang) https://github.com/llvm/offload-test-suite/actions/runs/19971719424/job/57277869135#step:12:543
- https://github.com/llvm/offload-test-suite/issues/320