### PR TITLE
Add sub matrix initializer test

### DIFF
--- a/test/Basic/Matrix/matrix_construct_by_sub_mat.test
+++ b/test/Basic/Matrix/matrix_construct_by_sub_mat.test
@@ -1,0 +1,67 @@
+#--- source.hlsl
+
+RWBuffer<int> In : register(u0);
+RWBuffer<int> Out : register(u1);
+
+[numthreads(16,1,1)]
+void main(uint GI : SV_GroupIndex) {
+  int2x2 A = int2x2(In[0], In[1],
+                    In[2], In[3]);
+  int2x2 B = int2x2(In[4], In[5],
+                    In[6], In[7]);
+  int2x2 C = int2x2(In[8], In[9],
+                    In[10], In[11]);
+  int3x1 D = int3x1(In[12], In[13], In[14]);
+
+  int4x4 Mat = {A, B, C, D, In[15]};
+  const uint COLS = 4;          
+  uint row = GI / COLS;
+  uint col = GI % COLS;
+
+  Out[GI] = Mat[row][col];
+}
+
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+    DispatchSize: [1, 1, 1]
+Buffers:
+  - Name: In
+    Format: Int32
+    Data: [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
+  - Name: Out
+    Format: Int32
+    FillSize: 64
+  - Name: ExpectedOut
+    Format: Int32
+    Data: [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
+Results:
+  - Result: Out
+    Rule: BufferExact
+    Actual: Out
+    Expected: ExpectedOut
+DescriptorSets:
+  - Resources:
+    - Name: In
+      Kind: RWBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: Out
+      Kind: RWBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+...
+#--- end
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
Before This PR: https://github.com/llvm/llvm-project/pull/178931 We were not properly consuming matrix types in the initializer list.

```
Expected:
---
Name:            ExpectedOut
Format:          Int32
Data:            [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 ]
OutputProps:
  Height:          0
  Width:           0
  Depth:           0
...
Got:
---
Name:            Out
Format:          Int32
Data:            [ 1, 3, 2, 4, 5, 7, 6, 8, 9, 11, 10, 12, 13, 14, 15, 16 ]
OutputProps:
  Height:          0
  Width:           0
  Depth:           0
```

Thats because we expect row major indexing via the Matrix AST. This is a test to confirm we are consuming matrix types correctly now.