### PR TITLE
Add NonUniformResourceIndex to inc_counter_array.test

### DIFF
--- a/test/Feature/StructuredBuffer/inc_counter_array.test
+++ b/test/Feature/StructuredBuffer/inc_counter_array.test
@@ -7,13 +7,10 @@ RWStructuredBuffer<int> Out[4] : register(u0);
 
 [numthreads(4,1,1)]
 void main(uint GI : SV_GroupIndex) {
-
-  int NUI = NonUniformResourceIndex(GI);
-
   for (int i = 0; i < GI; i++)
-    Out[NUI].IncrementCounter();
+    Out[NonUniformResourceIndex(GI)].IncrementCounter();
   
-  Out[NUI][0] = Out[NUI].IncrementCounter();
+  Out[NonUniformResourceIndex(GI)][0] = Out[NonUniformResourceIndex(GI)].IncrementCounter();
 }
 
 //--- pipeline.yaml


### PR DESCRIPTION
The test needs to use NonUniformResourceIndex to make sure it has a consistent behaviour accross GPUs

It is related to: #337