### PR TITLE
[Matrix] Add structured buffer tests

### DIFF
--- a/test/Feature/StructuredBuffer/matrix.test
+++ b/test/Feature/StructuredBuffer/matrix.test
@@ -1,6 +1,6 @@
 #--- source.hlsl
 
-// This test verifies reading/writing matrix types via StructuredBuffer.
+// This test verifies reading/writing matrix types element-by-element.
 
 StructuredBuffer<float3x2> InA : register(t0);
 RWStructuredBuffer<float3x2> OutA : register(u2);
@@ -111,7 +111,7 @@ DescriptorSets:
 # Unimplemented https://github.com/llvm/llvm-project/issues/188131
 # XFAIL: Clang && Vulkan
 
-# Unimplemented https://github.com/llvm/offload-test-suite/issues/305
+# Unimplemented https://github.com/llvm/offload-test-suite/issues/1021
 # XFAIL: Metal
 
 # RUN: split-file %s %t

--- a/test/Feature/StructuredBuffer/matrix_assign.test
+++ b/test/Feature/StructuredBuffer/matrix_assign.test
@@ -1,6 +1,6 @@
 #--- source.hlsl
 
-// This test verifies reading/writing matrix types via StructuredBuffer.
+// This test verifies reading/writing matrix types via StructuredBuffer assignment.
 
 StructuredBuffer<float3x2> InA : register(t0);
 RWStructuredBuffer<float3x2> OutA : register(u2);
@@ -100,7 +100,7 @@ DescriptorSets:
 # Unimplemented https://github.com/llvm/llvm-project/issues/188131
 # XFAIL: Clang && Vulkan
 
-# Unimplemented https://github.com/llvm/offload-test-suite/issues/305
+# Unimplemented https://github.com/llvm/offload-test-suite/issues/1021
 # XFAIL: Metal
 
 # RUN: split-file %s %t


### PR DESCRIPTION
This change confirms that both matrix subscripting and assignment work with StructuredBuffer