### PR TITLE
Revert "Update XFAIL from run results March 12th 2026 (#962)"

### DIFF
--- a/test/Feature/CBuffer/structs.test
+++ b/test/Feature/CBuffer/structs.test
@@ -98,6 +98,10 @@ DescriptorSets:
 ...
 #--- end
 
+# Clang trips on 2-element vectors in structs:
+# Bug https://github.com/llvm/llvm-project/issues/123968
+# XFAIL: Clang
+
 # Bug https://github.com/KhronosGroup/SPIRV-Cross/issues/2595
 # XFAIL: Vulkan && MoltenVK
 


### PR DESCRIPTION
This reverts the test correction as the linked issue, https://github.com/llvm/llvm-project/issues/123968, is not resolved.

It fails in a similar manner as a "driver" crash but it is not specific to any specific vendor, so it is unlikely to be a driver bug.