### PR TITLE
Update XFAIL from run results March 12th 2026

### DIFF
--- a/test/Feature/CBuffer/structs.test
+++ b/test/Feature/CBuffer/structs.test
@@ -98,10 +98,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Clang trips on 2-element vectors in structs:
-# Bug https://github.com/llvm/llvm-project/issues/123968
-# XFAIL: Clang
-
 # Bug https://github.com/KhronosGroup/SPIRV-Cross/issues/2595
 # XFAIL: Vulkan && MoltenVK
 


### PR DESCRIPTION
this patch is updating the XFAILs from the results produced by Tier 1 runs on March 12th 2026