### PR TITLE
Remove AMD && Vulkan XFAIL from `asdouble.32.test`

### DIFF
--- a/test/Feature/HLSLLib/asdouble.32.test
+++ b/test/Feature/HLSLLib/asdouble.32.test
@@ -82,9 +82,6 @@ DescriptorSets:
         Binding: 2
 #--- end
 
-# Bug https://github.com/llvm/offload-test-suite/issues/594
-# XFAIL: AMD && Vulkan
-
 # Bug https://github.com/microsoft/DirectXShaderCompiler/issues/7699
 # XFAIL: DXC && Vulkan
 


### PR DESCRIPTION
The test appears to be XPASSing now, so the corresponding issue has been closed.
- #594 