### PR TITLE
Make element-alignment XFAILs specific to Vulkan

### DIFF
--- a/test/Feature/CBuffer/arrays-64bit.test
+++ b/test/Feature/CBuffer/arrays-64bit.test
@@ -94,9 +94,10 @@ DescriptorSets:
 #--- end
 
 # Bug: https://github.com/microsoft/DirectXShaderCompiler/issues/7819
-# XFAIL: Vulkan
-# Unimplemented https://github.com/llvm/llvm-project/issues/147352
-# XFAIL: Clang
+# XFAIL: Vulkan && DXC
+
+# Unimplemented https://github.com/llvm/llvm-project/issues/186465
+# XFAIL: Clang && Vulkan
 
 # REQUIRES: Double, Int64
 # RUN: split-file %s %t

--- a/test/Feature/CBuffer/vectors-64bit.test
+++ b/test/Feature/CBuffer/vectors-64bit.test
@@ -68,9 +68,8 @@ DescriptorSets:
 # Bug: https://github.com/llvm/offload-test-suite/issues/471
 # XFAIL: Vulkan && Intel
 
-# Clang trips on 3-element vectors in structs:
-# Bug https://github.com/llvm/llvm-project/issues/123968
-# XFAIL: Clang
+# Unimplemented https://github.com/llvm/llvm-project/issues/186465
+# XFAIL: Clang && Vulkan
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -fvk-use-dx-layout -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/CBuffer/vectors.test
+++ b/test/Feature/CBuffer/vectors.test
@@ -64,9 +64,8 @@ DescriptorSets:
 ...
 #--- end
 
-# Clang trips on 3-element vectors in structs:
-# Bug https://github.com/llvm/llvm-project/issues/123968
-# XFAIL: Clang
+# Unimplemented https://github.com/llvm/llvm-project/issues/186465
+# XFAIL: Clang && Vulkan
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -fvk-use-dx-layout -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/PushConstant/multiple_values_offset.test
+++ b/test/Feature/PushConstant/multiple_values_offset.test
@@ -47,8 +47,8 @@ DescriptorSets:
 #--- end
 # UNSUPPORTED: Metal || DirectX
 
-# Clang adds a 4-byte padding between `a` and `b`.
-# XFAIL: Clang
+# Unimplemented https://github.com/llvm/llvm-project/issues/186465
+# XFAIL: Clang && Vulkan
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl


### PR DESCRIPTION
Now that llvm/llvm-project#123968 is resolved, these all pass with clang for DirectX.