### PR TITLE
[AMD][DX] Remove xfail for passing loop_peeling

### DIFF
--- a/test/Feature/MaximalReconvergence/loop_peeling.test
+++ b/test/Feature/MaximalReconvergence/loop_peeling.test
@@ -58,9 +58,6 @@ DescriptorSets:
 # Bug https://github.com/llvm/offload-test-suite/issues/521
 # XFAIL: NV && DirectX
 
-# Bug https://github.com/llvm/offload-test-suite/issues/755
-# XFAIL: AMD && DirectX
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -fspv-enable-maximal-reconvergence -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
This was marked as XFAIL based on a previous test failure: https://github.com/llvm/offload-test-suite/issues/755.

However, it appears this was because of the incorrect stride size and is passing now.

Resolves https://github.com/llvm/offload-test-suite/issues/755