### PR TITLE
Revert "Add XFAIL to tests that regressed on Vulkan after vector swizzle store fix (#547)"

### DIFF
--- a/test/Feature/HLSLLib/abs.32.test
+++ b/test/Feature/HLSLLib/abs.32.test
@@ -134,9 +134,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug https://github.com/llvm/llvm-project/issues/170241
-# XFAIL: Clang && Vulkan
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/abs.int16.test
+++ b/test/Feature/HLSLLib/abs.int16.test
@@ -94,9 +94,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug https://github.com/llvm/llvm-project/issues/170241
-# XFAIL: Clang && Vulkan
-
 # REQUIRES: Int16
 # RUN: split-file %s %t
 # RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/abs.int64.test
+++ b/test/Feature/HLSLLib/abs.int64.test
@@ -94,9 +94,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug https://github.com/llvm/llvm-project/issues/170241
-# XFAIL: Clang && Vulkan
-
 # REQUIRES: Int64
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/countbits.32.test
+++ b/test/Feature/HLSLLib/countbits.32.test
@@ -90,9 +90,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug https://github.com/llvm/llvm-project/issues/170241
-# XFAIL: Clang && Vulkan
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/isinf.16.test
+++ b/test/Feature/HLSLLib/isinf.16.test
@@ -55,9 +55,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug https://github.com/llvm/llvm-project/issues/170241
-# XFAIL: Clang && Vulkan
-
 # A bug in the Metal Shader Converter caused it to mis-translate this operation.
 # Version 3 fixes this issue.
 # UNSUPPORTED: Clang && Metal && !metal-shaderconverter-3.0.0-or-later

--- a/test/Feature/HLSLLib/isinf.32.test
+++ b/test/Feature/HLSLLib/isinf.32.test
@@ -55,9 +55,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug https://github.com/llvm/llvm-project/issues/170241
-# XFAIL: Clang && Vulkan
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/saturate.32.test
+++ b/test/Feature/HLSLLib/saturate.32.test
@@ -46,9 +46,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug https://github.com/llvm/llvm-project/issues/170241
-# XFAIL: Clang && Vulkan
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s

--- a/test/Feature/HLSLLib/sign.32.test
+++ b/test/Feature/HLSLLib/sign.32.test
@@ -173,9 +173,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug https://github.com/llvm/llvm-project/issues/170241
-# XFAIL: Clang && Vulkan
-
 # We're generating invalid SPIRV for this. I have _no_ idea why this isn't
 # failing on all Clang Vulkan tests.
 # Bug https://github.com/llvm/llvm-project/issues/149722

--- a/test/Feature/HLSLLib/sign.fp16.test
+++ b/test/Feature/HLSLLib/sign.fp16.test
@@ -97,9 +97,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug https://github.com/llvm/llvm-project/issues/170241
-# XFAIL: Clang && Vulkan
-
 # REQUIRES: Half
 # RUN: split-file %s %t
 # RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/sign.fp64.test
+++ b/test/Feature/HLSLLib/sign.fp64.test
@@ -92,9 +92,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug https://github.com/llvm/llvm-project/issues/170241
-# XFAIL: Clang && Vulkan
-
 # REQUIRES: Double
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/sign.int16.test
+++ b/test/Feature/HLSLLib/sign.int16.test
@@ -94,9 +94,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug https://github.com/llvm/llvm-project/issues/170241
-# XFAIL: Clang && Vulkan
-
 # Bug https://github.com/microsoft/DirectXShaderCompiler/issues/7755
 # XFAIL: DXC && Vulkan
 

--- a/test/Feature/HLSLLib/sign.int64.test
+++ b/test/Feature/HLSLLib/sign.int64.test
@@ -94,9 +94,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug https://github.com/llvm/llvm-project/issues/170241
-# XFAIL: Clang && Vulkan
-
 # Bug https://github.com/microsoft/DirectXShaderCompiler/issues/7755
 # XFAIL: DXC && Vulkan
 

--- a/test/Feature/StructuredBuffer/layout.test
+++ b/test/Feature/StructuredBuffer/layout.test
@@ -87,9 +87,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug https://github.com/llvm/llvm-project/issues/170241
-# XFAIL: Clang && Vulkan
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 %if Vulkan %{ -fvk-use-dx-layout %} -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s

--- a/test/WaveOps/WaveReadLaneAt.16.test
+++ b/test/WaveOps/WaveReadLaneAt.16.test
@@ -135,10 +135,6 @@ DescriptorSets:
         Binding: 5
 ...
 #--- end
-
-# Bug https://github.com/llvm/llvm-project/issues/170241
-# XFAIL: Clang && Vulkan
-
 # Bug https://github.com/llvm/offload-test-suite/issues/351
 # XFAIL: Metal
 

--- a/test/WaveOps/WaveReadLaneAt.32.test
+++ b/test/WaveOps/WaveReadLaneAt.32.test
@@ -175,9 +175,6 @@ DescriptorSets:
 # Bug https://github.com/llvm/offload-test-suite/issues/351
 # XFAIL: Metal
 
