### PR TITLE
Fix WaveActiveMax fp64 stride size

### DIFF
--- a/test/WaveOps/WaveActiveMax.fp64.test
+++ b/test/WaveOps/WaveActiveMax.fp64.test
@@ -32,7 +32,6 @@ void main(uint3 tid : SV_GroupThreadID)
             }
         }
     }
-    
     // constant folding case
     Out5[0] = WaveActiveMax(double4(1.5,2.5,3.5,4.5));
 }


### PR DESCRIPTION
This PR doesn't fully fix the issue https://github.com/llvm/offload-test-suite/issues/541, but maximally fixes the state of the test on this side of things.
The PR should enable Out1 - Out4 to pass / have expected results.
Out5 is seeing -inf, which has been filed as a driver bug here: 61038509.
This failure should be fixed with a driver update, and at that point we can just remove the XFAIL.
