### PR TITLE
remove nan, inf and denorm from log10.16 test input

### DIFF
--- a/test/Feature/HLSLLib/log10.16.test
+++ b/test/Feature/HLSLLib/log10.16.test
@@ -64,9 +64,6 @@ DescriptorSets:
 # Bug https://github.com/llvm/llvm-project/issues/145073
 # XFAIL: Clang && Vulkan
 
-# Bug https://github.com/llvm/offload-test-suite/issues/565
-# XFAIL: QC
-
 # REQUIRES: Half
 # RUN: split-file %s %t
 # RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl


### PR DESCRIPTION
This patch removes nan, inf and denorm from log10.16 test **inputs**.
Also, it modifies the ULP level to accommodate QC GPU precision.

fix: https://github.com/llvm/offload-test-suite/issues/565