### PR TITLE
XFAIL Update: March 16th 2026

### DIFF
--- a/test/Feature/CBuffer/arrays-64bit.test
+++ b/test/Feature/CBuffer/arrays-64bit.test
@@ -96,9 +96,6 @@ DescriptorSets:
 # Bug: https://github.com/microsoft/DirectXShaderCompiler/issues/7819
 # XFAIL: Vulkan && DXC
 
-# Unimplemented https://github.com/llvm/llvm-project/issues/186465
-# XFAIL: Clang && Vulkan
-
 # REQUIRES: Double, Int64
 # RUN: split-file %s %t
 # RUN: %dxc_target -fvk-use-dx-layout -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/CBuffer/vectors-64bit.test
+++ b/test/Feature/CBuffer/vectors-64bit.test
@@ -68,9 +68,6 @@ DescriptorSets:
 # Bug: https://github.com/llvm/offload-test-suite/issues/471
 # XFAIL: Vulkan && Intel
 
-# Unimplemented https://github.com/llvm/llvm-project/issues/186465
-# XFAIL: Clang && Vulkan
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -fvk-use-dx-layout -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s

--- a/test/Feature/CBuffer/vectors.test
+++ b/test/Feature/CBuffer/vectors.test
@@ -64,9 +64,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Unimplemented https://github.com/llvm/llvm-project/issues/186465
-# XFAIL: Clang && Vulkan
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -fvk-use-dx-layout -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s

--- a/test/Feature/HLSLLib/transpose.bool.test
+++ b/test/Feature/HLSLLib/transpose.bool.test
@@ -102,9 +102,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Not implemented https://github.com/llvm/wg-hlsl/issues/238
-# XFAIL: Clang
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/transpose.fp16.test
+++ b/test/Feature/HLSLLib/transpose.fp16.test
@@ -105,9 +105,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Not implemented https://github.com/llvm/wg-hlsl/issues/238
-# XFAIL: Clang
-
 # Bug https://github.com/llvm/offload-test-suite/issues/779
 # XFAIL: Intel && DirectX && DXC
 

--- a/test/Feature/HLSLLib/transpose.fp32.test
+++ b/test/Feature/HLSLLib/transpose.fp32.test
@@ -103,9 +103,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Not implemented https://github.com/llvm/wg-hlsl/issues/238
-# XFAIL: Clang
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/transpose.fp64.test
+++ b/test/Feature/HLSLLib/transpose.fp64.test
@@ -103,9 +103,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Not implemented https://github.com/llvm/wg-hlsl/issues/238
-# XFAIL: Clang
-
 # REQUIRES: Double
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/transpose.int16.test
+++ b/test/Feature/HLSLLib/transpose.int16.test
@@ -102,9 +102,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Not implemented https://github.com/llvm/wg-hlsl/issues/238
-# XFAIL: Clang
-
 # Bug https://github.com/llvm/offload-test-suite/issues/779
 # XFAIL: Intel && DirectX && DXC
 

--- a/test/Feature/HLSLLib/transpose.int32.test
+++ b/test/Feature/HLSLLib/transpose.int32.test
@@ -102,9 +102,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Not implemented https://github.com/llvm/wg-hlsl/issues/238
-# XFAIL: Clang
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/transpose.int64.test
+++ b/test/Feature/HLSLLib/transpose.int64.test
@@ -102,9 +102,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Not implemented https://github.com/llvm/wg-hlsl/issues/238
-# XFAIL: Clang
-
 # Bug https://github.com/llvm/offload-test-suite/issues/780
 # XFAIL: QC && DirectX && DXC
 


### PR DESCRIPTION
This patch removes the XFAIL from transpose intrinsic as well as cbuffers 