### PR TITLE
Revert "XFAIL Clang in `Feature/HLSLLib/adduint64.test` due to failure to compile the shader (#658)"

### DIFF
--- a/test/Feature/HLSLLib/adduint64.test
+++ b/test/Feature/HLSLLib/adduint64.test
@@ -63,9 +63,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug https://github.com/llvm/llvm-project/issues/176495
-# XFAIL: Clang
-
 # Bug https://github.com/llvm/offload-test-suite/issues/292
 # XFAIL: DXC && Metal
 


### PR DESCRIPTION
This reverts commit 926a8d98505a64092fe6cc715fc30cbf0b556523 from PR #658 because the corresponding issue for the XFAIL got fixed and the affected test is now XPASSing on all Clang targets.