### PR TITLE
[QC] Avoid special floating point values in log2.16.test

### DIFF
--- a/test/Feature/HLSLLib/log2.16.test
+++ b/test/Feature/HLSLLib/log2.16.test
@@ -35,7 +35,7 @@ Buffers:
     Format: Float16
     Stride: 8
     Data: [ 0xFC00, 0xFC00, 0x0, 0x7FFF, 0x4000, 0xBFFF, 0x4980, 0x4900, 0x3C00, 0x4200, 0x4400, 0x4500 ]
-    #  -Inf, -Inf, -23.984375, inf, 0, NaN, 2, -2, 11, 10, 1, 3, 4, 5
+    #  -Inf, -Inf, 0, Nan, 2, -1.9991, 11, 10, 1, 3, 4, 5
 Results:
   - Result: Test1
     Rule: BufferFloatULP


### PR DESCRIPTION
The test is using as input to the log2 intrinsic, Inf, Nan and denorm values, those are undefined behaviours and are not suitable to be in the test. This patch removes them to fix: #564 