### PR TITLE
Use DX layout and fix incorrect bindings in matrix cbuffer tests

### DIFF
--- a/test/Feature/CBuffer/Matrix/MatrixElement/one_based_mat_element.f32.test
+++ b/test/Feature/CBuffer/Matrix/MatrixElement/one_based_mat_element.f32.test
@@ -1,22 +1,22 @@
 #--- source.hlsl
-RWStructuredBuffer<float4> Out_f1x4 : register(u0);
-RWStructuredBuffer<float4> Out_f2x4 : register(u1);
-RWStructuredBuffer<float2> Out_f3x2 : register(u2);
-RWStructuredBuffer<float2> Out_f4x2 : register(u3);
+RWStructuredBuffer<float4> Out_f1x4 : register(u4);
+RWStructuredBuffer<float4> Out_f2x4 : register(u5);
+RWStructuredBuffer<float2> Out_f3x2 : register(u6);
+RWStructuredBuffer<float2> Out_f4x2 : register(u7);
 
-cbuffer example_f1x4 : register(b1) {
+cbuffer example_f1x4 : register(b0) {
     float1x4 M_f1x4;
 };
 
-cbuffer example_f2x4 : register(b2) {
+cbuffer example_f2x4 : register(b1) {
     float2x4 M_f2x4;
 };
 
-cbuffer example_f3x2 : register(b3) {
+cbuffer example_f3x2 : register(b2) {
     float3x2 M_f3x2;
 };
 
-cbuffer example_f4x2 : register(b4) {
+cbuffer example_f4x2 : register(b3) {
     float4x2 M_f4x2;
 };
 
@@ -125,56 +125,56 @@ DescriptorSets:
     - Name: cbuffer_f1x4
       Kind: ConstantBuffer
       DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: cbuffer_f2x4
+      Kind: ConstantBuffer
+      DirectXBinding:
         Register: 1
         Space: 0
       VulkanBinding:
         Binding: 1
-    - Name: cbuffer_f2x4
+    - Name: cbuffer_f3x2
       Kind: ConstantBuffer
       DirectXBinding:
         Register: 2
         Space: 0
       VulkanBinding:
         Binding: 2
-    - Name: cbuffer_f3x2
+    - Name: cbuffer_f4x2
       Kind: ConstantBuffer
       DirectXBinding:
         Register: 3
         Space: 0
       VulkanBinding:
         Binding: 3
-    - Name: cbuffer_f4x2
-      Kind: ConstantBuffer
+    - Name: Out_f1x4
+      Kind: RWStructuredBuffer
       DirectXBinding:
         Register: 4
         Space: 0
       VulkanBinding:
         Binding: 4
-    - Name: Out_f1x4
-      Kind: RWStructuredBuffer
-      DirectXBinding:
-        Register: 0
-        Space: 0
-      VulkanBinding:
-        Binding: 0
     - Name: Out_f2x4
       Kind: RWStructuredBuffer
       DirectXBinding:
-        Register: 1
+        Register: 5
         Space: 0
       VulkanBinding:
         Binding: 5
     - Name: Out_f3x2
       Kind: RWStructuredBuffer
       DirectXBinding:
-        Register: 2
+        Register: 6
         Space: 0
       VulkanBinding:
         Binding: 6
     - Name: Out_f4x2
       Kind: RWStructuredBuffer
       DirectXBinding:
-        Register: 3
+        Register: 7
         Space: 0
       VulkanBinding:
         Binding: 7
@@ -187,10 +187,6 @@ DescriptorSets:
 # BUG https://github.com/llvm/llvm-project/issues/179879
 # XFAIL: Clang && Vulkan
 
-# Note: NV crashes AMD and Intel Output buffers are empty.
-# Bug https://github.com/microsoft/DirectXShaderCompiler/issues/8218
-# XFAIL: DXC && Vulkan
-
 # RUN: split-file %s %t
-# RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -fvk-use-dx-layout -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/CBuffer/Matrix/MatrixElement/one_based_mat_element_scalar.f32.test
+++ b/test/Feature/CBuffer/Matrix/MatrixElement/one_based_mat_element_scalar.f32.test
@@ -1,22 +1,22 @@
 #--- source.hlsl
-RWStructuredBuffer<float> Out_f1x4 : register(u0);
-RWStructuredBuffer<float> Out_f2x4 : register(u1);
-RWStructuredBuffer<float> Out_f3x2 : register(u2);
-RWStructuredBuffer<float> Out_f4x2 : register(u3);
+RWStructuredBuffer<float> Out_f1x4 : register(u4);
+RWStructuredBuffer<float> Out_f2x4 : register(u5);
+RWStructuredBuffer<float> Out_f3x2 : register(u6);
+RWStructuredBuffer<float> Out_f4x2 : register(u7);
 
-cbuffer example_f1x4 : register(b1) {
+cbuffer example_f1x4 : register(b0) {
     float1x4 M_f1x4;
 };
 
-cbuffer example_f2x4 : register(b2) {
+cbuffer example_f2x4 : register(b1) {
     float2x4 M_f2x4;
 };
 
-cbuffer example_f3x2 : register(b3) {
+cbuffer example_f3x2 : register(b2) {
     float3x2 M_f3x2;
 };
 
-cbuffer example_f4x2 : register(b4) {
+cbuffer example_f4x2 : register(b3) {
     float4x2 M_f4x2;
 };
 
@@ -136,56 +136,56 @@ DescriptorSets:
     - Name: cbuffer_f1x4
       Kind: ConstantBuffer
       DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: cbuffer_f2x4
+      Kind: ConstantBuffer
+      DirectXBinding:
         Register: 1
         Space: 0
       VulkanBinding:
         Binding: 1
-    - Name: cbuffer_f2x4
+    - Name: cbuffer_f3x2
       Kind: ConstantBuffer
       DirectXBinding:
         Register: 2
         Space: 0
       VulkanBinding:
         Binding: 2
-    - Name: cbuffer_f3x2
+    - Name: cbuffer_f4x2
       Kind: ConstantBuffer
       DirectXBinding:
         Register: 3
         Space: 0
       VulkanBinding:
         Binding: 3
-    - Name: cbuffer_f4x2
-      Kind: ConstantBuffer
+    - Name: Out_f1x4
+      Kind: RWStructuredBuffer
       DirectXBinding:
         Register: 4
         Space: 0
       VulkanBinding:
         Binding: 4
-    - Name: Out_f1x4
-      Kind: RWStructuredBuffer
-      DirectXBinding:
-        Register: 0
-        Space: 0
-      VulkanBinding:
-        Binding: 0
     - Name: Out_f2x4
       Kind: RWStructuredBuffer
       DirectXBinding:
-        Register: 1
+        Register: 5
         Space: 0
       VulkanBinding:
         Binding: 5
     - Name: Out_f3x2
       Kind: RWStructuredBuffer
       DirectXBinding:
-        Register: 2
+        Register: 6
         Space: 0
       VulkanBinding:
         Binding: 6
     - Name: Out_f4x2
       Kind: RWStructuredBuffer
       DirectXBinding:
-        Register: 3
+        Register: 7
         Space: 0
       VulkanBinding:
         Binding: 7
@@ -198,10 +198,6 @@ DescriptorSets:
 # BUG https://github.com/llvm/llvm-project/issues/179879
 # XFAIL: Clang && Vulkan
 
-# Note: NV crashes AMD and Intel Output buffers are empty.
-# Bug https://github.com/microsoft/DirectXShaderCompiler/issues/8218
-# XFAIL: DXC && Vulkan
-
 # RUN: split-file %s %t
-# RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -fvk-use-dx-layout -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/CBuffer/Matrix/MatrixElement/zero_based_mat_element.f32.test
+++ b/test/Feature/CBuffer/Matrix/MatrixElement/zero_based_mat_element.f32.test
@@ -1,22 +1,22 @@
 #--- source.hlsl
-RWStructuredBuffer<float4> Out_f1x4 : register(u0);
-RWStructuredBuffer<float4> Out_f2x4 : register(u1);
-RWStructuredBuffer<float2> Out_f3x2 : register(u2);
-RWStructuredBuffer<float2> Out_f4x2 : register(u3);
+RWStructuredBuffer<float4> Out_f1x4 : register(u4);
+RWStructuredBuffer<float4> Out_f2x4 : register(u5);
+RWStructuredBuffer<float2> Out_f3x2 : register(u6);
+RWStructuredBuffer<float2> Out_f4x2 : register(u7);
 
-cbuffer example_f1x4 : register(b1) {
+cbuffer example_f1x4 : register(b0) {
     float1x4 M_f1x4;
 };
 
-cbuffer example_f2x4 : register(b2) {
+cbuffer example_f2x4 : register(b1) {
     float2x4 M_f2x4;
 };
 
-cbuffer example_f3x2 : register(b3) {
+cbuffer example_f3x2 : register(b2) {
     float3x2 M_f3x2;
 };
 
-cbuffer example_f4x2 : register(b4) {
+cbuffer example_f4x2 : register(b3) {
     float4x2 M_f4x2;
 };
 
@@ -125,56 +125,56 @@ DescriptorSets:
     - Name: cbuffer_f1x4
       Kind: ConstantBuffer
       DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: cbuffer_f2x4
+      Kind: ConstantBuffer
+      DirectXBinding:
         Register: 1
         Space: 0
       VulkanBinding:
         Binding: 1
-    - Name: cbuffer_f2x4
+    - Name: cbuffer_f3x2
       Kind: ConstantBuffer
       DirectXBinding:
         Register: 2
         Space: 0
       VulkanBinding:
         Binding: 2
-    - Name: cbuffer_f3x2
+    - Name: cbuffer_f4x2
       Kind: ConstantBuffer
       DirectXBinding:
         Register: 3
         Space: 0
       VulkanBinding:
         Binding: 3
-    - Name: cbuffer_f4x2
-      Kind: ConstantBuffer
+    - Name: Out_f1x4
+      Kind: RWStructuredBuffer
       DirectXBinding:
         Register: 4
         Space: 0
       VulkanBinding:
         Binding: 4
-    - Name: Out_f1x4
-      Kind: RWStructuredBuffer
-      DirectXBinding:
-        Register: 0
-        Space: 0
-      VulkanBinding:
-        Binding: 0
     - Name: Out_f2x4
       Kind: RWStructuredBuffer
       DirectXBinding:
-        Register: 1
+        Register: 5
         Space: 0
       VulkanBinding:
         Binding: 5
     - Name: Out_f3x2
       Kind: RWStructuredBuffer
       DirectXBinding:
-        Register: 2
+        Register: 6
         Space: 0
       VulkanBinding:
         Binding: 6
     - Name: Out_f4x2
       Kind: RWStructuredBuffer
       DirectXBinding:
-        Register: 3
+        Register: 7
         Space: 0
       VulkanBinding:
         Binding: 7
@@ -187,10 +187,6 @@ DescriptorSets:
 # BUG https://github.com/llvm/llvm-project/issues/179879
 # XFAIL: Clang && Vulkan
 
-# Note: NV crashes AMD and Intel Output buffers are empty.
-# Bug https://github.com/microsoft/DirectXShaderCompiler/issues/8218
-# XFAIL: DXC && Vulkan
-
 # RUN: split-file %s %t
-# RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -fvk-use-dx-layout -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/CBuffer/Matrix/MatrixElement/zero_based_mat_element_scalar.f32.test
+++ b/test/Feature/CBuffer/Matrix/MatrixElement/zero_based_mat_element_scalar.f32.test
@@ -1,22 +1,22 @@
 #--- source.hlsl
-RWStructuredBuffer<float> Out_f1x4 : register(u0);
-RWStructuredBuffer<float> Out_f2x4 : register(u1);
-RWStructuredBuffer<float> Out_f3x2 : register(u2);
-RWStructuredBuffer<float> Out_f4x2 : register(u3);
+RWStructuredBuffer<float> Out_f1x4 : register(u4);
+RWStructuredBuffer<float> Out_f2x4 : register(u5);
+RWStructuredBuffer<float> Out_f3x2 : register(u6);
+RWStructuredBuffer<float> Out_f4x2 : register(u7);
 
-cbuffer example_f1x4 : register(b1) {
+cbuffer example_f1x4 : register(b0) {
     float1x4 M_f1x4;
 };
 
-cbuffer example_f2x4 : register(b2) {
+cbuffer example_f2x4 : register(b1) {
     float2x4 M_f2x4;
 };
 
-cbuffer example_f3x2 : register(b3) {
+cbuffer example_f3x2 : register(b2) {
     float3x2 M_f3x2;
 };
 
-cbuffer example_f4x2 : register(b4) {
+cbuffer example_f4x2 : register(b3) {
     float4x2 M_f4x2;
 };
 
@@ -136,56 +136,56 @@ DescriptorSets:
     - Name: cbuffer_f1x4
       Kind: ConstantBuffer
       DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: cbuffer_f2x4
+      Kind: ConstantBuffer
+      DirectXBinding:
         Register: 1
         Space: 0
       VulkanBinding:
         Binding: 1
-    - Name: cbuffer_f2x4
+    - Name: cbuffer_f3x2
       Kind: ConstantBuffer
       DirectXBinding:
         Register: 2
         Space: 0
       VulkanBinding:
         Binding: 2
-    - Name: cbuffer_f3x2
+    - Name: cbuffer_f4x2
       Kind: ConstantBuffer
       DirectXBinding:
         Register: 3
         Space: 0
       VulkanBinding:
         Binding: 3
-    - Name: cbuffer_f4x2
-      Kind: ConstantBuffer
+    - Name: Out_f1x4
+      Kind: RWStructuredBuffer
       DirectXBinding:
         Register: 4
         Space: 0
       VulkanBinding:
         Binding: 4
-    - Name: Out_f1x4
-      Kind: RWStructuredBuffer
-      DirectXBinding:
-        Register: 0
-        Space: 0
-      VulkanBinding:
-        Binding: 0
     - Name: Out_f2x4
       Kind: RWStructuredBuffer
       DirectXBinding:
-        Register: 1
+        Register: 5
         Space: 0
       VulkanBinding:
         Binding: 5
     - Name: Out_f3x2
       Kind: RWStructuredBuffer
       DirectXBinding:
-        Register: 2
+        Register: 6
         Space: 0
       VulkanBinding:
         Binding: 6
     - Name: Out_f4x2
       Kind: RWStructuredBuffer
       DirectXBinding:
-        Register: 3
+        Register: 7
         Space: 0
       VulkanBinding:
         Binding: 7
@@ -198,10 +198,6 @@ DescriptorSets:
 # BUG https://github.com/llvm/llvm-project/issues/179879
 # XFAIL: Clang && Vulkan
 
-# Note: NV crashes AMD and Intel Output buffers are empty.
-# Bug https://github.com/microsoft/DirectXShaderCompiler/issues/8218
-# XFAIL: DXC && Vulkan
-
 # RUN: split-file %s %t
-# RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -fvk-use-dx-layout -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/CBuffer/Matrix/MatrixSubscript/matrix_subscript.f32.test
+++ b/test/Feature/CBuffer/Matrix/MatrixSubscript/matrix_subscript.f32.test
@@ -1,22 +1,22 @@
 #--- source.hlsl
-RWStructuredBuffer<float> Out_f1x4 : register(u0);
-RWStructuredBuffer<float> Out_f2x4 : register(u1);
-RWStructuredBuffer<float> Out_f3x2 : register(u2);
-RWStructuredBuffer<float> Out_f4x2 : register(u3);
+RWStructuredBuffer<float> Out_f1x4 : register(u4);
+RWStructuredBuffer<float> Out_f2x4 : register(u5);
+RWStructuredBuffer<float> Out_f3x2 : register(u6);
+RWStructuredBuffer<float> Out_f4x2 : register(u7);
 
-cbuffer example_f1x4 : register(b1) {
+cbuffer example_f1x4 : register(b0) {
     float1x4 M_f1x4;
 };
 
-cbuffer example_f2x4 : register(b2) {
+cbuffer example_f2x4 : register(b1) {
     float2x4 M_f2x4;
 };
 
-cbuffer example_f3x2 : register(b3) {
+cbuffer example_f3x2 : register(b2) {
     float3x2 M_f3x2;
 };
 
-cbuffer example_f4x2 : register(b4) {
+cbuffer example_f4x2 : register(b3) {
     float4x2 M_f4x2;
 };
 
@@ -136,56 +136,56 @@ DescriptorSets:
     - Name: cbuffer_f1x4
       Kind: ConstantBuffer
       DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: cbuffer_f2x4
+      Kind: ConstantBuffer
+      DirectXBinding:
         Register: 1
         Space: 0
       VulkanBinding:
         Binding: 1
-    - Name: cbuffer_f2x4
+    - Name: cbuffer_f3x2
       Kind: ConstantBuffer
       DirectXBinding:
         Register: 2
         Space: 0
       VulkanBinding:
         Binding: 2
-    - Name: cbuffer_f3x2
+    - Name: cbuffer_f4x2
       Kind: ConstantBuffer
       DirectXBinding:
         Register: 3
         Space: 0
       VulkanBinding:
         Binding: 3
-    - Name: cbuffer_f4x2
-      Kind: ConstantBuffer
+    - Name: Out_f1x4
+      Kind: RWStructuredBuffer
       DirectXBinding:
         Register: 4
         Space: 0
       VulkanBinding:
         Binding: 4
-    - Name: Out_f1x4
-      Kind: RWStructuredBuffer
-      DirectXBinding:
-        Register: 0
-        Space: 0
-      VulkanBinding:
-        Binding: 0
     - Name: Out_f2x4
       Kind: RWStructuredBuffer
       DirectXBinding:
-        Register: 1
+        Register: 5
         Space: 0
       VulkanBinding:
         Binding: 5
     - Name: Out_f3x2
       Kind: RWStructuredBuffer
       DirectXBinding:
-        Register: 2
+        Register: 6
         Space: 0
       VulkanBinding:
         Binding: 6
     - Name: Out_f4x2
       Kind: RWStructuredBuffer
       DirectXBinding:
-        Register: 3
+        Register: 7
         Space: 0
       VulkanBinding:
         Binding: 7
@@ -194,14 +194,10 @@ DescriptorSets:
 # Are always empty
 # UNSUPPORTED: Darwin
 
-# Note: NV crashes AMD and Intel Output buffers are empty.
-# Bug https://github.com/microsoft/DirectXShaderCompiler/issues/8218
-# XFAIL: DXC && Vulkan
-
 # Note: clang Vulkan crashes
 # BUG https://github.com/llvm/llvm-project/issues/179879
 # XFAIL: Clang && Vulkan
 
 # RUN: split-file %s %t
-# RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -fvk-use-dx-layout -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/CBuffer/Matrix/MatrixSubscript/row_major_flag_matrix_subscript.f32.test
+++ b/test/Feature/CBuffer/Matrix/MatrixSubscript/row_major_flag_matrix_subscript.f32.test
@@ -1,22 +1,22 @@
 #--- source.hlsl
-RWStructuredBuffer<float> Out_f4x1 : register(u0);
-RWStructuredBuffer<float> Out_f4x2 : register(u1);
-RWStructuredBuffer<float> Out_f2x3 : register(u2);
-RWStructuredBuffer<float> Out_f2x4 : register(u3);
+RWStructuredBuffer<float> Out_f4x1 : register(u4);
+RWStructuredBuffer<float> Out_f4x2 : register(u5);
+RWStructuredBuffer<float> Out_f2x3 : register(u6);
+RWStructuredBuffer<float> Out_f2x4 : register(u7);
 
-cbuffer example_f4x1 : register(b1) {
+cbuffer example_f4x1 : register(b0) {
     float4x1 M_f4x1;
 };
 
-cbuffer example_f4x2 : register(b2) {
+cbuffer example_f4x2 : register(b1) {
     float4x2 M_f4x2;
 };
 
-cbuffer example_f3x2 : register(b3) {
+cbuffer example_f3x2 : register(b2) {
     float2x3 M_f2x3;
 };
 
-cbuffer example_f2x4 : register(b4) {
+cbuffer example_f2x4 : register(b3) {
     float2x4 M_f2x4;
 };
 
@@ -136,56 +136,56 @@ DescriptorSets:
     - Name: cbuffer_f4x1
       Kind: ConstantBuffer
       DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: cbuffer_f2x4
+      Kind: ConstantBuffer
+      DirectXBinding:
         Register: 1
         Space: 0
       VulkanBinding:
         Binding: 1
-    - Name: cbuffer_f2x4
+    - Name: cbuffer_f3x2
       Kind: ConstantBuffer
       DirectXBinding:
         Register: 2
         Space: 0
       VulkanBinding:
         Binding: 2
-    - Name: cbuffer_f3x2
+    - Name: cbuffer_f4x2
       Kind: ConstantBuffer
       DirectXBinding:
         Register: 3
         Space: 0
       VulkanBinding:
         Binding: 3
-    - Name: cbuffer_f4x2
-      Kind: ConstantBuffer
+    - Name: Out_f4x1
+      Kind: RWStructuredBuffer
       DirectXBinding:
         Register: 4
         Space: 0
       VulkanBinding:
         Binding: 4
-    - Name: Out_f4x1
-      Kind: RWStructuredBuffer
-      DirectXBinding:
-        Register: 0
-        Space: 0
-      VulkanBinding:
-        Binding: 0
     - Name: Out_f4x2
       Kind: RWStructuredBuffer
       DirectXBinding:
-        Register: 1
+        Register: 5
         Space: 0
       VulkanBinding:
         Binding: 5
     - Name: Out_f2x3
       Kind: RWStructuredBuffer
       DirectXBinding:
-        Register: 2
+        Register: 6
         Space: 0
       VulkanBinding:
         Binding: 6
     - Name: Out_f2x4
       Kind: RWStructuredBuffer
       DirectXBinding:
-        Register: 3
+        Register: 7
         Space: 0
       VulkanBinding:
         Binding: 7
@@ -198,10 +198,6 @@ DescriptorSets:
 # BUG https://github.com/llvm/llvm-project/issues/179879
 # XFAIL: Clang && Vulkan
 
-# Note: NV crashes AMD and Intel Output buffers are empty.
-# Bug https://github.com/microsoft/DirectXShaderCompiler/issues/8218
-# XFAIL: DXC && Vulkan
-
 # RUN: split-file %s %t
-# RUN: %dxc_target -T cs_6_0 -Zpr -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -fvk-use-dx-layout -T cs_6_0 -Zpr -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/CBuffer/Matrix/MatrixSubscript/row_major_matrix_subscript.f32.test
+++ b/test/Feature/CBuffer/Matrix/MatrixSubscript/row_major_matrix_subscript.f32.test
@@ -1,22 +1,22 @@
 #--- source.hlsl
-RWStructuredBuffer<float> Out_f4x1 : register(u0);
-RWStructuredBuffer<float> Out_f4x2 : register(u1);
-RWStructuredBuffer<float> Out_f2x3 : register(u2);
-RWStructuredBuffer<float> Out_f2x4 : register(u3);
+RWStructuredBuffer<float> Out_f4x1 : register(u4);
+RWStructuredBuffer<float> Out_f4x2 : register(u5);
+RWStructuredBuffer<float> Out_f2x3 : register(u6);
+RWStructuredBuffer<float> Out_f2x4 : register(u7);
 
-cbuffer example_f4x1 : register(b1) {
+cbuffer example_f4x1 : register(b0) {
     row_major float4x1 M_f4x1;
 };
 
-cbuffer example_f4x2 : register(b2) {
+cbuffer example_f4x2 : register(b1) {
     row_major float4x2 M_f4x2;
 };
 
-cbuffer example_f3x2 : register(b3) {
+cbuffer example_f3x2 : register(b2) {
     row_major float2x3 M_f2x3;
 };
 
-cbuffer example_f2x4 : register(b4) {
+cbuffer example_f2x4 : register(b3) {
     row_major float2x4 M_f2x4;
 };
 
@@ -136,56 +136,56 @@ DescriptorSets:
     - Name: cbuffer_f4x1
       Kind: ConstantBuffer
       DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: cbuffer_f2x4
+      Kind: ConstantBuffer
+      DirectXBinding:
         Register: 1
         Space: 0
       VulkanBinding:
         Binding: 1
-    - Name: cbuffer_f2x4
+    - Name: cbuffer_f3x2
       Kind: ConstantBuffer
       DirectXBinding:
         Register: 2
         Space: 0
       VulkanBinding:
         Binding: 2
-    - Name: cbuffer_f3x2
+    - Name: cbuffer_f4x2
       Kind: ConstantBuffer
       DirectXBinding:
         Register: 3
         Space: 0
       VulkanBinding:
         Binding: 3
-    - Name: cbuffer_f4x2
-      Kind: ConstantBuffer
+    - Name: Out_f4x1
+      Kind: RWStructuredBuffer
       DirectXBinding:
         Register: 4
         Space: 0
       VulkanBinding:
         Binding: 4
-    - Name: Out_f4x1
-      Kind: RWStructuredBuffer
-      DirectXBinding:
-        Register: 0
-        Space: 0
-      VulkanBinding:
-        Binding: 0
     - Name: Out_f4x2
       Kind: RWStructuredBuffer
       DirectXBinding:
-        Register: 1
+        Register: 5
         Space: 0
       VulkanBinding:
         Binding: 5
     - Name: Out_f2x3
       Kind: RWStructuredBuffer
       DirectXBinding:
-        Register: 2
+        Register: 6
         Space: 0
       VulkanBinding:
         Binding: 6
     - Name: Out_f2x4
       Kind: RWStructuredBuffer
       DirectXBinding:
-        Register: 3
+        Register: 7
         Space: 0
       VulkanBinding:
         Binding: 7
@@ -197,10 +197,6 @@ DescriptorSets:
 # Unimplemented https://github.com/llvm/llvm-project/issues/185049
 # XFAIL: Clang
 
-# Note: NV crashes AMD and Intel Output buffers are empty.
-# Bug https://github.com/microsoft/DirectXShaderCompiler/issues/8218
-# XFAIL: DXC && Vulkan
-
 # RUN: split-file %s %t
-# RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -fvk-use-dx-layout -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/CBuffer/Matrix/SingleSubscript/mat_cbuffer-swizzle.f32.test
+++ b/test/Feature/CBuffer/Matrix/SingleSubscript/mat_cbuffer-swizzle.f32.test
@@ -1,22 +1,22 @@
 #--- source.hlsl
-RWStructuredBuffer<float4> Out_f1x4 : register(u0);
-RWStructuredBuffer<float4> Out_f2x4 : register(u1);
-RWStructuredBuffer<float2> Out_f3x2 : register(u2);
-RWStructuredBuffer<float2> Out_f4x2 : register(u3);
+RWStructuredBuffer<float4> Out_f1x4 : register(u4);
+RWStructuredBuffer<float4> Out_f2x4 : register(u5);
+RWStructuredBuffer<float2> Out_f3x2 : register(u6);
+RWStructuredBuffer<float2> Out_f4x2 : register(u7);
 
-cbuffer example_f1x4 : register(b1) {
+cbuffer example_f1x4 : register(b0) {
     float1x4 M_f1x4;
 };
 
-cbuffer example_f2x4 : register(b2) {
+cbuffer example_f2x4 : register(b1) {
     float2x4 M_f2x4;
 };
 
-cbuffer example_f3x2 : register(b3) {
+cbuffer example_f3x2 : register(b2) {
     float3x2 M_f3x2;
 };
 
-cbuffer example_f4x2 : register(b4) {
+cbuffer example_f4x2 : register(b3) {
     float4x2 M_f4x2;
 };
 
@@ -115,56 +115,56 @@ DescriptorSets:
     - Name: cbuffer_f1x4
       Kind: ConstantBuffer
       DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: cbuffer_f2x4
+      Kind: ConstantBuffer
+      DirectXBinding:
         Register: 1
         Space: 0
       VulkanBinding:
         Binding: 1
-    - Name: cbuffer_f2x4
+    - Name: cbuffer_f3x2
       Kind: ConstantBuffer
       DirectXBinding:
         Register: 2
         Space: 0
       VulkanBinding:
         Binding: 2
-    - Name: cbuffer_f3x2
+    - Name: cbuffer_f4x2
       Kind: ConstantBuffer
       DirectXBinding:
         Register: 3
         Space: 0
       VulkanBinding:
         Binding: 3
-    - Name: cbuffer_f4x2
-      Kind: ConstantBuffer
+    - Name: Out_f1x4
+      Kind: RWStructuredBuffer
       DirectXBinding:
         Register: 4
         Space: 0
       VulkanBinding:
         Binding: 4
-    - Name: Out_f1x4
-      Kind: RWStructuredBuffer
-      DirectXBinding:
-        Register: 0
-        Space: 0
-      VulkanBinding:
-        Binding: 0
     - Name: Out_f2x4
       Kind: RWStructuredBuffer
       DirectXBinding:
-        Register: 1
+        Register: 5
         Space: 0
       VulkanBinding:
         Binding: 5
     - Name: Out_f3x2
       Kind: RWStructuredBuffer
       DirectXBinding:
-        Register: 2
+        Register: 6
         Space: 0
       VulkanBinding:
         Binding: 6
     - Name: Out_f4x2
       Kind: RWStructuredBuffer
       DirectXBinding:
-        Register: 3
+        Register: 7
         Space: 0
       VulkanBinding:
         Binding: 7
@@ -177,10 +177,6 @@ DescriptorSets:
 # BUG https://github.com/llvm/llvm-project/issues/179879
 # XFAIL: Clang && Vulkan
 
-# Note: NV crashes AMD and Intel Output buffers are empty.
-# Bug https://github.com/microsoft/DirectXShaderCompiler/issues/8218
-# XFAIL: DXC && Vulkan
-
 # RUN: split-file %s %t
-# RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -fvk-use-dx-layout -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/CBuffer/Matrix/SingleSubscript/mat_cbuffer.f32.test
+++ b/test/Feature/CBuffer/Matrix/SingleSubscript/mat_cbuffer.f32.test
@@ -1,22 +1,22 @@
 #--- source.hlsl
-RWStructuredBuffer<float4> Out_f1x4 : register(u0);
-RWStructuredBuffer<float4> Out_f2x4 : register(u1);
-RWStructuredBuffer<float2> Out_f3x2 : register(u2);
-RWStructuredBuffer<float2> Out_f4x2 : register(u3);
+RWStructuredBuffer<float4> Out_f1x4 : register(u4);
+RWStructuredBuffer<float4> Out_f2x4 : register(u5);
+RWStructuredBuffer<float2> Out_f3x2 : register(u6);
+RWStructuredBuffer<float2> Out_f4x2 : register(u7);
 
-cbuffer example_f1x4 : register(b1) {
+cbuffer example_f1x4 : register(b0) {
     float1x4 M_f1x4;
 };
 
-cbuffer example_f2x4 : register(b2) {
+cbuffer example_f2x4 : register(b1) {
     float2x4 M_f2x4;
 };
 
-cbuffer example_f3x2 : register(b3) {
+cbuffer example_f3x2 : register(b2) {
     float3x2 M_f3x2;
 };
 
-cbuffer example_f4x2 : register(b4) {
+cbuffer example_f4x2 : register(b3) {
     float4x2 M_f4x2;
 };
 
@@ -115,56 +115,56 @@ DescriptorSets:
     - Name: cbuffer_f1x4
       Kind: ConstantBuffer
       DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: cbuffer_f2x4
+      Kind: ConstantBuffer
+      DirectXBinding:
         Register: 1
         Space: 0
       VulkanBinding:
         Binding: 1
-    - Name: cbuffer_f2x4
+    - Name: cbuffer_f3x2
       Kind: ConstantBuffer
       DirectXBinding:
         Register: 2
         Space: 0
       VulkanBinding:
         Binding: 2
-    - Name: cbuffer_f3x2
+    - Name: cbuffer_f4x2
       Kind: ConstantBuffer
       DirectXBinding:
         Register: 3
         Space: 0
       VulkanBinding:
         Binding: 3
-    - Name: cbuffer_f4x2
-      Kind: ConstantBuffer
+    - Name: Out_f1x4
+      Kind: RWStructuredBuffer
       DirectXBinding:
         Register: 4
         Space: 0
       VulkanBinding:
         Binding: 4
-    - Name: Out_f1x4
-      Kind: RWStructuredBuffer
-      DirectXBinding:
-        Register: 0
-        Space: 0
-      VulkanBinding:
-        Binding: 0
     - Name: Out_f2x4
       Kind: RWStructuredBuffer
       DirectXBinding:
-        Register: 1
+        Register: 5
         Space: 0
       VulkanBinding:
         Binding: 5
     - Name: Out_f3x2
       Kind: RWStructuredBuffer
       DirectXBinding:
-        Register: 2
+        Register: 6
         Space: 0
       VulkanBinding:
         Binding: 6
     - Name: Out_f4x2
       Kind: RWStructuredBuffer
       DirectXBinding:
-        Register: 3
+        Register: 7
         Space: 0
       VulkanBinding:
         Binding: 7
@@ -173,14 +173,10 @@ DescriptorSets:
 # Are always empty
 # UNSUPPORTED: Darwin
 
-# Note: NV crashes AMD and Intel Output buffers are empty.
-# Bug https://github.com/microsoft/DirectXShaderCompiler/issues/8218
-# XFAIL: DXC && Vulkan
-
 # Note: clang Vulkan crashes
 # BUG https://github.com/llvm/llvm-project/issues/179879
 # XFAIL: Clang && Vulkan
 
 # RUN: split-file %s %t
-# RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -fvk-use-dx-layout -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/CBuffer/Matrix/SingleSubscript/mat_cbuffer_threadgroup.f4x2.test
+++ b/test/Feature/CBuffer/Matrix/SingleSubscript/mat_cbuffer_threadgroup.f4x2.test
@@ -1,6 +1,6 @@
 #--- source.hlsl
-RWStructuredBuffer<float4> Out_f2x4 : register(u0); 
-RWStructuredBuffer<float2> Out_f4x2 : register(u1);
+RWStructuredBuffer<float4> Out_f2x4 : register(u2); 
+RWStructuredBuffer<float2> Out_f4x2 : register(u3);
 
 cbuffer example_f2x4 : register(b0) {
     float2x4 M_f2x4;
@@ -75,14 +75,14 @@ DescriptorSets:
     - Name: Out_f2x4
       Kind: RWStructuredBuffer
       DirectXBinding:
-        Register: 0
+        Register: 2
         Space: 0
       VulkanBinding:
         Binding: 2
     - Name: Out_f4x2
       Kind: RWStructuredBuffer
       DirectXBinding:
-        Register: 1
+        Register: 3
         Space: 0
       VulkanBinding:
         Binding: 3
@@ -91,11 +91,6 @@ DescriptorSets:
 # Note: Metal and Vulkan KosmicKrisp and MoltenVK 
 # Are always empty
 # UNSUPPORTED: Darwin
-
-# Note: NV crashes AMD and Intel Output buffers are empty.
-# Bug https://github.com/microsoft/DirectXShaderCompiler/issues/8218
-# XFAIL: DXC && Vulkan
-
 
 # BUG https://github.com/llvm/offload-test-suite/issues/931
 # XFAIL: Clang && DirectX && AMD


### PR DESCRIPTION
The bindings here didn't match between the HLSL source and the YAML, and they were also overlapping for Vulkan since the way that `register` annotations imply bindings for Vulkan doesn't differentiate between resource types.

We also need the `-fvk-use-dx-layout` flag here so that the memory for cbuffers is laid out consistently between DX and Vulkan.

Fixes microsoft/DirectXShaderCompiler#8218