### PR TITLE
Revert "adding xfail for matrix failing instrisic (#949)"

### DIFF
--- a/test/Basic/Matrix/matrix_elementwise_cast.test
+++ b/test/Basic/Matrix/matrix_elementwise_cast.test
@@ -102,6 +102,3 @@ DescriptorSets:
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o
-
-# Bug https://github.com/llvm/llvm-project/issues/185518
-# XFAIL: Clang && Vulkan


### PR DESCRIPTION
This reverts commit f69eac69bc92a53646c1d7f1c594301aac0401e2 which added an xfail due to https://github.com/llvm/llvm-project/issues/185518.
The issue has been fixed, so the test should no longer be xfailed.