### PR TITLE
[AMD] enable inc_counter_array.test for SPIRV on DXC

### DIFF
--- a/test/Feature/StructuredBuffer/inc_counter_array.test
+++ b/test/Feature/StructuredBuffer/inc_counter_array.test
@@ -53,7 +53,7 @@ DescriptorSets:
 # XFAIL: Intel
 
 # Bug https://github.com/llvm/offload-test-suite/issues/337
-# XFAIL: AMD
+# XFAIL: AMD && Clang && DirectX
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl


### PR DESCRIPTION
This test is passing now on Vulkan with DXC. The XFAIL needs to change to account for this.