### PR TITLE
[NFC] Replace deprecated `llvm::make_scope_exit` with `llvm::scope_exit`

### DIFF
--- a/lib/Image/Image.cpp
+++ b/lib/Image/Image.cpp
@@ -125,7 +125,7 @@ static llvm::Error writePNGImpl(ImageRef Img, llvm::StringRef OutputPath) {
                                    "Failed creating PNG data");
   png_infop PNGInfo = png_create_info_struct(PNG);
   FILE *F = nullptr;
-  llvm::scope_exit ScopeExit([&PNG, &PNGInfo, &F]() {
+  const llvm::scope_exit ScopeExit([&PNG, &PNGInfo, &F]() {
     png_destroy_write_struct(&PNG, &PNGInfo);
     if (F)
       fclose(F);
@@ -192,7 +192,7 @@ llvm::Expected<Image> Image::loadPNG(llvm::StringRef Path) {
     return llvm::createStringError(std::errc::io_error,
                                    "Failed reading PNG header from file");
 
-  llvm::scope_exit ScopeExit([&PNG]() { png_image_free(&PNG); });
+  const llvm::scope_exit ScopeExit([&PNG]() { png_image_free(&PNG); });
 
   PNG.format = PNG_FORMAT_RGB;
   const size_t Size = PNG_IMAGE_SIZE(PNG);


### PR DESCRIPTION
This PR fixes a build breakage caused due to https://github.com/llvm/llvm-project/pull/174109 which deprecates `llvm::make_scope_exit` in favor of `llvm::scope_exit` (CTAD).

The replacement is rather simple and uses the same pattern as PR https://github.com/llvm/llvm-project/pull/174030