### PR TITLE
[Vulkan] Increase test coverage for push constants

### DIFF
--- a/test/Feature/PushConstant/array_of_matrices.test
+++ b/test/Feature/PushConstant/array_of_matrices.test
@@ -80,7 +80,7 @@ DescriptorSets:
 #   Bug: https://github.com/microsoft/DirectXShaderCompiler/issues/8080
 
 # RUN: split-file %s %t
-# RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -fvk-use-dx-layout -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s
 
 # CHECK: Name: output

--- a/test/Feature/PushConstant/arrays.test
+++ b/test/Feature/PushConstant/arrays.test
@@ -44,7 +44,7 @@ DescriptorSets:
 # UNSUPPORTED: Metal || DirectX
 
 # RUN: split-file %s %t
-# RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -fvk-use-dx-layout -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s
 
 # CHECK: Name: output

--- a/test/Feature/PushConstant/bool.test
+++ b/test/Feature/PushConstant/bool.test
@@ -46,7 +46,7 @@ DescriptorSets:
 # UNSUPPORTED: Metal || DirectX
 
 # RUN: split-file %s %t
-# RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -fvk-use-dx-layout -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s
 
 # CHECK: Name: output

--- a/test/Feature/PushConstant/explicit_offset.test
+++ b/test/Feature/PushConstant/explicit_offset.test
@@ -49,7 +49,7 @@ DescriptorSets:
 # XFAIL: Clang
 
 # RUN: split-file %s %t
-# RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -fvk-use-dx-layout -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s
 
 # CHECK: Name: output

--- a/test/Feature/PushConstant/matrix.test
+++ b/test/Feature/PushConstant/matrix.test
@@ -45,7 +45,7 @@ DescriptorSets:
 # XFAIL: Clang
 
 # RUN: split-file %s %t
-# RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -fvk-use-dx-layout -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s
 
 # CHECK: Name: output

--- a/test/Feature/PushConstant/matrix_packing.test
+++ b/test/Feature/PushConstant/matrix_packing.test
@@ -64,7 +64,7 @@ DescriptorSets:
 # XFAIL: Clang
 
 # RUN: split-file %s %t
-# RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -fvk-use-dx-layout -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s
 
 # CHECK: Name: output

--- a/test/Feature/PushConstant/methods.test
+++ b/test/Feature/PushConstant/methods.test
@@ -48,7 +48,7 @@ DescriptorSets:
 # UNSUPPORTED: Metal || DirectX
 
 # RUN: split-file %s %t
-# RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -fvk-use-dx-layout -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s
 
 # CHECK: Name: output

--- a/test/Feature/PushConstant/mixed_types.test
+++ b/test/Feature/PushConstant/mixed_types.test
@@ -62,7 +62,7 @@ DescriptorSets:
 # UNSUPPORTED: Metal || DirectX
 
 # RUN: split-file %s %t
-# RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -fvk-use-dx-layout -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s
 
 # CHECK: Name: output

--- a/test/Feature/PushConstant/nested_structs.test
+++ b/test/Feature/PushConstant/nested_structs.test
@@ -59,7 +59,7 @@ DescriptorSets:
 # UNSUPPORTED: Metal || DirectX
 
 # RUN: split-file %s %t
-# RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -fvk-use-dx-layout -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s
 
 # CHECK: Name: output

--- a/test/Feature/PushConstant/padding.test
+++ b/test/Feature/PushConstant/padding.test
@@ -48,7 +48,7 @@ DescriptorSets:
 # UNSUPPORTED: Metal || DirectX
 
 # RUN: split-file %s %t
-# RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -fvk-use-dx-layout -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s
 
 # CHECK: Name: output

--- a/test/Feature/PushConstant/static_member.test
+++ b/test/Feature/PushConstant/static_member.test
@@ -51,7 +51,7 @@ DescriptorSets:
 # UNSUPPORTED: Metal || DirectX
 
 # RUN: split-file %s %t
-# RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -fvk-use-dx-layout -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s
 
 # CHECK: Name: output

--- a/test/Feature/PushConstant/types.test
+++ b/test/Feature/PushConstant/types.test
@@ -59,7 +59,7 @@ DescriptorSets:
 # UNSUPPORTED: Metal || DirectX
 
 # RUN: split-file %s %t
-# RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -fvk-use-dx-layout -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s
 
 # CHECK: Name: output

--- a/test/Feature/PushConstant/types_16bit.test
+++ b/test/Feature/PushConstant/types_16bit.test
@@ -54,7 +54,7 @@ DescriptorSets:
 # XFAIL: Clang
 
 # RUN: split-file %s %t
-# RUN: %dxc_target -T cs_6_6 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -fvk-use-dx-layout -T cs_6_6 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s
 
 # CHECK: Name: output

--- a/test/Feature/PushConstant/types_64bit.test
+++ b/test/Feature/PushConstant/types_64bit.test
@@ -74,7 +74,7 @@ DescriptorSets:
 # REQUIRES: Double, Int64
 
 # RUN: split-file %s %t
-# RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -fvk-use-dx-layout -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s
 
 # CHECK: Name: output_d


### PR DESCRIPTION
Adds multiple tests focusing on alternative types, offsets and nested structs.