### PR TITLE
Remove QC DirectX Clang XFAIL from WaveOps/WaveActiveSum.fp16.test

### DIFF
--- a/test/WaveOps/WaveActiveSum.fp16.test
+++ b/test/WaveOps/WaveActiveSum.fp16.test
@@ -177,9 +177,6 @@ DescriptorSets:
 # Bug https://github.com/llvm/offload-test-suite/issues/525
 # XFAIL: NV && Clang && DirectX
 
-# Bug https://github.com/llvm/offload-test-suite/issues/528
-# XFAIL: QC && Clang && DirectX
-
 # Bug https://github.com/llvm/offload-test-suite/issues/393
 # XFAIL: Metal
 


### PR DESCRIPTION
The test is now XPASSing, so the corresponding issue has been closed.
- https://github.com/llvm/offload-test-suite/issues/528