### PR TITLE
[Intel][Vulkan] Enable select tests for clang

### DIFF
--- a/test/Feature/HLSLLib/select.32.test
+++ b/test/Feature/HLSLLib/select.32.test
@@ -350,9 +350,6 @@ DescriptorSets:
         Binding: 15
 #--- end
 
-# Bug https://github.com/llvm/offload-test-suite/issues/615
-# XFAIL: Clang && Vulkan && Intel
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -HV 202x -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/select.fp16.test
+++ b/test/Feature/HLSLLib/select.fp16.test
@@ -131,9 +131,6 @@ DescriptorSets:
         Binding: 4
 #--- end
 
-# Bug https://github.com/llvm/offload-test-suite/issues/615
-# XFAIL: Clang && Vulkan && Intel
-
 # REQUIRES: Half
 # RUN: split-file %s %t
 # RUN: %dxc_target -enable-16bit-types -HV 202x -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/select.fp64.test
+++ b/test/Feature/HLSLLib/select.fp64.test
@@ -124,9 +124,6 @@ DescriptorSets:
         Binding: 4
 #--- end
 
-# Bug https://github.com/llvm/offload-test-suite/issues/615
-# XFAIL: Clang && Vulkan && Intel
-
 # REQUIRES: Double
 # RUN: split-file %s %t
 # RUN: %dxc_target -HV 202x -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/select.int16.test
+++ b/test/Feature/HLSLLib/select.int16.test
@@ -204,9 +204,6 @@ DescriptorSets:
         Binding: 8
 #--- end
 
-# Bug https://github.com/llvm/offload-test-suite/issues/615
-# XFAIL: Clang && Vulkan && Intel
-
 # REQUIRES: Int16
 # RUN: split-file %s %t
 # RUN: %dxc_target -enable-16bit-types -HV 202x -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/select.int64.test
+++ b/test/Feature/HLSLLib/select.int64.test
@@ -203,9 +203,6 @@ DescriptorSets:
         Binding: 8
 #--- end
 
-# Bug https://github.com/llvm/offload-test-suite/issues/615
-# XFAIL: Clang && Vulkan && Intel
-
 # REQUIRES: Int64
 # RUN: split-file %s %t
 # RUN: %dxc_target -HV 202x -T cs_6_5 -Fo %t.o %t/source.hlsl


### PR DESCRIPTION
resolves #615

It looks like this commit to Scalarize single-element vectors in SPIRV has fixed the Intel select bugs:
That went in on 4:12:06 PM EST https://github.com/llvm/llvm-project/commit/1919b3b0474583e703d9545d536caf72c05b4ad4.patch

caused these tests to start passing select tests (Feb 11, 5:07 PM EST): https://github.com/llvm/offload-test-suite/actions/runs/21924936578/job/63314924039

They were still failing on (Feb 11, 3:10 PM EST) https://github.com/llvm/offload-test-suite/actions/runs/21921310889/job/63301932477