### PR TITLE
Remove XFAIL from passing matrix tests

### DIFF
--- a/test/Basic/Matrix/matrix_elementwise_cast.test
+++ b/test/Basic/Matrix/matrix_elementwise_cast.test
@@ -99,9 +99,6 @@ DescriptorSets:
         Binding: 3
 ...
 #--- end
-# Unimplemented: https://github.com/llvm/llvm-project/issues/170534
-# XFAIL: Vulkan && Clang
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Basic/Matrix/matrix_scalar_arithmetic.test
+++ b/test/Basic/Matrix/matrix_scalar_arithmetic.test
@@ -83,9 +83,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug https://github.com/llvm/offload-test-suite/issues/538
-# XFAIL: Clang && Vulkan
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s

--- a/test/Basic/Matrix/matrix_scalar_constructor.test
+++ b/test/Basic/Matrix/matrix_scalar_constructor.test
@@ -56,9 +56,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug https://github.com/llvm/offload-test-suite/issues/538
-# XFAIL: Clang && Vulkan
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
These tests were marked as XFAIL but are now passing. Removing the XFAIL directive.

Tests:
- Basic/Matrix/matrix_elementwise_cast.test
- Basic/Matrix/matrix_scalar_arithmetic.test
- Basic/Matrix/matrix_scalar_constructor.test

Fixes https://github.com/llvm/offload-test-suite/issues/538
