### PR TITLE
Correct `transpose.*16.test` XFails

### DIFF
--- a/test/Feature/HLSLLib/transpose.fp16.test
+++ b/test/Feature/HLSLLib/transpose.fp16.test
@@ -106,7 +106,7 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/offload-test-suite/issues/779
-# XFAIL: Intel && DirectX && DXC
+# XFAIL: Intel && DirectX
 
 # REQUIRES: Half
 # RUN: split-file %s %t

--- a/test/Feature/HLSLLib/transpose.int16.test
+++ b/test/Feature/HLSLLib/transpose.int16.test
@@ -103,7 +103,7 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/offload-test-suite/issues/779
-# XFAIL: Intel && DirectX && DXC
+# XFAIL: Intel && DirectX
 
 # REQUIRES: Int16
 # RUN: split-file %s %t


### PR DESCRIPTION
After updates to transpose in clang it is now uncovered that clang runs into the same erroneous driver behaviour