### PR TITLE
Remove DXC && Vulkan XFAIL from `Feature/CBuffer/structs.test`

### DIFF
--- a/test/Feature/CBuffer/structs.test
+++ b/test/Feature/CBuffer/structs.test
@@ -102,9 +102,6 @@ DescriptorSets:
 # Bug https://github.com/llvm/llvm-project/issues/123968
 # XFAIL: Clang
 
-# Bug https://github.com/microsoft/DirectXShaderCompiler/issues/7968
-# XFAIL: DXC && Vulkan
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -fvk-use-dx-layout -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s


### PR DESCRIPTION
The corresponding XFAIL for this test has been fixed and the test is currently XPASSing on all DXC-Vulkan runners
- https://github.com/microsoft/DirectXShaderCompiler/issues/7968

```
╭────┬──────────────────────┬─────────────┬──────────────────────────────┬─────────────┬──────────────────────────────╮
│  # │      timestamp       │   run-id    │           workflow           │   status    │             test             │
├────┼──────────────────────┼─────────────┼──────────────────────────────┼─────────────┼──────────────────────────────┤
│  0 │ 2025-12-15T18:01:10Z │ 20242372776 │ Windows D3D12 AMD DXC        │ PASS        │ Feature/CBuffer/structs.test │
│  1 │ 2025-12-15T18:01:16Z │ 20242375668 │ Windows D3D12 Intel DXC      │ PASS        │ Feature/CBuffer/structs.test │
│  2 │ 2025-12-15T17:06:03Z │ 20240766371 │ Windows D3D12 NVIDIA DXC     │ PASS        │ Feature/CBuffer/structs.test │
│  3 │ 2025-12-15T16:09:50Z │ 20239039604 │ Windows D3D12 QC DXC         │ PASS        │ Feature/CBuffer/structs.test │
│  4 │ 2025-12-15T12:12:41Z │ 20231746387 │ Windows D3D12 Warp DXC       │ PASS        │ Feature/CBuffer/structs.test │
│  5 │ 2025-12-15T16:01:28Z │ 20238764704 │ Windows ARM64 D3D12 Warp DXC │ PASS        │ Feature/CBuffer/structs.test │
│  6 │ 2025-12-15T17:41:13Z │ 20241796481 │ macOS Metal DXC              │ UNSUPPORTED │ Feature/CBuffer/structs.test │
│  7 │ 2025-12-15T12:08:25Z │ 20231623950 │ Windows Vulkan AMD DXC       │ XPASS       │ Feature/CBuffer/structs.test │
│  8 │ 2025-12-15T16:02:56Z │ 20238811740 │ Windows Vulkan Intel DXC     │ XPASS       │ Feature/CBuffer/structs.test │
│  9 │ 2025-12-15T16:08:16Z │ 20238987911 │ Windows Vulkan NVIDIA DXC    │ XPASS       │ Feature/CBuffer/structs.test │
│ 10 │ 2025-12-15T16:03:22Z │ 20238826498 │ Windows Vulkan QC DXC        │ XPASS       │ Feature/CBuffer/structs.test │
╰────┴──────────────────────┴─────────────┴──────────────────────────────┴─────────────┴──────────────────────────────╯
```