### PR TITLE
Verify that flags are correctly set when overflowing UAV resources

### DIFF
--- a/test/Feature/ResourceArrays/overflow-unbounded-array.test
+++ b/test/Feature/ResourceArrays/overflow-unbounded-array.test
@@ -67,7 +67,6 @@ DescriptorSets:
 
 # Unimplemented https://github.com/llvm/offload-test-suite/issues/305
 # XFAIL: Metal
-# XFAIL: DXC && Vulkan && KosmicKrisp
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl


### PR DESCRIPTION
This patch adds a new test to make sure we pass validation when UAV resources are overflowing. Such overflow would case Max64UAVs to not be set and the code wouldn't pass DXV validation