### PR TITLE
[Metal] Fix top level argument buffer indexing when creating descriptors

### DIFF
--- a/include/Support/Pipeline.h
+++ b/include/Support/Pipeline.h
@@ -255,6 +255,8 @@ struct Resource {
     }
   }
 
+  bool isConstantBuffer() const { return Kind == ResourceKind::ConstantBuffer; }
+
   uint32_t getElementSize() const {
     assert(!isSampler() && "Samplers do not have element size");
     // ByteAddressBuffers are treated as 4-byte elements to match their memory

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -72,6 +72,78 @@ static MTL::VertexFormat getMTLVertexFormat(DataFormat Format, int Channels) {
   return MTL::VertexFormatInvalid;
 }
 
+template <> struct llvm::DenseMapInfo<DirectXBinding> {
+  static DirectXBinding getEmptyKey() {
+    return {std::numeric_limits<uint32_t>::max(),
+            std::numeric_limits<uint32_t>::max()};
+  }
+  static DirectXBinding getTombstoneKey() {
+    return {std::numeric_limits<uint32_t>::max() - 1,
+            std::numeric_limits<uint32_t>::max() - 1};
+  }
+  static unsigned getHashValue(const DirectXBinding &K) {
+    return llvm::hash_combine(K.Register, K.Space);
+  }
+  static bool isEqual(const DirectXBinding &LHS, const DirectXBinding &RHS) {
+    return LHS.Register == RHS.Register && LHS.Space == RHS.Space;
+  }
+};
+
+// TLAB index map is a mapping from (register, space) pairs to the index of the
+// corresponding top-level argument buffer in the shader reflection. This is
+// used to create resource descriptors in the correct argument buffer entry.
+llvm::Expected<llvm::DenseMap<DirectXBinding, uint32_t>>
+computeTLABIndexMap(llvm::MemoryBuffer *ReflectionJSON) {
+  if (!ReflectionJSON)
+    return llvm::createStringError(std::errc::invalid_argument,
+                                   "Reflection buffer is null.");
+
+  llvm::Expected<llvm::json::Value> E =
+      llvm::json::parse(llvm::StringRef(ReflectionJSON->getBuffer()));
+  if (!E)
+    return E.takeError();
+  llvm::json::Value Reflection = *E;
+
+  const llvm::json::Object *ReflectionObj = Reflection.getAsObject();
+  if (!ReflectionObj)
+    return llvm::createStringError(std::errc::invalid_argument,
+                                   "Shader reflection must be a JSON object.");
+  auto TLABIt = ReflectionObj->find("TopLevelArgumentBuffer");
+  if (TLABIt == ReflectionObj->end())
+    return llvm::createStringError(
+        std::errc::invalid_argument,
+        "Key 'TopLevelArgumentBuffer' not found in shader reflection.");
+
+  const llvm::json::Array *TLAB = TLABIt->second.getAsArray();
+  llvm::DenseMap<DirectXBinding, uint32_t> TLABIndexMap;
+  TLABIndexMap.reserve(TLAB->size());
+  for (uint32_t I = 0; I < static_cast<uint32_t>(TLAB->size()); ++I) {
+    const llvm::json::Object *ArgObj = (*TLAB)[I].getAsObject();
+    if (!ArgObj)
+      return llvm::createStringError(
+          std::errc::invalid_argument,
+          "Top-level argument buffer entries in shader reflection must be JSON "
+          "objects.");
+    auto SlotIt = ArgObj->find("Slot");
+    auto SpaceIt = ArgObj->find("Space");
+    if (SlotIt == ArgObj->end() || SpaceIt == ArgObj->end())
+      return llvm::createStringError(
+          std::errc::invalid_argument,
+          "Top-level argument buffer entries in shader reflection must have "
+          "'Slot' and 'Space' fields.");
+    auto SlotVal = SlotIt->second.getAsUINT64();
+    auto SpaceVal = SpaceIt->second.getAsUINT64();
+    if (!SlotVal || !SpaceVal)
+      return llvm::createStringError(
+          std::errc::invalid_argument,
+          "Slot and Space fields in shader reflection must be integers.");
+    DirectXBinding Binding{static_cast<uint32_t>(*SlotVal),
+                           static_cast<uint32_t>(*SpaceVal)};
+    TLABIndexMap.insert({Binding, I});
+  }
+  return TLABIndexMap;
+}
+
 namespace {
 class MTLQueue : public offloadtest::Queue {
 public:
@@ -346,13 +418,36 @@ class MTLDevice : public offloadtest::Device {
     if (TableSize > 0) {
       IS.ArgBuffer =
           Device->newBuffer(TableSize, MTL::ResourceStorageModeManaged);
-      uint32_t HeapIndex = 0;
-      for (auto &D : P.Sets) {
-        for (auto &R : D.Resources) {
-          if (auto Err = createDescriptor(R, IS, HeapIndex++))
-            return Err;
+
+      if (P.isCompute()) {
+        auto TLABIndexMap = computeTLABIndexMap(P.Shaders[0].Reflection.get());
+        if (!TLABIndexMap)
+          return TLABIndexMap.takeError();
+
+        for (auto &D : P.Sets) {
+          for (auto &R : D.Resources) {
+            auto BindingIt = TLABIndexMap->find(R.DXBinding);
+            if (BindingIt == TLABIndexMap->end())
+              return llvm::createStringError(
+                  std::errc::invalid_argument,
+                  "Resource with register %u and space %u not found in shader "
+                  "reflection.",
+                  R.DXBinding.Register, R.DXBinding.Space);
+
+            if (auto Err = createDescriptor(R, IS, BindingIt->second))
+              return Err;
+          }
+        }
+      } else {
+        uint32_t HeapIndex = 0;
+        for (auto &D : P.Sets) {
+          for (auto &R : D.Resources) {
+            if (auto Err = createDescriptor(R, IS, HeapIndex++))
+              return Err;
+          }
         }
       }
+
       IS.ArgBuffer->didModifyRange(NS::Range::Make(0, IS.ArgBuffer->length()));
     }
     if (P.isGraphics()) {

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -13,6 +13,7 @@
 #include "Support/Pipeline.h"
 
 #include "llvm/ADT/SmallString.h"
+#include "llvm/ADT/StringSwitch.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/JSON.h"
 #include "llvm/Support/raw_ostream.h"
@@ -72,27 +73,69 @@ static MTL::VertexFormat getMTLVertexFormat(DataFormat Format, int Channels) {
   return MTL::VertexFormatInvalid;
 }
 
-template <> struct llvm::DenseMapInfo<DirectXBinding> {
-  static DirectXBinding getEmptyKey() {
-    return {std::numeric_limits<uint32_t>::max(),
+// From metal_irconverter.h which is not part of the third-party
+enum IRResourceType {
+  IRResourceTypeTable,
+  IRResourceTypeConstant,
+  IRResourceTypeCBV,
+  IRResourceTypeSRV,
+  IRResourceTypeUAV,
+  IRResourceTypeSampler,
+  IRResourceTypeInvalid
+};
+
+struct IRResourceLocation {
+  IRResourceType resourceType;
+  uint32_t space;
+  uint32_t slot;
+};
+
+static IRResourceType getIRResourceTypeFromString(llvm::StringRef S) {
+  return llvm::StringSwitch<IRResourceType>(S)
+      .Case("Table", IRResourceTypeTable)
+      .Case("Constant", IRResourceTypeConstant)
+      .Case("CBV", IRResourceTypeCBV)
+      .Case("SRV", IRResourceTypeSRV)
+      .Case("UAV", IRResourceTypeUAV)
+      .Case("Sampler", IRResourceTypeSampler)
+      .Default(IRResourceTypeInvalid);
+}
+
+static IRResourceType inferIRResourceTypeFromResource(const Resource &R) {
+  if (R.isConstantBuffer())
+    return IRResourceTypeCBV;
+  if (R.isReadOnly())
+    return IRResourceTypeSRV;
+  if (R.isReadWrite())
+    return IRResourceTypeUAV;
+  if (R.isSampler())
+    return IRResourceTypeSampler;
+  llvm_unreachable("Unable to infer resource type for resource!");
+}
+
+template <> struct llvm::DenseMapInfo<IRResourceLocation> {
+  static IRResourceLocation getEmptyKey() {
+    return {IRResourceTypeInvalid, std::numeric_limits<uint32_t>::max(),
             std::numeric_limits<uint32_t>::max()};
   }
-  static DirectXBinding getTombstoneKey() {
-    return {std::numeric_limits<uint32_t>::max() - 1,
+  static IRResourceLocation getTombstoneKey() {
+    return {IRResourceTypeInvalid, std::numeric_limits<uint32_t>::max() - 1,
             std::numeric_limits<uint32_t>::max() - 1};
   }
-  static unsigned getHashValue(const DirectXBinding &K) {
-    return llvm::hash_combine(K.Register, K.Space);
+  static unsigned getHashValue(const IRResourceLocation &K) {
+    return llvm::hash_combine(K.resourceType, K.slot, K.space);
   }
-  static bool isEqual(const DirectXBinding &LHS, const DirectXBinding &RHS) {
-    return LHS.Register == RHS.Register && LHS.Space == RHS.Space;
+  static bool isEqual(const IRResourceLocation &LHS,
+                      const IRResourceLocation &RHS) {
+    return LHS.resourceType == RHS.resourceType && LHS.slot == RHS.slot &&
+           LHS.space == RHS.space;
   }
 };
 
 // TLAB index map is a mapping from (register, space) pairs to the index of the
 // corresponding top-level argument buffer in the shader reflection. This is
 // used to create resource descriptors in the correct argument buffer entry.
-llvm::Expected<llvm::DenseMap<DirectXBinding, uint32_t>>
+llvm::Expected<llvm::DenseMap<IRResourceLocation, uint32_t>>
 computeTLABIndexMap(llvm::MemoryBuffer *ReflectionJSON) {
   if (!ReflectionJSON)
     return llvm::createStringError(std::errc::invalid_argument,
@@ -115,7 +158,7 @@ computeTLABIndexMap(llvm::MemoryBuffer *ReflectionJSON) {
         "Key 'TopLevelArgumentBuffer' not found in shader reflection.");
 
   const llvm::json::Array *TLAB = TLABIt->second.getAsArray();
-  llvm::DenseMap<DirectXBinding, uint32_t> TLABIndexMap;
+  llvm::DenseMap<IRResourceLocation, uint32_t> TLABIndexMap;
   TLABIndexMap.reserve(TLAB->size());
   for (uint32_t I = 0; I < static_cast<uint32_t>(TLAB->size()); ++I) {
     const llvm::json::Object *ArgObj = (*TLAB)[I].getAsObject();
@@ -126,20 +169,25 @@ computeTLABIndexMap(llvm::MemoryBuffer *ReflectionJSON) {
           "objects.");
     auto SlotIt = ArgObj->find("Slot");
     auto SpaceIt = ArgObj->find("Space");
-    if (SlotIt == ArgObj->end() || SpaceIt == ArgObj->end())
+    auto TypeIt = ArgObj->find("Type");
+    if (SlotIt == ArgObj->end() || SpaceIt == ArgObj->end() ||
+        TypeIt == ArgObj->end())
       return llvm::createStringError(
           std::errc::invalid_argument,
           "Top-level argument buffer entries in shader reflection must have "
-          "'Slot' and 'Space' fields.");
+          "'Slot', 'Space', and 'Type' fields.");
     auto SlotVal = SlotIt->second.getAsUINT64();
     auto SpaceVal = SpaceIt->second.getAsUINT64();
-    if (!SlotVal || !SpaceVal)
+    auto TypeVal = TypeIt->second.getAsString();
+    if (!SlotVal || !SpaceVal || !TypeVal)
       return llvm::createStringError(
           std::errc::invalid_argument,
-          "Slot and Space fields in shader reflection must be integers.");
-    DirectXBinding Binding{static_cast<uint32_t>(*SlotVal),
-                           static_cast<uint32_t>(*SpaceVal)};
-    TLABIndexMap.insert({Binding, I});
+          "Slot, Space, and Type fields in shader reflection must be valid.");
+    IRResourceLocation Location = {.resourceType =
+                                       getIRResourceTypeFromString(*TypeVal),
+                                   .slot = static_cast<uint32_t>(*SlotVal),
+                                   .space = static_cast<uint32_t>(*SpaceVal)};
+    TLABIndexMap.insert({Location, I});
   }
   return TLABIndexMap;
 }
@@ -426,7 +474,12 @@ class MTLDevice : public offloadtest::Device {
 
         for (auto &D : P.Sets) {
           for (auto &R : D.Resources) {
-            auto BindingIt = TLABIndexMap->find(R.DXBinding);
+            IRResourceLocation Location = {
+                .resourceType = inferIRResourceTypeFromResource(R),
+                .slot = R.DXBinding.Register,
+                .space = R.DXBinding.Space,
+            };
+            auto BindingIt = TLABIndexMap->find(Location);
             if (BindingIt == TLABIndexMap->end())
               return llvm::createStringError(
                   std::errc::invalid_argument,

--- a/test/Feature/ResourcesInStructs/res-in-struct-mix.test
+++ b/test/Feature/ResourcesInStructs/res-in-struct-mix.test
@@ -122,9 +122,6 @@ DescriptorSets:
 # Unimplemented https://github.com/llvm/wg-hlsl/issues/367
 # XFAIL: Clang
 
-# Bug https://github.com/llvm/offload-test-suite/issues/642
-# XFAIL: Metal
-
 # Vulkan does not support global structures with buffers or structures
 # containing both resources and non-resources.
 # UNSUPPORTED: Vulkan

--- a/test/Feature/StructuredBuffer/matrix.test
+++ b/test/Feature/StructuredBuffer/matrix.test
@@ -108,9 +108,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Unimplemented https://github.com/llvm/offload-test-suite/issues/1021
-# XFAIL: Metal
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -fvk-use-dx-layout -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/StructuredBuffer/matrix_assign.test
+++ b/test/Feature/StructuredBuffer/matrix_assign.test
@@ -97,9 +97,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Unimplemented https://github.com/llvm/offload-test-suite/issues/1021
-# XFAIL: Metal
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -fvk-use-dx-layout -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/WaveOps/QuadReadAcrossX.32.test
+++ b/test/WaveOps/QuadReadAcrossX.32.test
@@ -340,9 +340,6 @@ DescriptorSets:
 # Bug: https://github.com/llvm/offload-test-suite/issues/986
 # XFAIL: Intel && Vulkan && DXC
 
-# Bug: https://github.com/llvm/offload-test-suite/issues/989
-# XFAIL: Metal
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o 

--- a/test/WaveOps/QuadReadAcrossX.int16.test
+++ b/test/WaveOps/QuadReadAcrossX.int16.test
@@ -236,9 +236,6 @@ DescriptorSets:
 # Bug: https://github.com/llvm/offload-test-suite/issues/986
 # XFAIL: Intel && Vulkan && DXC
 
-# Bug: https://github.com/llvm/offload-test-suite/issues/989
-# XFAIL: Metal
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/WaveOps/QuadReadAcrossY.32.test
+++ b/test/WaveOps/QuadReadAcrossY.32.test
@@ -340,9 +340,6 @@ DescriptorSets:
 # Bug: https://github.com/llvm/offload-test-suite/issues/986
 # XFAIL: Intel && Vulkan && DXC
 
-# Bug: https://github.com/llvm/offload-test-suite/issues/989
-# XFAIL: Metal
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o 

--- a/test/WaveOps/QuadReadAcrossY.int16.test
+++ b/test/WaveOps/QuadReadAcrossY.int16.test
@@ -236,9 +236,6 @@ DescriptorSets:
 # Bug: https://github.com/llvm/offload-test-suite/issues/986
 # XFAIL: Intel && Vulkan && DXC
 
-# Bug: https://github.com/llvm/offload-test-suite/issues/989
-# XFAIL: Metal
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/WaveOps/WaveActiveMax.fp16.test
+++ b/test/WaveOps/WaveActiveMax.fp16.test
@@ -307,9 +307,6 @@ DescriptorSets:
 # Bug https://github.com/llvm/llvm-project/issues/172577
 # XFAIL: Clang && Vulkan
 
-# Bug https://github.com/llvm/offload-test-suite/issues/393
-# XFAIL: Metal
-
 # REQUIRES: Half
 
 # RUN: split-file %s %t

--- a/test/WaveOps/WaveActiveMax.fp32.test
+++ b/test/WaveOps/WaveActiveMax.fp32.test
@@ -307,9 +307,6 @@ DescriptorSets:
 # Bug https://github.com/llvm/llvm-project/issues/172577
 # XFAIL: Clang && Vulkan
 
-# Bug https://github.com/llvm/offload-test-suite/issues/393
-# XFAIL: Metal
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o 

--- a/test/WaveOps/WaveActiveMax.int16.test
+++ b/test/WaveOps/WaveActiveMax.int16.test
@@ -307,9 +307,6 @@ DescriptorSets:
 # Bug https://github.com/llvm/llvm-project/issues/172577
 # XFAIL: Clang && Vulkan
 
-# Bug https://github.com/llvm/offload-test-suite/issues/393
-# XFAIL: Metal
-
 # REQUIRES: Int16
 
 # RUN: split-file %s %t

--- a/test/WaveOps/WaveActiveMax.int32.test
+++ b/test/WaveOps/WaveActiveMax.int32.test
@@ -307,9 +307,6 @@ DescriptorSets:
 # Bug https://github.com/llvm/llvm-project/issues/172577
 # XFAIL: Clang && Vulkan
 
-# Bug https://github.com/llvm/offload-test-suite/issues/393
-# XFAIL: Metal
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o 

--- a/test/WaveOps/WaveActiveSum.int16.test
+++ b/test/WaveOps/WaveActiveSum.int16.test
@@ -328,9 +328,6 @@ DescriptorSets:
 # Bug https://github.com/llvm/offload-test-suite/issues/525
 # XFAIL: NV && Clang && DirectX
 
-# Bug https://github.com/llvm/offload-test-suite/issues/393
-# XFAIL: Metal || (Vulkan && MoltenVK)
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o 

--- a/test/WaveOps/WaveActiveSum.int32.test
+++ b/test/WaveOps/WaveActiveSum.int32.test
@@ -319,10 +319,6 @@ DescriptorSets:
 ...
 #--- end
 
-
-# Bug https://github.com/llvm/offload-test-suite/issues/393
-# XFAIL: Metal
-
 # Bug https://github.com/llvm/llvm-project/issues/156775
 # XFAIL: Vulkan && Clang
 

--- a/test/WaveOps/WavePrefixSum.int16.test
+++ b/test/WaveOps/WavePrefixSum.int16.test
@@ -321,9 +321,6 @@ DescriptorSets:
 # Bug: https://github.com/llvm/llvm-project/issues/186151
 # XFAIL: Clang && Vulkan
 
-# Bug: https://github.com/llvm/offload-test-suite/issues/960
-# XFAIL: Metal
-
 # Bug: https://github.com/llvm/offload-test-suite/issues/961
 # XFAIL: NV && Clang && DirectX
 

--- a/test/WaveOps/WaveReadLaneAt.16.test
+++ b/test/WaveOps/WaveReadLaneAt.16.test
@@ -136,9 +136,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug https://github.com/llvm/offload-test-suite/issues/351
-# XFAIL: Metal
-
 # Bug https://github.com/llvm/offload-test-suite/issues/532
 # XFAIL: DirectX && QC
 

--- a/test/WaveOps/WaveReadLaneAt.32.test
+++ b/test/WaveOps/WaveReadLaneAt.32.test
@@ -172,8 +172,6 @@ DescriptorSets:
         Binding: 7
 ...
 #--- end
-# Bug https://github.com/llvm/offload-test-suite/issues/351
-# XFAIL: Metal
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Gis -Fo %t.o %t/source.hlsl

--- a/test/WaveOps/WaveReadLaneFirst.fp16.test
+++ b/test/WaveOps/WaveReadLaneFirst.fp16.test
@@ -307,9 +307,6 @@ DescriptorSets:
 # Bug https://github.com/llvm/llvm-project/issues/156775
 # XFAIL: Clang
 
-# Bug https://github.com/llvm/offload-test-suite/issues/393
-# XFAIL: Metal
-
 # Bug https://github.com/llvm/offload-test-suite/issues/627
 # XFAIL: QC && DirectX
 

--- a/test/WaveOps/WaveReadLaneFirst.fp32.test
+++ b/test/WaveOps/WaveReadLaneFirst.fp32.test
@@ -307,9 +307,6 @@ DescriptorSets:
 # Bug https://github.com/llvm/llvm-project/issues/156775
 # XFAIL: Clang
 
-# Bug https://github.com/llvm/offload-test-suite/issues/393
-# XFAIL: Metal
-
 # Bug https://github.com/llvm/offload-test-suite/issues/627
 # XFAIL: QC && DirectX
 

--- a/test/WaveOps/WaveReadLaneFirst.int16.test
+++ b/test/WaveOps/WaveReadLaneFirst.int16.test
@@ -307,9 +307,6 @@ DescriptorSets:
 # Bug https://github.com/llvm/llvm-project/issues/156775
 # XFAIL: Clang
 
-# Bug https://github.com/llvm/offload-test-suite/issues/393
-# XFAIL: Metal
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o 

--- a/test/WaveOps/WaveReadLaneFirst.int32.test
+++ b/test/WaveOps/WaveReadLaneFirst.int32.test
@@ -307,9 +307,6 @@ DescriptorSets:
 # Bug https://github.com/llvm/llvm-project/issues/156775
 # XFAIL: Clang
 
-# Bug https://github.com/llvm/offload-test-suite/issues/393
-# XFAIL: Metal
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o 


### PR DESCRIPTION
I looked deeper into why some tests fails on Metal and I think found the reason why.

The Metal backend generates a automatic linear layout of the resources into the top-level argument buffer, but the actual heap index of the resources seems to be sorted by the resource type in the metal shader reflection. Given the following declarations:
```
StructuredBuffer<int16_t4> In: register(t0);
RWStructuredBuffer<int16_t4> Out1 : register(u1);
RWStructuredBuffer<int16_t4> Out2 : register(u2);
RWStructuredBuffer<int16_t4> Out3 : register(u3);
RWStructuredBuffer<int16_t4> Out4 : register(u4);

StructuredBuffer<uint16_t4> UIn: register(t5);
RWStructuredBuffer<uint16_t4> UOut1 : register(u6);
RWStructuredBuffer<uint16_t4> UOut2 : register(u7);
RWStructuredBuffer<uint16_t4> UOut3 : register(u8);
RWStructuredBuffer<uint16_t4> UOut4 : register(u9);
```
when compiled with `-metal` and `-Fre` options, we get the following in the metal json reflection:
```
{
  ...
  "TopLevelArgumentBuffer": [
    { "EltOffset": 0, "Name": "", "Size": 24, "Slot": 0, "Space": 0, "Type": "SRV" },
    { "EltOffset": 24, "Name": "", "Size": 24, "Slot": 5, "Space": 0, "Type": "SRV" },
    { "EltOffset": 48, "Name": "", "Size": 24, "Slot": 1, "Space": 0, "Type": "UAV" },
    { "EltOffset": 72, "Name": "", "Size": 24, "Slot": 2, "Space": 0, "Type": "UAV" },
    { "EltOffset": 96, "Name": "", "Size": 24, "Slot": 3, "Space": 0, "Type": "UAV" },
    { "EltOffset": 120, "Name": "", "Size": 24, "Slot": 4, "Space": 0, "Type": "UAV" },
    { "EltOffset": 144, "Name": "", "Size": 24, "Slot": 6, "Space": 0, "Type": "UAV" },
    { "EltOffset": 168, "Name": "", "Size": 24, "Slot": 7, "Space": 0, "Type": "UAV" },
    { "EltOffset": 192, "Name": "", "Size": 24, "Slot": 8, "Space": 0, "Type": "UAV" },
    { "EltOffset": 216, "Name": "", "Size": 24, "Slot": 9, "Space": 0, "Type": "UAV" }
  ],
  ...
}
```
From the reflection data we can see `In` and `UIn` SRV resource descriptors should be created at index 0 and 1, but this is not the case in the backend because it assumes heap index is 1:1 to the order they are declared in the `DescriptorSets -> Resources` field.

The PR fixes this by adding a hash map using `Slot` and `Space` values in the reflection as keys that maps to the actual index of the top level argument buffer when creating descriptors.

With the above changes, I get the following on my local machine:
```
Unexpectedly Passed Tests (16):
  OffloadTest-mtl :: Feature/ResourcesInStructs/res-in-struct-mix.test
  OffloadTest-mtl :: WaveOps/QuadReadAcrossX.32.test
  OffloadTest-mtl :: WaveOps/QuadReadAcrossX.int16.test
  OffloadTest-mtl :: WaveOps/WaveActiveMax.fp16.test
  OffloadTest-mtl :: WaveOps/WaveActiveMax.fp32.test
  OffloadTest-mtl :: WaveOps/WaveActiveMax.int16.test
  OffloadTest-mtl :: WaveOps/WaveActiveMax.int32.test
  OffloadTest-mtl :: WaveOps/WaveActiveSum.int16.test
  OffloadTest-mtl :: WaveOps/WaveActiveSum.int32.test
  OffloadTest-mtl :: WaveOps/WavePrefixSum.int16.test
  OffloadTest-mtl :: WaveOps/WaveReadLaneAt.16.test
  OffloadTest-mtl :: WaveOps/WaveReadLaneAt.32.test
  OffloadTest-mtl :: WaveOps/WaveReadLaneFirst.fp16.test
  OffloadTest-mtl :: WaveOps/WaveReadLaneFirst.fp32.test
  OffloadTest-mtl :: WaveOps/WaveReadLaneFirst.int16.test
  OffloadTest-mtl :: WaveOps/WaveReadLaneFirst.int32.test
```