### PR TITLE
Remove nan, inf denorm from inputs in saturate.16

### DIFF
--- a/test/Feature/HLSLLib/saturate.16.test
+++ b/test/Feature/HLSLLib/saturate.16.test
@@ -34,12 +34,12 @@ Buffers:
   - Name: ExpectedOut # The result we expect
     Format: Float16
     Stride: 8
-    Data: [ 0x0, 0x0, 0x3C00, 0x0, 0x3800, 0x1D1F, 0x3BFE, 0x3C00, 0x3C00, 0x3C00, 0x3C00, 0x3C00 ]
-    #  0, 0, 1, 0, 0.5, 0.005002, 0.9991, 1, 1, 1, 1, 1
+    Data: [ 0x0, 0x0, 0x3C00, 0x0, 0x3800, 0x1D1E, 0x3BFD, 0x3C00, 0x3C00, 0x3C00, 0x3C00, 0x3C00 ]
+    #  0, 0, 1, 0, 0.5, 0.005, 0.999, 1, 1, 1, 1, 1
 Results:
   - Result: Test1
     Rule: BufferFloatEpsilon
-    Epsilon: 0
+    Epsilon: 0.0005
     Actual: Out
     Expected: ExpectedOut
 DescriptorSets:


### PR DESCRIPTION
This patch removes nan, inf and denorm values from inputs to saturate intrinsic call on saturate.16 test. 
fix: https://github.com/llvm/offload-test-suite/issues/558