### PR TITLE
Remove erroneously marked XFAIL

### DIFF
--- a/test/Basic/Matrix/matrix_const_single_subscript.test
+++ b/test/Basic/Matrix/matrix_const_single_subscript.test
@@ -63,9 +63,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Unimplemented: https://github.com/llvm/llvm-project/issues/170534
-# XFAIL: Vulkan && Clang
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
This test started XPASSing after #634, which removed the other XFAIL in the file. As far as I can tell #170534 isn't relevant to this test and it was simply marked incorrectly.