### PR TITLE
[VK] Enable SimpleTriangle on Vulkan

### DIFF
--- a/test/Graphics/SimpleTriangle.test
+++ b/test/Graphics/SimpleTriangle.test
@@ -70,8 +70,9 @@ DescriptorSets: []
 ...
 #--- end
 
-# UNSUPPORTED: Clang
 # REQUIRES: goldenimage
+# XFAIL: Clang && Metal
+# XFAIL: Clang && DirectX
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T vs_6_0 -Fo %t-vertex.o %t/vertex.hlsl


### PR DESCRIPTION
This also updates the test to XFAIL on DX & Metal so that once we have this working we'll see the failure.