### PR TITLE
[Metal] mark SamplerComparison as not implemented

### DIFF
--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -290,6 +290,7 @@ class MTLDevice : public offloadtest::Device {
                                                            Height, false);
         break;
       case ResourceKind::Sampler:
+      case ResourceKind::SamplerComparison:
         llvm_unreachable("Not implemented yet.");
       case ResourceKind::StructuredBuffer:
       case ResourceKind::RWStructuredBuffer:


### PR DESCRIPTION
PR #650 introduced `SamplerComparison` but did not implement it for Metal. To fix the warnings will mark as not implemented for now.

Fix for warning 
```
[2/7] Building CXX object tools/OffloadTest/lib/API/CMakeFiles/OffloadTestAPI.dir/MTL/MTLDevice.cpp.o
offload-test-suite/lib/API/MTL/MTLDevice.cpp:281:15: warning: enumeration value 'SamplerComparison' not handled in switch [-Wswitch]
  281 |       switch (R.Kind) {
      |               ^~~~~~
offload-test-suite/lib/API/MTL/MTLDevice.cpp:281:15: note: add missing switch cases
  281 |       switch (R.Kind) {
      |               ^
1 warning generated.
```
