### PR TITLE
[Matrix][Vulkan] update tests for memory layout fixes in spirv

### DIFF
--- a/test/Feature/CBuffer/Matrix/MatrixElement/one_based_mat_element.f32.test
+++ b/test/Feature/CBuffer/Matrix/MatrixElement/one_based_mat_element.f32.test
@@ -184,7 +184,7 @@ DescriptorSets:
 # UNSUPPORTED: Darwin
 
 # Note: clang Vulkan crashes
-# BUG https://github.com/llvm/llvm-project/issues/179879
+# BUG https://github.com/llvm/llvm-project/issues/176995
 # XFAIL: Clang && Vulkan
 
 # RUN: split-file %s %t

--- a/test/Feature/CBuffer/Matrix/MatrixElement/one_based_mat_element_scalar.f32.test
+++ b/test/Feature/CBuffer/Matrix/MatrixElement/one_based_mat_element_scalar.f32.test
@@ -195,7 +195,7 @@ DescriptorSets:
 # UNSUPPORTED: Darwin
 
 # Note: clang Vulkan crashes
-# BUG https://github.com/llvm/llvm-project/issues/179879
+# BUG https://github.com/llvm/llvm-project/issues/176995
 # XFAIL: Clang && Vulkan
 
 # RUN: split-file %s %t

--- a/test/Feature/CBuffer/Matrix/MatrixElement/zero_based_mat_element.f32.test
+++ b/test/Feature/CBuffer/Matrix/MatrixElement/zero_based_mat_element.f32.test
@@ -184,7 +184,7 @@ DescriptorSets:
 # UNSUPPORTED: Darwin
 
 # Note: clang Vulkan crashes
-# BUG https://github.com/llvm/llvm-project/issues/179879
+# BUG https://github.com/llvm/llvm-project/issues/176995
 # XFAIL: Clang && Vulkan
 
 # RUN: split-file %s %t

--- a/test/Feature/CBuffer/Matrix/MatrixElement/zero_based_mat_element_scalar.f32.test
+++ b/test/Feature/CBuffer/Matrix/MatrixElement/zero_based_mat_element_scalar.f32.test
@@ -195,7 +195,7 @@ DescriptorSets:
 # UNSUPPORTED: Darwin
 
 # Note: clang Vulkan crashes
-# BUG https://github.com/llvm/llvm-project/issues/179879
+# BUG https://github.com/llvm/llvm-project/issues/176995
 # XFAIL: Clang && Vulkan
 
 # RUN: split-file %s %t

--- a/test/Feature/CBuffer/Matrix/MatrixSubscript/matrix_subscript.f32.test
+++ b/test/Feature/CBuffer/Matrix/MatrixSubscript/matrix_subscript.f32.test
@@ -195,7 +195,7 @@ DescriptorSets:
 # UNSUPPORTED: Darwin
 
 # Note: clang Vulkan crashes
-# BUG https://github.com/llvm/llvm-project/issues/179879
+# BUG https://github.com/llvm/llvm-project/issues/176995
 # XFAIL: Clang && Vulkan
 
 # RUN: split-file %s %t

--- a/test/Feature/CBuffer/Matrix/MatrixSubscript/row_major_flag_matrix_subscript.f32.test
+++ b/test/Feature/CBuffer/Matrix/MatrixSubscript/row_major_flag_matrix_subscript.f32.test
@@ -195,7 +195,7 @@ DescriptorSets:
 # UNSUPPORTED: Darwin
 
 # Note: clang Vulkan crashes
-# BUG https://github.com/llvm/llvm-project/issues/179879
+# BUG https://github.com/llvm/llvm-project/issues/176995
 # XFAIL: Clang && Vulkan
 
 # RUN: split-file %s %t

--- a/test/Feature/CBuffer/Matrix/SingleSubscript/mat_cbuffer-swizzle.f32.test
+++ b/test/Feature/CBuffer/Matrix/SingleSubscript/mat_cbuffer-swizzle.f32.test
@@ -174,7 +174,7 @@ DescriptorSets:
 # UNSUPPORTED: Darwin
 
 # Note: clang Vulkan crashes
-# BUG https://github.com/llvm/llvm-project/issues/179879
+# BUG https://github.com/llvm/llvm-project/issues/176995
 # XFAIL: Clang && Vulkan
 
 # RUN: split-file %s %t

--- a/test/Feature/CBuffer/Matrix/SingleSubscript/mat_cbuffer.f32.test
+++ b/test/Feature/CBuffer/Matrix/SingleSubscript/mat_cbuffer.f32.test
@@ -174,7 +174,7 @@ DescriptorSets:
 # UNSUPPORTED: Darwin
 
 # Note: clang Vulkan crashes
-# BUG https://github.com/llvm/llvm-project/issues/179879
+# BUG https://github.com/llvm/llvm-project/issues/176995
 # XFAIL: Clang && Vulkan
 
 # RUN: split-file %s %t

--- a/test/Feature/CBuffer/Matrix/SingleSubscript/mat_cbuffer_threadgroup.f4x2.test
+++ b/test/Feature/CBuffer/Matrix/SingleSubscript/mat_cbuffer_threadgroup.f4x2.test
@@ -95,9 +95,6 @@ DescriptorSets:
 # BUG https://github.com/llvm/offload-test-suite/issues/931
 # XFAIL: Clang && DirectX && AMD
 
-# Note: clang Vulkan crashes
-# BUG https://github.com/llvm/llvm-project/issues/179879
-# XFAIL: Clang && Vulkan
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl


### PR DESCRIPTION
with the fix to https://github.com/llvm/llvm-project/issues/179879 we can now enable some of these cbuffers tests.

What remains is https://github.com/llvm/llvm-project/issues/176995