### PR TITLE
Simplify createCBV copying logic

### DIFF
--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -899,12 +899,9 @@ public:
       if (auto Err = HR::toError(UploadBuffer->Map(0, nullptr, &ResDataPtr),
                                  "Failed to acquire UAV data pointer."))
         return Err;
+      memset(ResDataPtr, 0, CBVSize);
       memcpy(ResDataPtr, ResData.get(), R.size());
-      // Zero any remaining bytes
-      if (R.size() < CBVSize) {
-        void *ExtraData = static_cast<char *>(ResDataPtr) + R.size();
-        memset(ExtraData, 0, CBVSize - R.size() - 1);
-      }
+
       UploadBuffer->Unmap(0, nullptr);
 
       addResourceUploadCommands(R, IS, Buffer, UploadBuffer);


### PR DESCRIPTION
This PR removes / simplifies some logic when copying over data. 
Inside of `createCBV`, there was a copy that took place if R.size() < CBVSize. The memory after the copy would then be 0'd out, except for the final byte, which would be left uninitialized.
Instead, this PR zero-initializes the memory first, then copies the data over. 
It simplifies the function.
Fixes https://github.com/llvm/offload-test-suite/issues/477