### PR TITLE
[HLSL] Add WavePrefixCountBits tests

### DIFF
--- a/test/WaveOps/WavePrefixCountBits.Wave128.test
+++ b/test/WaveOps/WavePrefixCountBits.Wave128.test
@@ -8,7 +8,7 @@ void main(uint3 tid : SV_GroupThreadID) {
   
   // this should be an ascending sequence of numbers
   Out1[tid.x] = WavePrefixCountBits(true);
-  // this should look more like 1, 1, 2, 2, 3, 3, etc.
+  // this should look more like 0, 1, 1, 2, 2, 3, 3, etc.
   Out2[tid.x] = WavePrefixCountBits(tid.x % 2 == 0);
 }
 
@@ -50,8 +50,7 @@ Buffers:
  33, 33, 34, 34, 35, 35, 36, 36, 37, 37, 38, 38, 39, 39, 40, 40,
  41, 41, 42, 42, 43, 43, 44, 44, 45, 45, 46, 46, 47, 47, 48, 48,
  49, 49, 50, 50, 51, 51, 52, 52, 53, 53, 54, 54, 55, 55, 56, 56,
- 57, 57, 58, 58, 59, 59, 60, 60, 61, 61, 62, 62, 63, 63,
- 64]
+ 57, 57, 58, 58, 59, 59, 60, 60, 61, 61, 62, 62, 63, 63, 64]
 Results:
   - Result: Test1
     Rule: BufferExact

--- a/test/WaveOps/WavePrefixCountBits.Wave32.test
+++ b/test/WaveOps/WavePrefixCountBits.Wave32.test
@@ -8,7 +8,7 @@ void main(uint3 tid : SV_GroupThreadID) {
   
   // this should be an ascending sequence of numbers
   Out1[tid.x] = WavePrefixCountBits(true);
-  // this should look more like 1, 1, 2, 2, 3, 3, etc.
+  // this should look more like 0, 1, 1, 2, 2, 3, 3, etc.
   Out2[tid.x] = WavePrefixCountBits(tid.x % 2 == 0);
 }
 

--- a/test/WaveOps/WavePrefixCountBits.Wave64.test
+++ b/test/WaveOps/WavePrefixCountBits.Wave64.test
@@ -8,7 +8,7 @@ void main(uint3 tid : SV_GroupThreadID) {
   
   // this should be an ascending sequence of numbers
   Out1[tid.x] = WavePrefixCountBits(true);
-  // this should look more like 1, 1, 2, 2, 3, 3, etc.
+  // this should look more like 0, 1, 1, 2, 2, 3, 3, etc.
   Out2[tid.x] = WavePrefixCountBits(tid.x % 2 == 0);
 }
 


### PR DESCRIPTION
This PR adds the WavePrefixCountBits tests, using 32 64 and 128-sized waves. 
Fixes https://github.com/llvm/offload-test-suite/issues/687