### PR TITLE
[WARP] Add O1 to temporarily fix failures due to SimplifyCFG

### DIFF
--- a/test/WaveOps/WaveActiveSum.fp16.test
+++ b/test/WaveOps/WaveActiveSum.fp16.test
@@ -171,9 +171,6 @@ DescriptorSets:
 # Bug https://github.com/llvm/llvm-project/issues/156775
 # XFAIL: Vulkan && Clang
 
-# Bug https://github.com/llvm/offload-test-suite/issues/524
-# XFAIL: WARP && Clang
-
 # Bug https://github.com/llvm/offload-test-suite/issues/525
 # XFAIL: NV && Clang && DirectX
 

--- a/test/WaveOps/WaveActiveSum.fp32.test
+++ b/test/WaveOps/WaveActiveSum.fp32.test
@@ -171,9 +171,6 @@ DescriptorSets:
 # Bug https://github.com/llvm/llvm-project/issues/156775
 # XFAIL: Vulkan && Clang
 
-# Bug https://github.com/llvm/offload-test-suite/issues/524
-# XFAIL: WARP && Clang
-
 # Bug https://github.com/llvm/offload-test-suite/issues/525
 # XFAIL: NV && Clang && DirectX
 

--- a/test/WaveOps/WaveActiveSum.fp64.test
+++ b/test/WaveOps/WaveActiveSum.fp64.test
@@ -171,7 +171,6 @@ DescriptorSets:
 # Bug https://github.com/llvm/llvm-project/issues/156775
 # XFAIL: Vulkan && Clang
 
-
 # Bug https://github.com/llvm/offload-test-suite/issues/525
 # XFAIL: NV && Clang && DirectX
 

--- a/test/WaveOps/WaveActiveSum.int16.test
+++ b/test/WaveOps/WaveActiveSum.int16.test
@@ -325,9 +325,6 @@ DescriptorSets:
 # Bug https://github.com/llvm/llvm-project/issues/156775
 # XFAIL: Vulkan && Clang
 
-# Bug https://github.com/llvm/offload-test-suite/issues/524
-# XFAIL: WARP && Clang
-
 # Bug https://github.com/llvm/offload-test-suite/issues/525
 # XFAIL: NV && Clang && DirectX
 
@@ -335,5 +332,5 @@ DescriptorSets:
 # XFAIL: Metal || (Vulkan && MoltenVK)
 
 # RUN: split-file %s %t
-# RUN: %dxc_target -enable-16bit-types -T -O1 cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -enable-16bit-types -T cs_6_5 -O1 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o 

--- a/test/WaveOps/WaveActiveSum.int32.test
+++ b/test/WaveOps/WaveActiveSum.int32.test
@@ -326,9 +326,6 @@ DescriptorSets:
 # Bug https://github.com/llvm/llvm-project/issues/156775
 # XFAIL: Vulkan && Clang
 
-# Bug https://github.com/llvm/offload-test-suite/issues/524
-# XFAIL: WARP && Clang
-
 # Bug https://github.com/llvm/offload-test-suite/issues/525
 # XFAIL: NV && Clang && DirectX
 

--- a/test/WaveOps/WaveActiveSum.int64.test
+++ b/test/WaveOps/WaveActiveSum.int64.test
@@ -325,9 +325,6 @@ DescriptorSets:
 # Bug https://github.com/llvm/llvm-project/issues/156775
 # XFAIL: Vulkan && Clang
 
-# Bug https://github.com/llvm/offload-test-suite/issues/524
-# XFAIL: WARP && Clang
-
 # Bug https://github.com/llvm/offload-test-suite/issues/525
 # XFAIL: NV && Clang && DirectX
 


### PR DESCRIPTION
This PR serves to temporarily resolve the issues facing WaveActiveSum* tests described in this issue:
https://github.com/llvm/offload-test-suite/issues/525
With -O1, the CFG is less aggressively optimized, preventing a switch construct from being generated, and allowing WARP to safely ingest the compiled clang IR.
When the root of the problem is resolved, the plan is to remove -O1.