### PR TITLE
Fix stride in test res-in-struct-mix

### DIFF
--- a/test/Feature/ResourcesInStructs/res-in-struct-mix.test
+++ b/test/Feature/ResourcesInStructs/res-in-struct-mix.test
@@ -1,6 +1,6 @@
 #--- source.hlsl
 
-// This test verifies handling of a resource array in a struct.
+// This test verifies handling of a resource in a class.
 
 class E {
   RWBuffer<int> UavBuf1;
@@ -124,9 +124,6 @@ DescriptorSets:
 
 # Bug https://github.com/llvm/offload-test-suite/issues/642
 # XFAIL: Metal
-
-# Bug https://github.com/llvm/offload-test-suite/issues/643
-# XFAIL: Intel
 
 # Vulkan does not support global structures with buffers or structures
 # containing both resources and non-resources.


### PR DESCRIPTION
The stride was wrong for res-in-struct-mix.test, this patches fixes it making it pass in AMD GPUs
Also Fix Out Buffer type from `RWBuffer` to `RWStructuredBuffer`.

fixes: #655
fixes #643