### PR TITLE
[VK] Remove xfail for passing Texture2D test

### DIFF
--- a/test/Feature/Textures/Texture2D.GatherCmp.test.yaml
+++ b/test/Feature/Textures/Texture2D.GatherCmp.test.yaml
@@ -137,8 +137,7 @@ Results:
 #--- end
 
 # Unimplemented: Clang + DX: https://github.com/llvm/llvm-project/issues/101558
-# Unimplemented: Clang + VK: https://github.com/llvm/llvm-project/issues/175630
-# XFAIL: DirectX || Metal || Clang
+# XFAIL: DirectX || Metal
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl

--- a/test/Feature/Textures/Texture2D.Load.test.yaml
+++ b/test/Feature/Textures/Texture2D.Load.test.yaml
@@ -75,8 +75,7 @@ Results:
 #--- end
 
 # Unimplemented: Clang + DX: https://github.com/llvm/llvm-project/issues/101558
-# Unimplemented: Clang + VK: https://github.com/llvm/llvm-project/issues/175630
-# XFAIL: Clang
+# XFAIL: Clang && !Vulkan
 
 
 


### PR DESCRIPTION
Recent commits to clang implemented missing features for
some Texture2D tests.
