### PR TITLE
Add WaveActiveBitOr tests

### DIFF
--- a/test/WaveOps/WaveActiveBitOr.convergence.test
+++ b/test/WaveOps/WaveActiveBitOr.convergence.test
@@ -8,32 +8,32 @@ RWStructuredBuffer<uint> Out4 : register(u4); // loop
 RWStructuredBuffer<uint> Out5 : register(u5); // divergent loop
 
 [numthreads(4,1,1)]
-void main(uint3 tid : SV_GroupThreadID) {
-    uint v = In[tid.x];
+void main(uint3 TID : SV_GroupThreadID) {
+    uint V = In[TID.x];
 
     // divergent branch
-    if (tid.x < 2)
-        Out1[tid.x] = WaveActiveBitOr(v);
+    if (TID.x < 2)
+        Out1[TID.x] = WaveActiveBitOr(V);
     else
-        Out2[tid.x] = WaveActiveBitOr(v);
+        Out2[TID.x] = WaveActiveBitOr(V);
 
     // reconverged wave op
-    Out3[tid.x] = WaveActiveBitOr(v);
+    Out3[TID.x] = WaveActiveBitOr(V);
 
     // loop case
-    uint r = v;
+    uint R = V;
     for (uint i = 0; i < 2; i++)
-        r = WaveActiveBitOr(r);
+        R = WaveActiveBitOr(R);
 
-    Out4[tid.x] = r;
+    Out4[TID.x] = R;
 
-    // divergent loop: each thread iterates tid.x times
+    // divergent loop: each thread iterates TID.x times
     // thread 0: 0 iters, thread 1: 1 iter, thread 2: 2 iters, thread 3: 3 iters
-    uint r2 = v;
-    for (uint j = 0; j < tid.x; j++)
-        r2 = WaveActiveBitOr(r2);
+    uint R2 = V;
+    for (uint j = 0; j < TID.x; j++)
+        R2 = WaveActiveBitOr(R2);
 
-    Out5[tid.x] = r2;
+    Out5[TID.x] = R2;
 }
 
 #--- pipeline.yaml

--- a/test/WaveOps/WaveActiveBitOr.int.test
+++ b/test/WaveOps/WaveActiveBitOr.int.test
@@ -9,20 +9,20 @@ RWStructuredBuffer<uint4> Out5 : register(u5);
 
 
 [numthreads(4,1,1)]
-void main(uint3 tid : SV_GroupThreadID) {
-    uint4 v = In[tid.x];
+void main(uint3 TID : SV_GroupThreadID) {
+    uint4 V = In[TID.x];
 
-    Out1[tid.x] = WaveActiveBitOr(v.x);
+    Out1[TID.x] = WaveActiveBitOr(V.x);
 
-    Out2[tid.x] = WaveActiveBitOr(v.xy);
+    Out2[TID.x] = WaveActiveBitOr(V.xy);
 
-    uint3 r3 = WaveActiveBitOr(v.xyz);
-    Out3[tid.x].xyz = r3;
+    uint3 R3 = WaveActiveBitOr(V.xyz);
+    Out3[TID.x].xyz = R3;
 
-    Out4[tid.x] = WaveActiveBitOr(v);    
+    Out4[TID.x] = WaveActiveBitOr(V);    
     
     // constant folding uint4
-    Out5[tid.x] = WaveActiveBitOr(uint4(1,2,3,4));
+    Out5[TID.x] = WaveActiveBitOr(uint4(1,2,3,4));
     
 }
 

--- a/test/WaveOps/WaveActiveBitOr.int64.test
+++ b/test/WaveOps/WaveActiveBitOr.int64.test
@@ -9,20 +9,20 @@ RWStructuredBuffer<uint64_t4> Out4 : register(u4);
 RWStructuredBuffer<uint64_t4> Out5 : register(u5);
 
 [numthreads(4,1,1)]
-void main(uint3 tid : SV_GroupThreadID) {
-    uint64_t4 v64 = In[tid.x];
+void main(uint3 TID : SV_GroupThreadID) {
+    uint64_t4 V64 = In[TID.x];
 
-    Out1[tid.x] = WaveActiveBitOr(v64.x);
+    Out1[TID.x] = WaveActiveBitOr(V64.x);
 
-    Out2[tid.x] = WaveActiveBitOr(v64.xy);
+    Out2[TID.x] = WaveActiveBitOr(V64.xy);
 
-    uint64_t3 r64_3 = WaveActiveBitOr(v64.xyz);
-    Out3[tid.x].xyz = r64_3;
+    uint64_t3 R64_3 = WaveActiveBitOr(V64.xyz);
+    Out3[TID.x].xyz = R64_3;
 
-    Out4[tid.x] = WaveActiveBitOr(v64);
+    Out4[TID.x] = WaveActiveBitOr(V64);
 
     // constant folding uint4
-    Out5[tid.x] = WaveActiveBitOr(uint64_t4(1,2,3,4));
+    Out5[TID.x] = WaveActiveBitOr(uint64_t4(1,2,3,4));
 }
 
 #--- pipeline.yaml


### PR DESCRIPTION
This PR adds tests for WaveActiveBitOr.
WaveActiveBitOr only accepts uint and uint64 types.
The PR also adds a control flow test, since this operation is convergent.
Fixes https://github.com/llvm/offload-test-suite/issues/92
Assisted by: Claude Opus 4.6