### PR TITLE
Clean up loop_peeling.test

### DIFF
--- a/test/Feature/MaximalReconvergence/loop_peeling.test
+++ b/test/Feature/MaximalReconvergence/loop_peeling.test
@@ -21,11 +21,11 @@ Shaders:
 Buffers:
   - Name: Out
     Format: UInt32
-    Stride: 16
+    Stride: 4
     FillSize: 256
   - Name: ExpectedOut
     Format: UInt32
-    Stride: 16
+    Stride: 4
     Data: [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ]
 
 Results:


### PR DESCRIPTION
This change updates the test case to more directly highlight the underlying issue. Namely that for the NV and QC test failures, it is because there is an unexpected number of active lanes during the invocation of `WaveActiveCountBits(true)`.

This additionally highlights another issue with AMD as it appears to report in quads in an unexpected manner.