### PR TITLE
Add test for CheckAccessFullyMapped

### DIFF
--- a/test/Feature/HLSLLib/checkaccessfullymapped.test
+++ b/test/Feature/HLSLLib/checkaccessfullymapped.test
@@ -166,8 +166,6 @@ DescriptorSets:
 # Bug https://github.com/llvm/offload-test-suite/issues/485
 # XFAIL: Intel
 
-
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
This PR adds a test for CheckAccessFullyMapped. It builds on the previous test that was added to test the partially mapped / reserved resources infrastructure.
The test can be extended and simultaneously used to test both the reserved resources infrastructure and CheckAccessFullyMapped, the former implicitly and the latter explicitly.

It also tests unsigned ints directly given to CheckAccessFullyMapped, validating results for non-status inputs.
Fixes https://github.com/llvm/offload-test-suite/issues/181

Clang is currently failing, but will pass once https://github.com/llvm/llvm-project/pull/170949 goes in.