### PR TITLE
tests: update tests after #708

### DIFF
--- a/test/Feature/Semantics/ArraySemantics.test
+++ b/test/Feature/Semantics/ArraySemantics.test
@@ -49,7 +49,7 @@ Buffers:
     OutputProps:
       Height: 1
       Width: 1
-      Depth: 16
+      Depth: 1
 Bindings:
   VertexBuffer: VertexData
   VertexAttributes:

--- a/test/Feature/Semantics/MatrixSemantics.test
+++ b/test/Feature/Semantics/MatrixSemantics.test
@@ -63,7 +63,7 @@ Buffers:
     OutputProps:
       Height: 1
       Width: 1
-      Depth: 16
+      Depth: 1
   - Name: ResultBuffer
     Format: Float32
     FillSize: 28

--- a/test/Feature/Semantics/NestedStructSemantics.test
+++ b/test/Feature/Semantics/NestedStructSemantics.test
@@ -66,7 +66,7 @@ Buffers:
     OutputProps:
       Height: 1
       Width: 1
-      Depth: 16
+      Depth: 1
   - Name: ResultBuffer
     Format: Int32
     FillSize: 12

--- a/test/Feature/Semantics/SemanticTypes.test
+++ b/test/Feature/Semantics/SemanticTypes.test
@@ -64,7 +64,7 @@ Buffers:
     OutputProps:
       Height: 1
       Width: 1
-      Depth: 16
+      Depth: 1
   - Name: ResultBuffer
     Format: Int32
     FillSize: 12

--- a/test/Feature/Semantics/ShadowedSemantics.test
+++ b/test/Feature/Semantics/ShadowedSemantics.test
@@ -71,7 +71,7 @@ Buffers:
     OutputProps:
       Height: 1
       Width: 1
-      Depth: 16
+      Depth: 1
   - Name: ResultBuffer
     Format: Int32
     FillSize: 12

--- a/test/Feature/Semantics/UserSemantics.test
+++ b/test/Feature/Semantics/UserSemantics.test
@@ -46,7 +46,7 @@ Buffers:
     OutputProps:
       Height: 1
       Width: 1
-      Depth: 16
+      Depth: 1
 Bindings:
   VertexBuffer: VertexData
   VertexAttributes:


### PR DESCRIPTION
The PR started using the Depth parameter, which was hardcoded to 1. Those tests were added in another PR at the same time and thus Depth value we still the one used previously.