### PR TITLE
Add Vulkan && DXC XFAIL to `Texture2D.Sample` tests

### DIFF
--- a/test/Feature/Textures/Texture2D.Sample.test.yaml
+++ b/test/Feature/Textures/Texture2D.Sample.test.yaml
@@ -157,6 +157,9 @@ Results:
 # Unimplemented: https://github.com/llvm/llvm-project/issues/175630
 # XFAIL: Clang
 
+# Bug: https://github.com/llvm/offload-test-suite/issues/690
+# XFAIL: Vulkan && DXC
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T vs_6_0 -E mainVS -Fo %t-vs.o %t/vertex.hlsl
 # RUN: %dxc_target -T ps_6_0 -E mainPS -Fo %t-ps.o %t/pixel.hlsl

--- a/test/Feature/Textures/Texture2D.SampleBias.test.yaml
+++ b/test/Feature/Textures/Texture2D.SampleBias.test.yaml
@@ -148,6 +148,9 @@ Results:
 # Unimplemented: https://github.com/llvm/llvm-project/issues/175630
 # XFAIL: Clang
 
+# Bug: https://github.com/llvm/offload-test-suite/issues/690
+# XFAIL: Vulkan && DXC
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T vs_6_0 -E mainVS -Fo %t-vs.o %t/vertex.hlsl
 # RUN: %dxc_target -T ps_6_0 -E mainPS -Fo %t-ps.o %t/pixel.hlsl

--- a/test/Feature/Textures/Texture2D.SampleCmp.test.yaml
+++ b/test/Feature/Textures/Texture2D.SampleCmp.test.yaml
@@ -180,6 +180,9 @@ Results:
 # Unimplemented: https://github.com/llvm/llvm-project/issues/175630
 # XFAIL: Clang
 
+# Bug: https://github.com/llvm/offload-test-suite/issues/690
+# XFAIL: Vulkan && DXC
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T vs_6_0 -E mainVS -Fo %t-vs.o %t/vertex.hlsl
 # RUN: %dxc_target -T ps_6_0 -E mainPS -Fo %t-ps.o %t/pixel.hlsl


### PR DESCRIPTION
XFAILs added to Texture2D.Sample tests due to observed failures, tracked under #690