### PR TITLE
[MoltenVK] enable sine and cosine tests

### DIFF
--- a/test/Feature/HLSLLib/cos.32.test
+++ b/test/Feature/HLSLLib/cos.32.test
@@ -61,9 +61,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug https://github.com/KhronosGroup/SPIRV-Cross/issues/2525
-# XFAIL: Vulkan && MoltenVK
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/sin.32.test
+++ b/test/Feature/HLSLLib/sin.32.test
@@ -61,9 +61,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug https://github.com/KhronosGroup/SPIRV-Cross/issues/2525
-# XFAIL: Vulkan && MoltenVK
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
The original bug is fixed since August 2025: https://github.com/KhronosGroup/SPIRV-Cross/issues/2525 We didn't notice because the inf\nan\denorm issues. Since those moved this test started passing.