### PR TITLE
[Vulkan] Enable sign.32.test for clang vulkan mac enviornments

### DIFF
--- a/test/Feature/HLSLLib/sign.32.test
+++ b/test/Feature/HLSLLib/sign.32.test
@@ -173,11 +173,6 @@ DescriptorSets:
 ...
 #--- end
 
-# We're generating invalid SPIRV for this. I have _no_ idea why this isn't
-# failing on all Clang Vulkan tests.
-# Bug https://github.com/llvm/llvm-project/issues/149722
-# XFAIL: Clang && Vulkan && Darwin
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
fixes https://github.com/llvm/llvm-project/issues/149722

This issue was already fixed but since we don't test MoltenVK we didn't see it go green. This change just removes the unecessary XFAIL.