### PR TITLE
[WARP] Mark some tests as XFAIL

### DIFF
--- a/test/WaveOps/WaveReadLaneFirst.fp64.test
+++ b/test/WaveOps/WaveReadLaneFirst.fp64.test
@@ -315,6 +315,7 @@ DescriptorSets:
 
 # Bug https://github.com/llvm/offload-test-suite/issues/433
 # XFAIL: WARP && arm64
+# XFAIL: WARP && DXC
 
 REQUIRES: Double
 

--- a/test/WaveOps/WaveReadLaneFirst.int64.test
+++ b/test/WaveOps/WaveReadLaneFirst.int64.test
@@ -312,8 +312,9 @@ DescriptorSets:
 # Bug https://github.com/llvm/offload-test-suite/issues/393
 # XFAIL: Metal
 
-# XFAIL: WARP && arm64
 # Bug https://github.com/llvm/offload-test-suite/issues/433
+# XFAIL: WARP && arm64
+# XFAIL: WARP && DXC
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl


### PR DESCRIPTION
Those tests are already broken. Marking them as such. Seems like the issue is not only ARM related.