### PR TITLE
Add tests for concurrent writes to matrices

### DIFF
--- a/test/WaveOps/GroupSharedMatrixEltComponentDataRace.test
+++ b/test/WaveOps/GroupSharedMatrixEltComponentDataRace.test
@@ -62,9 +62,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug: https://github.com/llvm/llvm-project/issues/174629
-# XFAIL: Clang && !WARP
-
 # Bug https://github.com/llvm/llvm-project/issues/172577
 # XFAIL: Clang && Vulkan
 

--- a/test/WaveOps/GroupSharedMatrixRowComponentDataRace.test
+++ b/test/WaveOps/GroupSharedMatrixRowComponentDataRace.test
@@ -64,9 +64,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug: https://github.com/llvm/llvm-project/issues/174629
-# XFAIL: Clang && !WARP
-
 # Bug https://github.com/llvm/llvm-project/issues/172577
 # XFAIL: Clang && Vulkan
 


### PR DESCRIPTION
Adds new offload tests as mentioned should be done in https://github.com/llvm/llvm-project/issues/174629

These tests are concurrently writing to a matrix in groupshared memory instead of directly in UAVs because the writing of matrices to UAVs is not currently implemented in Clang.

The XFAIL on Clang with bug https://github.com/llvm/llvm-project/issues/174629 can be removed after https://github.com/llvm/llvm-project/pull/176216 is merged.

