### PR TITLE
Remove use of denorm in mad fp16 test because we can't specify denorm preserve across compilers

### DIFF
--- a/test/Feature/HLSLLib/mad.fp16.test
+++ b/test/Feature/HLSLLib/mad.fp16.test
@@ -24,8 +24,8 @@ Buffers:
   - Name: M
     Format: Float16
     Stride: 8
-    Data: [ 0x7e00, 0xfc00, 0x03FF, 0x8000, 0x0000, 0x7c00, 0x3c00, 0xbc00, 0x0000, 0x3c00, 0x3e00, 0xc300 ]
-    # NaN, -Inf, denorm, -0, 0, Inf, 1, -1, 0, 1, 1.5, -3.5
+    Data: [ 0x7e00, 0xfc00, 0x4500, 0x8000, 0x0000, 0x7c00, 0x3c00, 0xbc00, 0x0000, 0x3c00, 0x3e00, 0xc300 ]
+    # NaN, -Inf, 5, -0, 0, Inf, 1, -1, 0, 1, 1.5, -3.5
   - Name: A
     Format: Float16
     Stride: 8
@@ -34,8 +34,8 @@ Buffers:
   - Name: B
     Format: Float16
     Stride: 8
-    Data: [ 0x7e00, 0xfc00, 0x03FF, 0x8000, 0x0000, 0x7c00, 0x3c00, 0xbc00, 0x3c00, 0x0000, 0xc580, 0x3c00 ]
-    # NaN, -Inf, denorm, -0, 0, Inf, 1, -1, 1, 0, -5.5, 1
+    Data: [ 0x7e00, 0xfc00, 0x4500, 0x8000, 0x0000, 0x7c00, 0x3c00, 0xbc00, 0x3c00, 0x0000, 0xc580, 0x3c00 ]
+    # NaN, -Inf, 5, -0, 0, Inf, 1, -1, 1, 0, -5.5, 1
   - Name: Out
     Format: Float16
     Stride: 8
@@ -43,8 +43,8 @@ Buffers:
   - Name: ExpectedOut
     Format: Float16
     Stride: 8
-    Data: [ 0x7e00, 0x7e00, 0x07FE, 0x0000, 0x0000, 0x7c00, 0x4000, 0, 0x3c00, 0x3c00, 0x48c0, 0xcc20, 0x4000, 0x48c0, 0x7c00, 0xfc00 ]
-    # NaN, NaN, 0.00012195110, 0, 0, Inf, 2, 0, 1, 1, 9.5, -16.5, 2, 9.5, Inf, -Inf
+    Data: [ 0x7e00, 0x7e00, 0x4900, 0x0000, 0x0000, 0x7c00, 0x4000, 0, 0x3c00, 0x3c00, 0x48c0, 0xcc20, 0x4000, 0x48c0, 0x7c00, 0xfc00 ]
+    # NaN, NaN, 10, 0, 0, Inf, 2, 0, 1, 1, 9.5, -16.5, 2, 9.5, Inf, -Inf
 Results:
   - Result: Test0
     Rule: BufferFloatULP
@@ -83,14 +83,8 @@ DescriptorSets:
         Binding: 3
 #--- end
 
-# Bug https://github.com/llvm/offload-test-suite/issues/562
-# XFAIL: QC && Vulkan
-
-# Bug https://github.com/llvm/offload-test-suite/issues/563
-# XFAIL: NV && Vulkan
-
 # REQUIRES: Half
 # RUN: split-file %s %t
-# RUN: %dxc_target %if Vulkan %{ -denorm preserve %} -enable-16bit-types -Gis -HV 202x -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -enable-16bit-types -Gis -HV 202x -T cs_6_5 -Fo %t.o %t/source.hlsl
 
 # RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
Remove use of denorm values in this test because although using '-denorm preserve' for DXC makes this test pass on the machines it is failing on, there is currently no option in the clang compiler. So, the test would still need to be xfailed for the clang compiler. 

Closes #563
Closes #562