### PR TITLE
Fix WaveReadLaneFirst stride size for fp64

### DIFF
--- a/test/WaveOps/WaveReadLaneFirst.fp64.test
+++ b/test/WaveOps/WaveReadLaneFirst.fp64.test
@@ -304,6 +304,7 @@ DescriptorSets:
 ...
 #--- end
 
+
 # Bug https://github.com/llvm/llvm-project/issues/156775
 # XFAIL: Clang
 


### PR DESCRIPTION
This PR resolves a failure only seen on AMD machines with the directx target.
The stride sizes were wrong, and too small.
Fixes https://github.com/llvm/offload-test-suite/issues/625