### PR TITLE
Removed XFAIL for Clang config for QuadReadAcrossX

### DIFF
--- a/test/WaveOps/QuadReadAcrossX.32.test
+++ b/test/WaveOps/QuadReadAcrossX.32.test
@@ -338,7 +338,7 @@ DescriptorSets:
 #--- end
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/986
-# XFAIL: Intel && Vulkan
+# XFAIL: Intel && Vulkan && !Clang
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/989
 # XFAIL: Metal

--- a/test/WaveOps/QuadReadAcrossX.32.test
+++ b/test/WaveOps/QuadReadAcrossX.32.test
@@ -338,7 +338,7 @@ DescriptorSets:
 #--- end
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/986
-# XFAIL: Intel && Vulkan && !Clang
+# XFAIL: Intel && Vulkan && DXC
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/989
 # XFAIL: Metal

--- a/test/WaveOps/QuadReadAcrossX.32.test
+++ b/test/WaveOps/QuadReadAcrossX.32.test
@@ -337,9 +337,6 @@ DescriptorSets:
 ...
 #--- end
 
-# WIP PR: https://github.com/llvm/llvm-project/pull/184360
-# XFAIL: Clang
-
 # Bug: https://github.com/llvm/offload-test-suite/issues/986
 # XFAIL: Intel && Vulkan
 

--- a/test/WaveOps/QuadReadAcrossX.fp16.test
+++ b/test/WaveOps/QuadReadAcrossX.fp16.test
@@ -126,7 +126,7 @@ DescriptorSets:
 # REQUIRES: Half
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/986
-# XFAIL: Intel && Vulkan
+# XFAIL: Intel && Vulkan && !Clang
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/WaveOps/QuadReadAcrossX.fp16.test
+++ b/test/WaveOps/QuadReadAcrossX.fp16.test
@@ -125,9 +125,6 @@ DescriptorSets:
 
 # REQUIRES: Half
 
-# WIP PR: https://github.com/llvm/llvm-project/pull/184360
-# XFAIL: Clang
-
 # Bug: https://github.com/llvm/offload-test-suite/issues/986
 # XFAIL: Intel && Vulkan
 

--- a/test/WaveOps/QuadReadAcrossX.fp16.test
+++ b/test/WaveOps/QuadReadAcrossX.fp16.test
@@ -126,7 +126,7 @@ DescriptorSets:
 # REQUIRES: Half
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/986
-# XFAIL: Intel && Vulkan && !Clang
+# XFAIL: Intel && Vulkan && DXC
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/WaveOps/QuadReadAcrossX.fp64.test
+++ b/test/WaveOps/QuadReadAcrossX.fp64.test
@@ -126,7 +126,7 @@ DescriptorSets:
 # REQUIRES: Double
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/986
-# XFAIL: Intel && Vulkan && !Clang
+# XFAIL: Intel && Vulkan && DXC
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/WaveOps/QuadReadAcrossX.fp64.test
+++ b/test/WaveOps/QuadReadAcrossX.fp64.test
@@ -125,9 +125,6 @@ DescriptorSets:
 
 # REQUIRES: Double
 
-# WIP PR: https://github.com/llvm/llvm-project/pull/184360
-# XFAIL: Clang
-
 # Bug: https://github.com/llvm/offload-test-suite/issues/986
 # XFAIL: Intel && Vulkan
 

--- a/test/WaveOps/QuadReadAcrossX.fp64.test
+++ b/test/WaveOps/QuadReadAcrossX.fp64.test
@@ -126,7 +126,7 @@ DescriptorSets:
 # REQUIRES: Double
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/986
-# XFAIL: Intel && Vulkan
+# XFAIL: Intel && Vulkan && !Clang
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/WaveOps/QuadReadAcrossX.int16.test
+++ b/test/WaveOps/QuadReadAcrossX.int16.test
@@ -233,9 +233,6 @@ DescriptorSets:
 
 # REQUIRES: Int16
 
-# WIP PR: https://github.com/llvm/llvm-project/pull/184360
-# XFAIL: Clang
-
 # Bug: https://github.com/llvm/offload-test-suite/issues/986
 # XFAIL: Intel && Vulkan
 

--- a/test/WaveOps/QuadReadAcrossX.int16.test
+++ b/test/WaveOps/QuadReadAcrossX.int16.test
@@ -234,7 +234,7 @@ DescriptorSets:
 # REQUIRES: Int16
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/986
-# XFAIL: Intel && Vulkan && !Clang
+# XFAIL: Intel && Vulkan && DXC
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/989
 # XFAIL: Metal

--- a/test/WaveOps/QuadReadAcrossX.int16.test
+++ b/test/WaveOps/QuadReadAcrossX.int16.test
@@ -234,7 +234,7 @@ DescriptorSets:
 # REQUIRES: Int16
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/986
-# XFAIL: Intel && Vulkan
+# XFAIL: Intel && Vulkan && !Clang
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/989
 # XFAIL: Metal

--- a/test/WaveOps/QuadReadAcrossX.int64.test
+++ b/test/WaveOps/QuadReadAcrossX.int64.test
@@ -233,9 +233,6 @@ DescriptorSets:
 
 # REQUIRES: Int64
 
-# WIP PR: https://github.com/llvm/llvm-project/pull/184360
-# XFAIL: Clang
-
 # Bug: https://github.com/llvm/offload-test-suite/issues/988
 # Bug: https://github.com/llvm/offload-test-suite/issues/989
 # XFAIL: Metal

--- a/test/WaveOps/QuadReadAcrossX.int64.test
+++ b/test/WaveOps/QuadReadAcrossX.int64.test
@@ -238,7 +238,7 @@ DescriptorSets:
 # XFAIL: Metal
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/986
-# XFAIL: Intel && Vulkan
+# XFAIL: Intel && Vulkan && !Clang
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/WaveOps/QuadReadAcrossX.int64.test
+++ b/test/WaveOps/QuadReadAcrossX.int64.test
@@ -238,7 +238,7 @@ DescriptorSets:
 # XFAIL: Metal
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/986
-# XFAIL: Intel && Vulkan && !Clang
+# XFAIL: Intel && Vulkan && DXC
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/WaveOps/QuadReadAcrossX.test
+++ b/test/WaveOps/QuadReadAcrossX.test
@@ -63,9 +63,6 @@ DescriptorSets:
 ...
 #--- end
 
-# WIP PR: https://github.com/llvm/llvm-project/pull/184360
-# XFAIL: Clang
-
 # Bug: https://github.com/llvm/offload-test-suite/issues/986
 # XFAIL: Intel && Vulkan
 

--- a/test/WaveOps/QuadReadAcrossX.test
+++ b/test/WaveOps/QuadReadAcrossX.test
@@ -64,7 +64,7 @@ DescriptorSets:
 #--- end
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/986
-# XFAIL: Intel && Vulkan && !Clang
+# XFAIL: Intel && Vulkan && DXC
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl

--- a/test/WaveOps/QuadReadAcrossX.test
+++ b/test/WaveOps/QuadReadAcrossX.test
@@ -64,7 +64,7 @@ DescriptorSets:
 #--- end
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/986
-# XFAIL: Intel && Vulkan
+# XFAIL: Intel && Vulkan && !Clang
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl


### PR DESCRIPTION
We can remove the XFAIL directives for Clang config for QuadReadAcrossX tests now that QuadReadAcrossX intrinsic has landed in LLVM: https://github.com/llvm/llvm-project/pull/184360