### PR TITLE
[Matrix] Enable MatrixElement Tests

### DIFF
--- a/test/Feature/CBuffer/Matrix/MatrixElement/one_based_mat_element.f32.test
+++ b/test/Feature/CBuffer/Matrix/MatrixElement/one_based_mat_element.f32.test
@@ -183,9 +183,9 @@ DescriptorSets:
 # Are always empty
 # UNSUPPORTED: Darwin
 
-# Note: Not implemented yet
-# Issue https://github.com/llvm/llvm-project/issues/184877
-# XFAIL: Clang
+# Note: clang Vulkan crashes
+# BUG https://github.com/llvm/llvm-project/issues/179879
+# XFAIL: Clang && Vulkan
 
 # Note: NV crashes AMD and Intel Output buffers are empty.
 # Bug https://github.com/microsoft/DirectXShaderCompiler/issues/8218

--- a/test/Feature/CBuffer/Matrix/MatrixElement/one_based_mat_element_scalar.f32.test
+++ b/test/Feature/CBuffer/Matrix/MatrixElement/one_based_mat_element_scalar.f32.test
@@ -194,9 +194,9 @@ DescriptorSets:
 # Are always empty
 # UNSUPPORTED: Darwin
 
-# Note: Not implemented yet
-# Issue https://github.com/llvm/llvm-project/issues/184877
-# XFAIL: Clang
+# Note: clang Vulkan crashes
+# BUG https://github.com/llvm/llvm-project/issues/179879
+# XFAIL: Clang && Vulkan
 
 # Note: NV crashes AMD and Intel Output buffers are empty.
 # Bug https://github.com/microsoft/DirectXShaderCompiler/issues/8218

--- a/test/Feature/CBuffer/Matrix/MatrixElement/zero_based_mat_element.f32.test
+++ b/test/Feature/CBuffer/Matrix/MatrixElement/zero_based_mat_element.f32.test
@@ -183,9 +183,9 @@ DescriptorSets:
 # Are always empty
 # UNSUPPORTED: Darwin
 
-# Note: Not implemented yet
-# Issue https://github.com/llvm/llvm-project/issues/184877
-# XFAIL: Clang
+# Note: clang Vulkan crashes
+# BUG https://github.com/llvm/llvm-project/issues/179879
+# XFAIL: Clang && Vulkan
 
 # Note: NV crashes AMD and Intel Output buffers are empty.
 # Bug https://github.com/microsoft/DirectXShaderCompiler/issues/8218

--- a/test/Feature/CBuffer/Matrix/MatrixElement/zero_based_mat_element_scalar.f32.test
+++ b/test/Feature/CBuffer/Matrix/MatrixElement/zero_based_mat_element_scalar.f32.test
@@ -194,9 +194,9 @@ DescriptorSets:
 # Are always empty
 # UNSUPPORTED: Darwin
 
-# Note: Not implemented yet
-# Issue https://github.com/llvm/llvm-project/issues/184877
-# XFAIL: Clang
+# Note: clang Vulkan crashes
+# BUG https://github.com/llvm/llvm-project/issues/179879
+# XFAIL: Clang && Vulkan
 
 # Note: NV crashes AMD and Intel Output buffers are empty.
 # Bug https://github.com/microsoft/DirectXShaderCompiler/issues/8218


### PR DESCRIPTION
This change is fixed https://github.com/llvm/llvm-project/issues/184877 by this pr: https://github.com/llvm/llvm-project/pull/185471 remove the xfails for all clang