### PR TITLE
XFAIL Vulkan && Clang in affected matrix single subscript tests

### DIFF
--- a/test/Basic/Matrix/matrix_const_single_subscript.i2x3.test
+++ b/test/Basic/Matrix/matrix_const_single_subscript.i2x3.test
@@ -93,6 +93,9 @@ DescriptorSets:
 ...
 #--- end
 
+# Bug: https://github.com/llvm/offload-test-suite/issues/660
+# XFAIL: Vulkan && Clang
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Basic/Matrix/matrix_single_subscript_basic.i2x3.test
+++ b/test/Basic/Matrix/matrix_single_subscript_basic.i2x3.test
@@ -93,6 +93,9 @@ DescriptorSets:
 ...
 #--- end
 
+# Bug: https://github.com/llvm/offload-test-suite/issues/660
+# XFAIL: Vulkan && Clang
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Basic/Matrix/matrix_single_subscript_basic.i3x2.test
+++ b/test/Basic/Matrix/matrix_single_subscript_basic.i3x2.test
@@ -97,6 +97,9 @@ DescriptorSets:
 ...
 #--- end
 
+# Bug: https://github.com/llvm/offload-test-suite/issues/660
+# XFAIL: Vulkan && Clang
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Basic/Matrix/matrix_single_subscript_basic.test
+++ b/test/Basic/Matrix/matrix_single_subscript_basic.test
@@ -99,6 +99,9 @@ DescriptorSets:
 ...
 #--- end
 
+# Bug: https://github.com/llvm/offload-test-suite/issues/660
+# XFAIL: Vulkan && Clang
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
New failures appearing in matrix single subscript tests under Vulkan with Clang. The issue is being tracked by https://github.com/llvm/llvm-project/issues/176995 and will be XFAILed by this PR for now while the issue gets triaged and fixed.