### PR TITLE
Update an XFAIL for element-aligned vectors

### DIFF
--- a/test/Feature/CBuffer/structs.test
+++ b/test/Feature/CBuffer/structs.test
@@ -98,6 +98,9 @@ DescriptorSets:
 ...
 #--- end
 
+# Unimplemented https://github.com/llvm/llvm-project/issues/186465
+# XFAIL: Clang && Vulkan
+
 # Bug https://github.com/KhronosGroup/SPIRV-Cross/issues/2595
 # XFAIL: Vulkan && MoltenVK
 


### PR DESCRIPTION
As of llvm/llvm-project#180622 this failure is Vulkan only.