### PR TITLE
Remove XFAIL from reversebit 16 QC

### DIFF
--- a/test/Feature/HLSLLib/reversebits.16.test
+++ b/test/Feature/HLSLLib/reversebits.16.test
@@ -57,9 +57,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug https://github.com/llvm/offload-test-suite/issues/518
-# XFAIL: Clang && Vulkan && QC
-
 # REQUIRES: Int16
 # RUN: split-file %s %t
 # RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl


### PR DESCRIPTION
This patch removes the XFAIL from reversebit 16 when running on QC GPU
Fix: #518 