### PR TITLE
Exclude AMD from DXC && Vulkan XFAIL in `Feature/TypedBuffer/GetDimensions.test`

### DIFF
--- a/test/Feature/TypedBuffer/GetDimensions.test
+++ b/test/Feature/TypedBuffer/GetDimensions.test
@@ -81,7 +81,9 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/offload-test-suite/issues/469
-# XFAIL: DXC && Vulkan
+# GetDimensions on Vulkan (DXC) returns [ 16, 16 ] instead of [ 8, 5 ]
+# except on AMD https://github.com/llvm/offload-test-suite/issues/523
+# XFAIL: DXC && Vulkan && !AMD
 
 # Unimplemented https://github.com/llvm/llvm-project/issues/164008
 # XFAIL: Clang && Vulkan


### PR DESCRIPTION
This is an XFAIL change to address:
- #523

This PR excludes AMD from the DXC && Vulkan XFAIL because it passes while all other runners/GPUs fail the test.