-# Bug https://github.com/llvm/llvm-project/issues/170241
-# XFAIL: Clang && Vulkan
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Gis -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/WaveOps/WaveReadLaneAt.Float.64.test
+++ b/test/WaveOps/WaveReadLaneAt.Float.64.test
@@ -62,9 +62,6 @@ DescriptorSets:
 # Bug https://github.com/llvm/offload-test-suite/issues/533
 # XFAIL: DirectX && AMD
 
-# Bug https://github.com/llvm/llvm-project/issues/170241
-# XFAIL: Clang && Vulkan
-
 # REQUIRES: Double
 
 # RUN: split-file %s %t

--- a/test/WaveOps/WaveReadLaneAt.Int.64.test
+++ b/test/WaveOps/WaveReadLaneAt.Int.64.test
@@ -103,9 +103,6 @@ DescriptorSets:
 # Bug https://github.com/llvm/offload-test-suite/issues/533
 # XFAIL: DirectX && AMD
 
-# Bug https://github.com/llvm/llvm-project/issues/170241
-# XFAIL: Clang && Vulkan
-
 # REQUIRES: Int64
 
 # RUN: split-file %s %t


### PR DESCRIPTION
This reverts commit 6d549f06180db1b0c33132e2042963c6828aba9b from https://github.com/llvm/offload-test-suite/pull/547 which added XFAILs that are now fixed.
- https://github.com/llvm/llvm-project/issues/170241

```
╭────┬──────────────────────┬─────────────┬────────────────────────────┬────────┬──────────────────────────────────────╮
│  # │      timestamp       │   run-id    │          workflow          │ status │                 test                 │
├────┼──────────────────────┼─────────────┼────────────────────────────┼────────┼──────────────────────────────────────┤
│  0 │ 2025-12-15T16:06:15Z │ 20238920570 │ Windows Vulkan Intel Clang │ XPASS  │ Feature/HLSLLib/abs.32.test          │
│  1 │ 2025-12-15T16:06:15Z │ 20238920570 │ Windows Vulkan Intel Clang │ XPASS  │ Feature/HLSLLib/abs.int16.test       │
│  2 │ 2025-12-15T16:06:15Z │ 20238920570 │ Windows Vulkan Intel Clang │ XPASS  │ Feature/HLSLLib/abs.int64.test       │
│  3 │ 2025-12-15T16:06:15Z │ 20238920570 │ Windows Vulkan Intel Clang │ XPASS  │ Feature/HLSLLib/countbits.32.test    │
│  4 │ 2025-12-15T16:06:15Z │ 20238920570 │ Windows Vulkan Intel Clang │ XPASS  │ Feature/HLSLLib/isinf.16.test        │
│  5 │ 2025-12-15T16:06:15Z │ 20238920570 │ Windows Vulkan Intel Clang │ XPASS  │ Feature/HLSLLib/isinf.32.test        │
│  6 │ 2025-12-15T16:06:15Z │ 20238920570 │ Windows Vulkan Intel Clang │ XPASS  │ Feature/HLSLLib/saturate.32.test     │
│  7 │ 2025-12-15T16:06:15Z │ 20238920570 │ Windows Vulkan Intel Clang │ XPASS  │ Feature/HLSLLib/sign.32.test         │
│  8 │ 2025-12-15T16:06:15Z │ 20238920570 │ Windows Vulkan Intel Clang │ XPASS  │ Feature/HLSLLib/sign.fp16.test       │
│  9 │ 2025-12-15T16:06:15Z │ 20238920570 │ Windows Vulkan Intel Clang │ XPASS  │ Feature/HLSLLib/sign.fp64.test       │
│ 10 │ 2025-12-15T16:06:15Z │ 20238920570 │ Windows Vulkan Intel Clang │ XPASS  │ Feature/HLSLLib/sign.int16.test      │
│ 11 │ 2025-12-15T16:06:15Z │ 20238920570 │ Windows Vulkan Intel Clang │ XPASS  │ Feature/HLSLLib/sign.int64.test      │
│ 12 │ 2025-12-15T16:06:15Z │ 20238920570 │ Windows Vulkan Intel Clang │ XPASS  │ Feature/StructuredBuffer/layout.test │
│ 13 │ 2025-12-15T16:06:15Z │ 20238920570 │ Windows Vulkan Intel Clang │ XPASS  │ WaveOps/WaveReadLaneAt.16.test       │
│ 14 │ 2025-12-15T16:06:15Z │ 20238920570 │ Windows Vulkan Intel Clang │ XPASS  │ WaveOps/WaveReadLaneAt.32.test       │
│ 15 │ 2025-12-15T16:06:15Z │ 20238920570 │ Windows Vulkan Intel Clang │ XPASS  │ WaveOps/WaveReadLaneAt.Float.64.test │
│ 16 │ 2025-12-15T16:06:15Z │ 20238920570 │ Windows Vulkan Intel Clang │ XPASS  │ WaveOps/WaveReadLaneAt.Int.64.test   │
╰────┴──────────────────────┴─────────────┴────────────────────────────┴────────┴──────────────────────────────────────╯
```

(showing only Intel for brevity. The AMD and NVIDIA machines are also XPASSing all the same tests)
- https://github.com/llvm/offload-test-suite/actions/runs/20242414860/job/58113699880#step:12:2961
- https://github.com/llvm/offload-test-suite/actions/runs/20242557621/job/58114180211#step:12:2891