### PR TITLE
Fix warning with Sampler Resource Kind on Metal

### DIFF
--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -289,6 +289,8 @@ class MTLDevice : public offloadtest::Device {
         Desc = MTL::TextureDescriptor::texture2DDescriptor(Format, Width,
                                                            Height, false);
         break;
+      case ResourceKind::Sampler:
+        llvm_unreachable("Not implemented yet.");
       case ResourceKind::StructuredBuffer:
       case ResourceKind::RWStructuredBuffer:
       case ResourceKind::ByteAddressBuffer:


### PR DESCRIPTION
This PR https://github.com/llvm/offload-test-suite/pull/650 Added a new ResourceKind::Sampler that we don't have any handling for on Metal. This change fixes the warning but does not add an implementation.