### PR TITLE
Make QC cron jobs run every 6 hours instead of 2

### DIFF
--- a/.github/workflows/windows-qc-clang-d3d12.yaml
+++ b/.github/workflows/windows-qc-clang-d3d12.yaml
@@ -7,7 +7,7 @@ permissions:
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 */2 * * *' # run every 2 hours
+    - cron: '0 */6 * * *' # run every 6 hours
   pull_request:
     paths:
      - .github/workflows/windows-qc-clang-d3d12.yaml

--- a/.github/workflows/windows-qc-clang-vk.yaml
+++ b/.github/workflows/windows-qc-clang-vk.yaml
@@ -7,7 +7,7 @@ permissions:
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 */2 * * *' # run every 2 hours
+    - cron: '0 */6 * * *' # run every 6 hours
   pull_request:
     paths:
      - .github/workflows/windows-qc-clang-vk.yaml

--- a/.github/workflows/windows-qc-clang-warp-d3d12.yaml
+++ b/.github/workflows/windows-qc-clang-warp-d3d12.yaml
@@ -7,7 +7,7 @@ permissions:
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 */2 * * *' # run every 2 hours
+    - cron: '0 */6 * * *' # run every 6 hours
   pull_request:
     paths:
      - .github/workflows/windows-qc-clang-warp-d3d12.yaml

--- a/.github/workflows/windows-qc-dxc-d3d12.yaml
+++ b/.github/workflows/windows-qc-dxc-d3d12.yaml
@@ -7,7 +7,7 @@ permissions:
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 */2 * * *' # run every 2 hours
+    - cron: '0 */6 * * *' # run every 6 hours
   pull_request:
     paths:
      - .github/workflows/windows-qc-dxc-d3d12.yaml

--- a/.github/workflows/windows-qc-dxc-vk.yaml
+++ b/.github/workflows/windows-qc-dxc-vk.yaml
@@ -7,7 +7,7 @@ permissions:
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 */2 * * *' # run every 2 hours
+    - cron: '0 */6 * * *' # run every 6 hours
   pull_request:
     paths:
      - .github/workflows/windows-qc-dxc-vk.yaml

--- a/.github/workflows/windows-qc-dxc-warp-d3d12.yaml
+++ b/.github/workflows/windows-qc-dxc-warp-d3d12.yaml
@@ -7,7 +7,7 @@ permissions:
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 */2 * * *' # run every 2 hours
+    - cron: '0 */6 * * *' # run every 6 hours
   pull_request:
     paths:
      - .github/workflows/windows-qc-dxc-warp-d3d12.yaml


### PR DESCRIPTION
The HLSLPC-QC01 machine takes up to 53 minutes to complete one of its scheduled cron jobs (e.g., Windows ARM64 D3D12 Warp Clang: https://github.com/llvm/offload-test-suite/actions/runs/20321532212). If applicable, sccache reduces the time to around 15 minutes (e.g., Windows ARM64 D3D12 Warp DXC: https://github.com/llvm/offload-test-suite/actions/runs/20323987958)

The machine is currently scheduled to run 6 different cron jobs every 2 hours, which exceeds the rate at which the machine can complete all of them and therefore the machine falls behind schedule:
<img width="1323" height="917" alt="image" src="https://github.com/user-attachments/assets/e0b22804-6d15-4663-b24e-864457623c11" />

This PR schedules the cron jobs to run every 6 hours instead of 2, which is the same as for the AMD machine (e.g., https://github.com/llvm/offload-test-suite/blob/main/.github/workflows/windows-amd-clang-warp-d3d12.yaml)

These are the 6 different workflows the QC machine is running:

| Testing Machine | DXC | Clang |
|-----------------|-----|-------|
| Windows DirectX12 Warp (arm64 LKG) | [![DXC](https://github.com/llvm/offload-test-suite/actions/workflows/windows-qc-dxc-warp-d3d12.yaml/badge.svg)](https://github.com/llvm/offload-test-suite/actions/workflows/windows-qc-dxc-warp-d3d12.yaml) | [![Clang](https://github.com/llvm/offload-test-suite/actions/workflows/windows-qc-clang-warp-d3d12.yaml/badge.svg)](https://github.com/llvm/offload-test-suite/actions/workflows/windows-qc-clang-warp-d3d12.yaml) |
| Windows DirectX12 Qualcomm GPU | [![DXC](https://github.com/llvm/offload-test-suite/actions/workflows/windows-qc-dxc-d3d12.yaml/badge.svg)](https://github.com/llvm/offload-test-suite/actions/workflows/windows-qc-dxc-d3d12.yaml) | [![Clang](https://github.com/llvm/offload-test-suite/actions/workflows/windows-qc-clang-d3d12.yaml/badge.svg)](https://github.com/llvm/offload-test-suite/actions/workflows/windows-qc-clang-d3d12.yaml) |
| Windows Vulkan Qualcomm GPU | [![DXC](https://github.com/llvm/offload-test-suite/actions/workflows/windows-qc-dxc-vk.yaml/badge.svg)](https://github.com/llvm/offload-test-suite/actions/workflows/windows-qc-dxc-vk.yaml) | [![Clang](https://github.com/llvm/offload-test-suite/actions/workflows/windows-qc-clang-vk.yaml/badge.svg)](https://github.com/llvm/offload-test-suite/actions/workflows/windows-qc-clang-vk.yaml) |
