### PR TITLE
XFAIL AMD && DirectX in WaveActiveBallot Wave32 and Wave64 tests

### DIFF
--- a/test/WaveOps/WaveActiveBallot.Wave32.test
+++ b/test/WaveOps/WaveActiveBallot.Wave32.test
@@ -55,6 +55,9 @@ DescriptorSets:
 
 # REQUIRES: WaveSize_32
 
+# Bug: https://github.com/llvm/offload-test-suite/issues/688
+# XFAIL: AMD && DirectX
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_6 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/WaveOps/WaveActiveBallot.Wave64.test
+++ b/test/WaveOps/WaveActiveBallot.Wave64.test
@@ -55,6 +55,9 @@ DescriptorSets:
 
 # REQUIRES: WaveSize_64
 
+# Bug: https://github.com/llvm/offload-test-suite/issues/688
+# XFAIL: AMD && DirectX
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_6 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
Adds XFAILs to WaveActiveBallot tests to address observed AMD-only test failures: #688