### PR TITLE
Prevent WARP preview workflows from running automatically

### DIFF
--- a/.github/workflows/windows-amd-clang-warp-preview-d3d12.yaml
+++ b/.github/workflows/windows-amd-clang-warp-preview-d3d12.yaml
@@ -5,9 +5,10 @@ permissions:
 
 on:
   workflow_dispatch:
-  pull_request:
-    paths:
-     - .github/workflows/windows-amd-clang-warp-preview-d3d12.yaml
+  ## Note: This workflow is intentionally made to NOT run on schedule or when
+  ## modified by a PR due to a known issue where this workflow causes the
+  ## machine to stall indefinitely.
+  ## Issue link: https://github.com/llvm/offload-test-suite/issues/772
 
 jobs:
   Windows-D3D12-Warp-Clang:

--- a/.github/workflows/windows-amd-dxc-warp-preview-d3d12.yaml
+++ b/.github/workflows/windows-amd-dxc-warp-preview-d3d12.yaml
@@ -5,9 +5,10 @@ permissions:
 
 on:
   workflow_dispatch:
-  pull_request:
-    paths:
-     - .github/workflows/windows-amd-dxc-warp-preview-d3d12.yaml
+  ## Note: This workflow is intentionally made to NOT run on schedule or when
+  ## modified by a PR due to a known issue where this workflow causes the
+  ## machine to stall indefinitely.
+  ## Issue link: https://github.com/llvm/offload-test-suite/issues/772
 
 jobs:
   Windows-D3D12-Warp-DXC:


### PR DESCRIPTION
Due to a known issue where WARP preview workflow stalls the machine indefinitely (https://github.com/llvm/offload-test-suite/issues/772) this PR disables the WARP preview builds from running automatically when modified by a PR.

PRs like https://github.com/llvm/offload-test-suite/pull/935 and https://github.com/llvm/offload-test-suite/pull/769 have popped up to update/modify the WARP preview workflows and caused the machine to stall -- preventing it from running its usual scheduled jobs or other PRs.
