### PR TITLE
Amend WaveReadLaneAt.Int.64.test and WaveReadLaneAt.Float.64.test

### DIFF
--- a/test/WaveOps/WaveReadLaneAt.Float.64.test
+++ b/test/WaveOps/WaveReadLaneAt.Float.64.test
@@ -25,15 +25,15 @@ Shaders:
 Buffers:
   - Name: InFloat
     Format: Float64
-    Stride: 16
+    Stride: 32
     Data: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 ]
   - Name: OutFloat
     Format: Float64
-    Stride: 16
+    Stride: 32
     FillSize: 288
   - Name: ExpectedOutFloat # The result we expect
     Format: Float64
-    Stride: 16
+    Stride: 32
     Data: [ 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 0, 0, 4, 5, 6, 7, 4, 5, 6, 7, 4, 5, 0, 0, 8, 9, 10, 11, 8, 9, 10, 11, 8, 9, 0, 0 ]
 Results:
   - Result: TestFloat
@@ -58,9 +58,6 @@ DescriptorSets:
         Binding: 5
 ...
 #--- end
-
-# Bug https://github.com/llvm/offload-test-suite/issues/533
-# XFAIL: DirectX && AMD
 
 # REQUIRES: Double
 

--- a/test/WaveOps/WaveReadLaneAt.Int.64.test
+++ b/test/WaveOps/WaveReadLaneAt.Int.64.test
@@ -33,27 +33,27 @@ Shaders:
 Buffers:
   - Name: InInt
     Format: Int64
-    Stride: 16
+    Stride: 32
     Data: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 ]
   - Name: OutInt
     Format: Int64
-    Stride: 16
+    Stride: 32
     FillSize: 288
   - Name: ExpectedOutInt # The result we expect
     Format: Int64
-    Stride: 16
+    Stride: 32
     Data: [ 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 0, 0, 4, 5, 6, 7, 4, 5, 6, 7, 4, 5, 0, 0, 8, 9, 10, 11, 8, 9, 10, 11, 8, 9, 0, 0 ]
   - Name: InUInt
     Format: UInt64
-    Stride: 16
+    Stride: 32
     Data: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 ]
   - Name: OutUInt
     Format: UInt64
-    Stride: 16
+    Stride: 32
     FillSize: 288
   - Name: ExpectedOutUInt # The result we expect
     Format: UInt64
-    Stride: 16
+    Stride: 32
     Data: [ 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 0, 0, 4, 5, 6, 7, 4, 5, 6, 7, 4, 5, 0, 0, 8, 9, 10, 11, 8, 9, 10, 11, 8, 9, 0, 0 ]
 Results:
   - Result: TestInt
@@ -102,9 +102,6 @@ DescriptorSets:
 
 # Bug Tracked by https://github.com/llvm/offload-test-suite/issues/672
 # XFAIL: Vulkan && MoltenVK
-
-# Bug https://github.com/llvm/offload-test-suite/issues/533
-# XFAIL: DirectX && AMD
 
 # REQUIRES: Int64
 


### PR DESCRIPTION
The buffer strides specified in the pipeline don't match the buffer element size - i.e. the int64_t4, uint64_t4, and float64_t4 elements have a stride of 32 not 16 as specified.

Amended these strides as appropriate, and removed the XFAIL for AMD && DirectX as these tests pass with the amended stride values.

Fixes #533 