### PR TITLE
adding xfail for matrix failing instrisic

### DIFF
--- a/test/Basic/Matrix/matrix_elementwise_cast.test
+++ b/test/Basic/Matrix/matrix_elementwise_cast.test
@@ -104,4 +104,4 @@ DescriptorSets:
 # RUN: %offloader %t/pipeline.yaml %t.o
 
 # Bug https://github.com/llvm/llvm-project/issues/185518
-# XFAIL: Clang && Vulkan && Intel
+# XFAIL: Clang && Vulkan


### PR DESCRIPTION
This patch is adding a new XFAIL to keep track of failing issues on the builds