### PR TITLE
Add test for compute shader semantics

### DIFF
--- a/test/Feature/Semantics/ComputeSystemValues.test
+++ b/test/Feature/Semantics/ComputeSystemValues.test
@@ -710,3 +710,6 @@ DescriptorSets:
 # get 3 for the x dimension.
 # See https://github.com/llvm/offload-test-suite/issues/735
 # XFAIL: Metal
+#
+# See https://github.com/llvm/offload-test-suite/issues/764
+# XFAIL: Windows && AMD && DirectX


### PR DESCRIPTION
Add testing for compute shader system semantics on a 2x2x2 dispatch.