### PR TITLE
[Github] Test workflows when modifying them

### DIFF
--- a/.github/workflows/macos-clang-mtl.yaml
+++ b/.github/workflows/macos-clang-mtl.yaml
@@ -8,6 +8,9 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '*/30 * * * *' # run every 30 minutes
+  pull_request:
+    paths:
+     - .github/workflows/macos-clang-mtl.yaml
 
 jobs:
   macOS-Metal-Clang:

--- a/.github/workflows/macos-dxc-mtl.yaml
+++ b/.github/workflows/macos-dxc-mtl.yaml
@@ -8,6 +8,9 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '*/30 * * * *' # run every 30 minutes
+  pull_request:
+    paths:
+     - .github/workflows/macos-dxc-mtl.yaml
 
 jobs:
   macOS-Metal-DXC:

--- a/.github/workflows/windows-amd-clang-d3d12.yaml
+++ b/.github/workflows/windows-amd-clang-d3d12.yaml
@@ -8,6 +8,9 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 */6 * * *' # run every 6 hours
+  pull_request:
+    paths:
+     - .github/workflows/windows-amd-clang-d3d12.yaml
 
 jobs:
   Windows-D3D12-AMD-Clang:

--- a/.github/workflows/windows-amd-clang-vk.yaml
+++ b/.github/workflows/windows-amd-clang-vk.yaml
@@ -8,6 +8,9 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 */6 * * *' # run every 6 hours
+  pull_request:
+    paths:
+     - .github/workflows/windows-amd-clang-vk.yaml
 
 jobs:
   Windows-VK-AMD-Clang:

--- a/.github/workflows/windows-amd-clang-warp-d3d12.yaml
+++ b/.github/workflows/windows-amd-clang-warp-d3d12.yaml
@@ -8,6 +8,9 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 */6 * * *' # run every 6 hours
+  pull_request:
+    paths:
+     - .github/workflows/windows-amd-clang-warp-d3d12.yaml
 
 jobs:
   Windows-D3D12-Warp-Clang:

--- a/.github/workflows/windows-amd-clang-warp-preview-d3d12.yaml
+++ b/.github/workflows/windows-amd-clang-warp-preview-d3d12.yaml
@@ -6,6 +6,9 @@ permissions:
 
 on:
   workflow_dispatch:
+  pull_request:
+    paths:
+     - .github/workflows/windows-amd-clang-warp-preview-d3d12.yaml
 
 jobs:
   Windows-D3D12-Warp-Clang:

--- a/.github/workflows/windows-amd-dxc-d3d12.yaml
+++ b/.github/workflows/windows-amd-dxc-d3d12.yaml
@@ -8,6 +8,9 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 */6 * * *' # run every 6 hours
+  pull_request:
+    paths:
+     - .github/workflows/windows-amd-dxc-d3d12.yaml
 
 jobs:
   Windows-D3D12-AMD-DXC:

--- a/.github/workflows/windows-amd-dxc-vk.yaml
+++ b/.github/workflows/windows-amd-dxc-vk.yaml
@@ -8,6 +8,9 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 */6 * * *' # run every 6 hours
+  pull_request:
+    paths:
+     - .github/workflows/windows-amd-dxc-vk.yaml
 
 jobs:
   Windows-VK-AMD-DXC:

--- a/.github/workflows/windows-amd-dxc-warp-d3d12.yaml
+++ b/.github/workflows/windows-amd-dxc-warp-d3d12.yaml
@@ -8,6 +8,9 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 */6 * * *' # run every 6 hours
+  pull_request:
+    paths:
+     - .github/workflows/windows-amd-dxc-warp-d3d12.yaml
 
 jobs:
   Windows-D3D12-Warp-DXC:

--- a/.github/workflows/windows-amd-dxc-warp-preview-d3d12.yaml
+++ b/.github/workflows/windows-amd-dxc-warp-preview-d3d12.yaml
@@ -6,6 +6,9 @@ permissions:
 
 on:
   workflow_dispatch:
+  pull_request:
+    paths:
+     - .github/workflows/windows-amd-dxc-warp-preview-d3d12.yaml
 
 jobs:
   Windows-D3D12-Warp-DXC:

--- a/.github/workflows/windows-intel-clang-d3d12.yaml
+++ b/.github/workflows/windows-intel-clang-d3d12.yaml
@@ -8,6 +8,9 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 */2 * * *' # run every 2 hours
+  pull_request:
+    paths:
+     - .github/workflows/windows-intel-clang-d3d12.yaml
 
 jobs:
   Windows-D3D12-Intel-Clang:

--- a/.github/workflows/windows-intel-clang-vk.yaml
+++ b/.github/workflows/windows-intel-clang-vk.yaml
@@ -8,6 +8,9 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 */2 * * *' # run every 2 hours
+  pull_request:
+    paths:
+     - .github/workflows/windows-intel-clang-vk.yaml
 
 jobs:
   Windows-VK-Intel-Clang:

