### PR TITLE
Add GBV tests to offload test suite

### DIFF
--- a/.github/workflows/windows-amd-clang-d3d12-gbv.yaml
+++ b/.github/workflows/windows-amd-clang-d3d12-gbv.yaml
@@ -5,7 +5,7 @@ permissions:
 
 on:
   schedule:
-    - cron: '0 6 * * 2-6' # Run daily at 10pm PST, Mon-Fri (6am UTC, Tue-Sat)
+    - cron: '0 6 * * *' # Run daily at 10pm PST (6am UTC)
 
 jobs:
   Windows-D3D12-AMD-Clang-GBV:
@@ -18,4 +18,4 @@ jobs:
       SKU: windows-amd
       TestTarget: check-hlsl-clang-d3d12
       OffloadTest-branch: ${{ github.ref }}
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=On -DOFFLOADTEST_ENABLE_VALIDATION=ON
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_ENABLE_VALIDATION=ON


### PR DESCRIPTION
This PR adds a new pipeline to the offload test suite, scheduled to run only on schedule: 10PM PST Mon-Fri.
It borrows the logic used to run the windows amd clang d3d12 pipeline, except it adds the cmake arg for enabling GBV.
Adding this should give us more of a headsup when GBV catches something, enabling us to check against this new pipeline when we are trying to figure out if there's a driver bug. It's also a good reference point for which tests are broken.

Fixes https://github.com/llvm/offload-test-suite/issues/948