### PR TITLE
[WARP] Restrict XFAIL to Intel+WARP

### DIFF
--- a/test/WaveOps/WaveReadLaneFirst.fp64.test
+++ b/test/WaveOps/WaveReadLaneFirst.fp64.test
@@ -314,9 +314,7 @@ DescriptorSets:
 # XFAIL: AMD && DirectX
 
 # Bug https://github.com/llvm/offload-test-suite/issues/433
-# XFAIL: WARP && arm64
-# UNSUPPORTED: WARP && DXC
-# Apparently passing on AMD64, but cannot be differentiated.
+# UNSUPPORTED: WARP
 
 REQUIRES: Double
 

--- a/test/WaveOps/WaveReadLaneFirst.int64.test
+++ b/test/WaveOps/WaveReadLaneFirst.int64.test
@@ -313,9 +313,7 @@ DescriptorSets:
 # XFAIL: Metal
 
 # Bug https://github.com/llvm/offload-test-suite/issues/433
-# XFAIL: WARP && arm64
-# UNSUPPORTED: WARP && DXC
-# Apparently passing on AMD64, but cannot be differentiated.
+# UNSUPPORTED: WARP
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl


### PR DESCRIPTION
From #649, seems like those are padding for AMD64. I don't think those should be marked as unsupported as they are supposed to work for DXC (reported as supported), but yield incorrect values.