### PR TITLE
[QC][Vulkan] XFAIL mat_cbuffer_threadgroup.f4x2.test

### DIFF
--- a/test/Feature/CBuffer/Matrix/SingleSubscript/mat_cbuffer_threadgroup.f4x2.test
+++ b/test/Feature/CBuffer/Matrix/SingleSubscript/mat_cbuffer_threadgroup.f4x2.test
@@ -95,6 +95,11 @@ DescriptorSets:
 # BUG https://github.com/llvm/offload-test-suite/issues/931
 # XFAIL: Clang && DirectX && AMD
 
+# Driver BUG  https://github.com/llvm/offload-test-suite/issues/1005
+# Note: Values missing for 3rd and 4th thread.
+# Results: [ 1.1, 2.2, 0, 0, 5.5, 6.6, 0, 0 ]
+# XFAIL: Vulkan && QC && DXC
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl


### PR DESCRIPTION
This change xfails the test until we can triage it further.