### PR TITLE
[Vulkan] Enable `mad` intrinsic tests

### DIFF
--- a/test/Feature/HLSLLib/mad.int16.test
+++ b/test/Feature/HLSLLib/mad.int16.test
@@ -141,9 +141,6 @@ DescriptorSets:
         Binding: 7
 #--- end
 
-# https://github.com/llvm/llvm-project/issues/140095
-# UNSUPPORTED: Clang && Vulkan
-
 # REQUIRES: Int16
 # RUN: split-file %s %t
 # RUN: %dxc_target -enable-16bit-types -HV 202x -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/mad.int64.test
+++ b/test/Feature/HLSLLib/mad.int64.test
@@ -141,9 +141,6 @@ DescriptorSets:
         Binding: 7
 #--- end
 
-# https://github.com/llvm/llvm-project/issues/140095
-# UNSUPPORTED: Clang && Vulkan
-
 # Bug https://github.com/llvm/offload-test-suite/issues/412
 # XFAIL: AMD && DirectX
 


### PR DESCRIPTION
issue https://github.com/llvm/llvm-project/issues/140095 has been resolved. its time to enable these tests.