### PR TITLE
[AMD] Enable passing tests

### DIFF
--- a/test/Feature/Semantics/ComputeSystemValues.test
+++ b/test/Feature/Semantics/ComputeSystemValues.test
@@ -705,6 +705,3 @@ DescriptorSets:
 # RUN: split-file %s %t
 # RUN: %dxc_target -fvk-use-dx-layout -T cs_6_0 -Fo %t.o %t/system_values.hlsl
 # RUN: %offloader %t/system_values.yaml %t.o
-
-# See https://github.com/llvm/offload-test-suite/issues/764
-# XFAIL: Windows && AMD && DirectX

--- a/test/WaveOps/WaveReadLaneAt.Float.64.test
+++ b/test/WaveOps/WaveReadLaneAt.Float.64.test
@@ -11,7 +11,7 @@ void main(uint32_t3 TID : SV_GroupThreadID) {
   // Float
   OutFloat[OutIdx] = WaveReadLaneAt(InFloat[TID.x], TID.x);
   float64_t4 ThreadInFloat = {InFloat[TID.x].xyz, InFloat[TID.x].w};
-  OutFloat[OutIdx + 1] =  WaveReadLaneAt(ThreadInFloat, TID.x);;
+  OutFloat[OutIdx + 1] =  WaveReadLaneAt(ThreadInFloat, TID.x);
   OutFloat[OutIdx + 2].xy = WaveReadLaneAt(InFloat[TID.x].xy, TID.x);
 }
 
@@ -58,9 +58,6 @@ DescriptorSets:
         Binding: 5
 ...
 #--- end
-
-# Bug https://github.com/llvm/offload-test-suite/issues/533
-# XFAIL: DirectX && AMD
 
 # REQUIRES: Double
 


### PR DESCRIPTION
issue #533 was already fixed.
And #764 appears to be fixed as ci is showing ComputeSystemValues.test passing