--- a/.github/workflows/windows-intel-dxc-d3d12.yaml
+++ b/.github/workflows/windows-intel-dxc-d3d12.yaml
@@ -8,6 +8,9 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 * * * *' # run every 30 minutes
+  pull_request:
+    paths:
+     - .github/workflows/windows-intel-dxc-d3d12.yaml
 
 jobs:
   Windows-D3D12-Intel-DXC:

--- a/.github/workflows/windows-intel-dxc-vk.yaml
+++ b/.github/workflows/windows-intel-dxc-vk.yaml
@@ -8,6 +8,9 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 */2 * * *' # run every 2 hours
+  pull_request:
+    paths:
+     - .github/workflows/windows-intel-dxc-vk.yaml
 
 jobs:
   Windows-VK-Intel-DXC:

--- a/.github/workflows/windows-nvidia-clang-d3d12.yaml
+++ b/.github/workflows/windows-nvidia-clang-d3d12.yaml
@@ -8,6 +8,9 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 */2 * * *' # run every 2 hours
+  pull_request:
+    paths:
+     - .github/workflows/windows-nvidia-clang-d3d12.yaml
 
 jobs:
   Windows-D3D12-NVIDIA-Clang:

--- a/.github/workflows/windows-nvidia-clang-vk.yaml
+++ b/.github/workflows/windows-nvidia-clang-vk.yaml
@@ -8,6 +8,9 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 */2 * * *' # run every 2 hours
+  pull_request:
+    paths:
+     - .github/workflows/windows-nvidia-clang-vk.yaml
 
 jobs:
   Windows-VK-NVIDIA-Clang:

--- a/.github/workflows/windows-nvidia-dxc-d3d12.yaml
+++ b/.github/workflows/windows-nvidia-dxc-d3d12.yaml
@@ -8,6 +8,9 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 * * * *' # run every 30 minutes
+  pull_request:
+    paths:
+     - .github/workflows/windows-nvidia-dxc-d3d12.yaml
 
 jobs:
   Windows-D3D12-NVIDIA-DXC:

--- a/.github/workflows/windows-nvidia-dxc-vk.yaml
+++ b/.github/workflows/windows-nvidia-dxc-vk.yaml
@@ -8,6 +8,9 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 */2 * * *' # run every 2 hours
+  pull_request:
+    paths:
+     - .github/workflows/window-nvidia-dxc-vk.yaml
 
 jobs:
   Windows-VK-NVIDIA-DXC:

--- a/.github/workflows/windows-qc-clang-d3d12.yaml
+++ b/.github/workflows/windows-qc-clang-d3d12.yaml
@@ -8,6 +8,9 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 */2 * * *' # run every 2 hours
+  pull_request:
+    paths:
+     - .github/workflows/windows-qc-clang-d3d12.yaml
 
 jobs:
   Windows-D3D12-QC-Clang:

--- a/.github/workflows/windows-qc-clang-vk.yaml
+++ b/.github/workflows/windows-qc-clang-vk.yaml
@@ -8,6 +8,9 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 */2 * * *' # run every 2 hours
+  pull_request:
+    paths:
+     - .github/workflows/windows-qc-clang-vk.yaml
 
 jobs:
   Windows-VK-QC-Clang:

--- a/.github/workflows/windows-qc-clang-warp-d3d12.yaml
+++ b/.github/workflows/windows-qc-clang-warp-d3d12.yaml
@@ -8,6 +8,9 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 */2 * * *' # run every 2 hours
+  pull_request:
+    paths:
+     - .github/workflows/windows-qc-clang-warp-d3d12.yaml
 
 jobs:
   Windows-ARM64-D3D12-Warp-Clang:

--- a/.github/workflows/windows-qc-dxc-d3d12.yaml
+++ b/.github/workflows/windows-qc-dxc-d3d12.yaml
@@ -8,6 +8,9 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 */2 * * *' # run every 2 hours
+  pull_request:
+    paths:
+     - .github/workflows/windows-qc-dxc-d3d12.yaml
 
 jobs:
   Windows-D3D12-QC-DXC:

--- a/.github/workflows/windows-qc-dxc-vk.yaml
+++ b/.github/workflows/windows-qc-dxc-vk.yaml
@@ -8,6 +8,9 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 */2 * * *' # run every 2 hours
+  pull_request:
+    paths:
+     - .github/workflows/windows-qc-dxc-vk.yaml
 
 jobs:
   Windows-VK-QC-DXC:

--- a/.github/workflows/windows-qc-dxc-warp-d3d12.yaml
+++ b/.github/workflows/windows-qc-dxc-warp-d3d12.yaml
@@ -8,6 +8,9 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 */2 * * *' # run every 2 hours
+  pull_request:
+    paths:
+     - .github/workflows/windows-qc-dxc-warp-d3d12.yaml
 
 jobs:
   Windows-ARM64-D3D12-Warp-DXC:


### PR DESCRIPTION
The postcommit workflows set to run as cron jobs are difficult to test without landing changes in main. Add a workflow trigger to run them on pull requests when the workflow definition gets modified.

This will also soon be listed in LLVM's CI best practices document soon. https://github.com/llvm/llvm-project/pull/172235

Landing this primarily because it makes it easier to test some changes I want to make soon.