### PR TITLE
[Mac][VK] Enable passing tests

### DIFF
--- a/test/Feature/HLSLLib/cos.nan-inf-denorm.32.test
+++ b/test/Feature/HLSLLib/cos.nan-inf-denorm.32.test
@@ -60,7 +60,7 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/KhronosGroup/SPIRV-Cross/issues/2525
-# XFAIL: Vulkan && MoltenVK
+# XFAIL: Clang && Vulkan && MoltenVK
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/701
 # XFAIL: Metal && !AppleM1 && !AppleM2 && Clang

--- a/test/Feature/HLSLLib/sin.nan-inf-denorm.32.test
+++ b/test/Feature/HLSLLib/sin.nan-inf-denorm.32.test
@@ -60,7 +60,7 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/KhronosGroup/SPIRV-Cross/issues/2525
-# XFAIL: Vulkan && MoltenVK
+# XFAIL: Clang && Vulkan && MoltenVK
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/701
 # XFAIL: Metal && !AppleM1 && !AppleM2 && Clang

--- a/test/Feature/Textures/Texture2D.Sample.test.yaml
+++ b/test/Feature/Textures/Texture2D.Sample.test.yaml
@@ -160,7 +160,7 @@ Results:
 #--- end
 
 # Unimplemented: https://github.com/llvm/offload-test-suite/issues/664
-# XFAIL: DirectX || Metal || Vulkan && Darwin
+# XFAIL: DirectX || Metal || (Vulkan && Darwin && Clang)
 # XFAIL: Clang && !Vulkan
 
 

--- a/test/Feature/Textures/Texture2D.SampleBias.test.yaml
+++ b/test/Feature/Textures/Texture2D.SampleBias.test.yaml
@@ -151,7 +151,7 @@ Results:
 #--- end
 
 # Unimplemented: https://github.com/llvm/offload-test-suite/issues/664
-# XFAIL: DirectX || Metal || Vulkan && Darwin
+# XFAIL: DirectX || Metal
 
 # Unimplemented: https://github.com/llvm/llvm-project/issues/175630
 # XFAIL: Clang && !Intel

--- a/test/WaveOps/WaveActiveSum.int16.test
+++ b/test/WaveOps/WaveActiveSum.int16.test
@@ -332,7 +332,7 @@ DescriptorSets:
 # XFAIL: NV && Clang && DirectX
 
 # Bug https://github.com/llvm/offload-test-suite/issues/393
-# XFAIL: Metal || (Vulkan && MoltenVK)
+# XFAIL: Metal
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl


### PR DESCRIPTION
We don't have a CI to confirm this, but These tests are passing for dxc or both dxc and clang and so this change enables them