### PR TITLE
Add WaveActiveBitAnd tests

### DIFF
--- a/test/WaveOps/WaveActiveBitAnd.convergence.test
+++ b/test/WaveOps/WaveActiveBitAnd.convergence.test
@@ -8,32 +8,32 @@ RWStructuredBuffer<uint> Out4 : register(u4); // loop
 RWStructuredBuffer<uint> Out5 : register(u5); // divergent loop
 
 [numthreads(4,1,1)]
-void main(uint3 tid : SV_GroupThreadID) {
-    uint V = In[tid.x];
+void main(uint3 TID : SV_GroupThreadID) {
+    uint V = In[TID.x];
 
     // divergent branch
-    if (tid.x < 2)
-        Out1[tid.x] = WaveActiveBitAnd(V);
+    if (TID.x < 2)
+        Out1[TID.x] = WaveActiveBitAnd(V);
     else
-        Out2[tid.x] = WaveActiveBitAnd(V);
+        Out2[TID.x] = WaveActiveBitAnd(V);
 
     // reconverged wave op
-    Out3[tid.x] = WaveActiveBitAnd(V);
+    Out3[TID.x] = WaveActiveBitAnd(V);
 
     // loop case
     uint R = V;
     for (uint i = 0; i < 2; i++)
         R = WaveActiveBitAnd(R);
 
-    Out4[tid.x] = R;
+    Out4[TID.x] = R;
 
-    // divergent loop: each thread iterates tid.x times
+    // divergent loop: each thread iterates TID.x times
     // thread 0: 0 iters, thread 1: 1 iter, thread 2: 2 iters, thread 3: 3 iters
     uint R2 = V;
-    for (uint j = 0; j < tid.x; j++)
+    for (uint j = 0; j < TID.x; j++)
         R2 = WaveActiveBitAnd(R2);
 
-    Out5[tid.x] = R2;
+    Out5[TID.x] = R2;
 }
 
 #--- pipeline.yaml

--- a/test/WaveOps/WaveActiveBitAnd.int.test
+++ b/test/WaveOps/WaveActiveBitAnd.int.test
@@ -8,20 +8,20 @@ RWStructuredBuffer<uint4> Out4 : register(u4);
 RWStructuredBuffer<uint4> Out5 : register(u5);
 
 [numthreads(4,1,1)]
-void main(uint3 tid : SV_GroupThreadID) {
-    uint4 V = In[tid.x];
+void main(uint3 TID : SV_GroupThreadID) {
+    uint4 V = In[TID.x];
 
-    Out1[tid.x] = WaveActiveBitAnd(V.x);
+    Out1[TID.x] = WaveActiveBitAnd(V.x);
 
-    Out2[tid.x] = WaveActiveBitAnd(V.xy);
+    Out2[TID.x] = WaveActiveBitAnd(V.xy);
 
     uint3 R3 = WaveActiveBitAnd(V.xyz);
-    Out3[tid.x].xyz = R3;
+    Out3[TID.x].xyz = R3;
 
-    Out4[tid.x] = WaveActiveBitAnd(V);
+    Out4[TID.x] = WaveActiveBitAnd(V);
 
     // constant folding uint4
-    Out5[tid.x] = WaveActiveBitAnd(uint4(1,2,3,4));
+    Out5[TID.x] = WaveActiveBitAnd(uint4(1,2,3,4));
 }
 
 #--- pipeline.yaml

--- a/test/WaveOps/WaveActiveBitAnd.int64.test
+++ b/test/WaveOps/WaveActiveBitAnd.int64.test
@@ -8,20 +8,20 @@ RWStructuredBuffer<uint64_t4> Out4 : register(u4);
 RWStructuredBuffer<uint64_t4> Out5 : register(u5);
 
 [numthreads(4,1,1)]
-void main(uint3 tid : SV_GroupThreadID) {
-    uint64_t4 V64 = In[tid.x];
+void main(uint3 TID : SV_GroupThreadID) {
+    uint64_t4 V64 = In[TID.x];
 
-    Out1[tid.x] = WaveActiveBitAnd(V64.x);
+    Out1[TID.x] = WaveActiveBitAnd(V64.x);
 
-    Out2[tid.x] = WaveActiveBitAnd(V64.xy);
+    Out2[TID.x] = WaveActiveBitAnd(V64.xy);
 
     uint64_t3 R64_3 = WaveActiveBitAnd(V64.xyz);
-    Out3[tid.x].xyz = R64_3;
+    Out3[TID.x].xyz = R64_3;
 
-    Out4[tid.x] = WaveActiveBitAnd(V64);
+    Out4[TID.x] = WaveActiveBitAnd(V64);
 
     // constant folding uint4
-    Out5[tid.x] = WaveActiveBitAnd(uint64_t4(1,2,3,4));
+    Out5[TID.x] = WaveActiveBitAnd(uint64_t4(1,2,3,4));
 }
 
 #--- pipeline.yaml


### PR DESCRIPTION
This PR adds tests for WaveActiveBitAnd .
WaveActiveBitAnd only accepts uint and uint64 types.
The PR also adds a control flow test, since this operation is convergent.
Fixes https://github.com/llvm/offload-test-suite/issues/895