### PR TITLE
XFAIL QC Vulkan Clang in mul.int64 test

### DIFF
--- a/test/Feature/HLSLLib/mul.int64.test
+++ b/test/Feature/HLSLLib/mul.int64.test
@@ -113,6 +113,9 @@ DescriptorSets:
 # Bug https://github.com/llvm/offload-test-suite/issues/778
 # XFAIL: QC && DirectX
 
+# Bug https://github.com/llvm/offload-test-suite/issues/968
+# XFAIL: QC && Vulkan && Clang
+
 # REQUIRES: Int64
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl


### PR DESCRIPTION
@farzonl noticed the failure. This PR inserts an XFAIL for the newly filed issue about the failure: https://github.com/llvm/offload-test-suite/issues/968