### PR TITLE
[Github] Hash Pin all External Actions

### DIFF
--- a/.github/workflows/build-and-test-callable.yaml
+++ b/.github/workflows/build-and-test-callable.yaml
@@ -107,7 +107,7 @@ jobs:
     runs-on: [self-hosted, "hlsl-${{ inputs.SKU }}"]
     steps:
       - name: Checkout DXC
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           repository: Microsoft/DirectXShaderCompiler
           ref: ${{ inputs.DXC-branch }}
@@ -115,21 +115,21 @@ jobs:
           fetch-depth: 1
           submodules: true
       - name: Checkout LLVM
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           repository: ${{ inputs.LLVM-fork }}/llvm-project
           ref: ${{ inputs.LLVM-branch }}
           path: llvm-project
           fetch-depth: 1
       - name: Checkout OffloadTest
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           repository: llvm/offload-test-suite
           ref: ${{ inputs.OffloadTest-branch }}
           path: OffloadTest
           fetch-depth: 1
       - name: Checkout Golden Images
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           repository: llvm/offload-golden-images
           ref: main
@@ -137,12 +137,12 @@ jobs:
           fetch-depth: 1
       - name: Setup Windows x64
         if: inputs.OS == 'windows' && runner.arch != 'ARM64'
-        uses: llvm/actions/setup-windows@main
+        uses: llvm/actions/setup-windows@89a8cf80982d830faab019237860b344a6390c30 # main
         with:
           arch: amd64
       - name: Setup Windows
         if: inputs.OS == 'windows' && runner.arch == 'ARM64'
-        uses: llvm/actions/setup-windows@main
+        uses: llvm/actions/setup-windows@89a8cf80982d830faab019237860b344a6390c30 # main
         with:
           arch: arm64
       - name: Detect Clang
@@ -176,13 +176,13 @@ jobs:
             ninja check-hlsl-unit
             ninja ${{ inputs.TestTarget }}
       - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action/macos@v2
+        uses: EnricoMi/publish-unit-test-result-action/macos@34d7c956a59aed1bfebf31df77b8de55db9bbaaf # v2.21.0
         if: always() && inputs.OS == 'macOS'
         with:
           comment_mode: off
           files: llvm-project/build/**/testresults.xunit.xml
       #- name: Publish Test Results
-      #  uses: EnricoMi/publish-unit-test-result-action/windows@v2
+      #  uses: EnricoMi/publish-unit-test-result-action/windows@34d7c956a59aed1bfebf31df77b8de55db9bbaaf # v2.21.0
       #  if: always() && inputs.OS == 'windows'
       #  with:
       #    comment_mode: off

--- a/.github/workflows/pr-description-checker.yml
+++ b/.github/workflows/pr-description-checker.yml
@@ -11,7 +11,7 @@ jobs:
   check-pr-description:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: jadrol/pr-description-checker-action@c659fed338a52d657d34462c8bc7fc1f65d25758
         id: description-checker
         with:


### PR DESCRIPTION
This patch hash pins all of the external Github actions that are used within workflows. We consider this a best practice for LLVM (https://llvm.org/docs/CIBestPractices.html) as it improves security and ensures that we control exactly when actions are updated.

The primary motivation for this is so that we can delete setup-windows from llvm/actions while leaving this repository working until we can move away from the setup-windows action.