### PR TITLE
[Matrix] Remove xfail for dynamic indexing of single subscript operator

### DIFF
--- a/test/Basic/Matrix/matrix_single_subscript_load.test
+++ b/test/Basic/Matrix/matrix_single_subscript_load.test
@@ -64,9 +64,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Unimplemented: https://github.com/llvm/llvm-project/issues/170534
-# XFAIL: Vulkan && Clang
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Basic/Matrix/matrix_single_subscript_store.test
+++ b/test/Basic/Matrix/matrix_single_subscript_store.test
@@ -65,9 +65,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Unimplemented: https://github.com/llvm/llvm-project/issues/170534
-# XFAIL: Vulkan && Clang
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
After https://github.com/llvm/llvm-project/pull/170777 this change no longer needs to be xfailing for all of clang.