### PR TITLE
[DXC][Vulkan] Remove XFAIL for `asdouble` test.

### DIFF
--- a/test/Feature/HLSLLib/asdouble.32.test
+++ b/test/Feature/HLSLLib/asdouble.32.test
@@ -82,9 +82,6 @@ DescriptorSets:
         Binding: 2
 #--- end
 
-# Bug https://github.com/microsoft/DirectXShaderCompiler/issues/7699
-# XFAIL: DXC && Vulkan
-
 # REQUIRES: Double
 # RUN: split-file %s %t
 # RUN: %dxc_target -HV 202x -T cs_6_5 -Fo %t.o %t/source.hlsl


### PR DESCRIPTION
[Issue](https://github.com/microsoft/DirectXShaderCompiler/issues/7699) is fixed