### PR TITLE
[Matrix] Enable Row Swizzle test

### DIFF
--- a/test/Feature/CBuffer/Matrix/SingleSubscript/mat_cbuffer-swizzle.f32.test
+++ b/test/Feature/CBuffer/Matrix/SingleSubscript/mat_cbuffer-swizzle.f32.test
@@ -173,9 +173,9 @@ DescriptorSets:
 # Are always empty
 # UNSUPPORTED: Darwin
 
-# Note: Not implemented yet
-# Issue https://github.com/llvm/llvm-project/issues/184849
-# XFAIL: Clang
+# Note: clang Vulkan crashes
+# BUG https://github.com/llvm/llvm-project/issues/179879
+# XFAIL: Clang && Vulkan
 
 # Note: NV crashes AMD and Intel Output buffers are empty.
 # Bug https://github.com/microsoft/DirectXShaderCompiler/issues/8218


### PR DESCRIPTION
This PR: https://github.com/llvm/llvm-project/pull/185346 Resolved this issue: https://github.com/llvm/llvm-project/issues/184849 This change is to just reduce the xfail to allow DirectX, but still Xfail on Clang and Vulkan