### PR TITLE
Remove XFAILs from `Adjacent-Partial-Writes`, `countbits.64` and `spec_const_other_sizes` due to AMD and QC driver updates

### DIFF
--- a/test/Bugs/Adjacent-Partial-Writes.yaml
+++ b/test/Bugs/Adjacent-Partial-Writes.yaml
@@ -69,9 +69,6 @@ DescriptorSets:
 # https://github.com/llvm/llvm-project/issues/142677
 # UNSUPPORTED: Vulkan
 
-# Bug https://github.com/llvm/offload-test-suite/issues/330
-# XFAIL: AMD && DirectX
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/countbits.64.test
+++ b/test/Feature/HLSLLib/countbits.64.test
@@ -97,9 +97,6 @@ DescriptorSets:
 # https://github.com/llvm/llvm-project/issues/142677
 # UNSUPPORTED: Vulkan
 
-# Bug https://github.com/llvm/offload-test-suite/issues/331
-# XFAIL: AMD && DirectX
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/SpecializationConstant/spec_const_other_sizes.test
+++ b/test/Feature/SpecializationConstant/spec_const_other_sizes.test
@@ -45,9 +45,6 @@ DescriptorSets:
 # Bug https://github.com/microsoft/DirectXShaderCompiler/issues/7886
 # XFAIL: DXC
 
-# Bug https://github.com/llvm/offload-test-suite/issues/554
-# XFAIL: QC
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_2 -enable-16bit-types -Fo %t.o %t/simple_64bit.hlsl
 # RUN: %offloader %t/simple_64bit.yaml %t.o | FileCheck %s


### PR DESCRIPTION
As observed in the latest CI runs, the following tests are now XPASSing. Their corresponding issues have been closed and this PR removes the corresponding XFAILs.

```
╭───┬──────────────────────┬─────────────┬─────────────────────────┬────────┬────────────────────────────────────────────────────────────╮
│ # │      timestamp       │   run-id    │        workflow         │ status │                            test                            │
├───┼──────────────────────┼─────────────┼─────────────────────────┼────────┼────────────────────────────────────────────────────────────┤
│ 0 │ 2026-01-30T12:10:53Z │ 21515355359 │ Windows D3D12 AMD Clang │ XPASS  │ Bugs/Adjacent-Partial-Writes.yaml                          │
│ 1 │ 2026-01-30T12:02:42Z │ 21515137547 │ Windows D3D12 AMD DXC   │ XPASS  │ Bugs/Adjacent-Partial-Writes.yaml                          │
│ 2 │ 2026-01-30T12:10:53Z │ 21515355359 │ Windows D3D12 AMD Clang │ XPASS  │ Feature/HLSLLib/countbits.64.test                          │
│ 3 │ 2026-01-30T12:02:42Z │ 21515137547 │ Windows D3D12 AMD DXC   │ XPASS  │ Feature/HLSLLib/countbits.64.test                          │
│ 4 │ 2026-01-30T12:09:35Z │ 21515320324 │ Windows Vulkan QC Clang │ XPASS  │ Feature/SpecializationConstant/spec_const_other_sizes.test │
╰───┴──────────────────────┴─────────────┴─────────────────────────┴────────┴────────────────────────────────────────────────────────────╯
```