### PR TITLE
Remove XFAIL for passing AMD DirectX tests

### DIFF
--- a/test/Feature/HLSLLib/dot.int64.test
+++ b/test/Feature/HLSLLib/dot.int64.test
@@ -134,9 +134,6 @@ DescriptorSets:
 # Bug https://github.com/llvm/offload-test-suite/issues/569
 # XFAIL: QC && Vulkan && Clang
 
-# Bug https://github.com/llvm/offload-test-suite/issues/570
-# XFAIL: AMD && DirectX
-
 # REQUIRES: Int64
 # RUN: split-file %s %t
 # RUN: %dxc_target  -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/mad.int64.test
+++ b/test/Feature/HLSLLib/mad.int64.test
@@ -141,9 +141,6 @@ DescriptorSets:
         Binding: 7
 #--- end
 
-# Bug https://github.com/llvm/offload-test-suite/issues/412
-# XFAIL: AMD && DirectX
-
 # REQUIRES: Int64
 # RUN: split-file %s %t
 # RUN: %dxc_target -HV 202x -T cs_6_5 -Fo %t.o %t/source.hlsl


### PR DESCRIPTION
The tests dot.int64.test and mad.int64.test were marked XFAIL due to an AMD driver bug. This is now fixed so the tests now pass, and this change simply removes the XFAIL.