### PR TITLE
[Matrix] Fix build break from merging const single subscript swizzle

### DIFF
--- a/test/Basic/Matrix/matrix_const_single_subscript.i2x3.test
+++ b/test/Basic/Matrix/matrix_const_single_subscript.i2x3.test
@@ -96,9 +96,6 @@ DescriptorSets:
 # Unimplemented: https://github.com/llvm/llvm-project/issues/170534
 # XFAIL: Vulkan && Clang
 
-# Bug: https://github.com/llvm/llvm-project/issues/172805
-# XFAIL: Clang
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Basic/Matrix/matrix_const_single_subscript.test
+++ b/test/Basic/Matrix/matrix_const_single_subscript.test
@@ -66,9 +66,6 @@ DescriptorSets:
 # Unimplemented: https://github.com/llvm/llvm-project/issues/170534
 # XFAIL: Vulkan && Clang
 
-# Bug: https://github.com/llvm/llvm-project/issues/172805
-# XFAIL: Clang
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
We merged a fix for https://github.com/llvm/llvm-project/issues/172805
in this commit: https://github.com/llvm/llvm-project/commit/d48050ab272245db1491f5c791d44ad963e26949

This change removes the XFAILs