### PR TITLE
Fix WaveActiveAllEqual copy paste bugs

### DIFF
--- a/test/WaveOps/WaveActiveAllEqual.32.test
+++ b/test/WaveOps/WaveActiveAllEqual.32.test
@@ -359,9 +359,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug: https://github.com/llvm/offload-test-suite/issues/943
-# XFAIL: Intel && Vulkan
-
 # Bug: https://github.com/llvm/offload-test-suite/issues/981
 # XFAIL: Clang
 

--- a/test/WaveOps/WaveActiveAllEqual.fp16.test
+++ b/test/WaveOps/WaveActiveAllEqual.fp16.test
@@ -148,9 +148,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug: https://github.com/llvm/offload-test-suite/issues/943
-# XFAIL: Intel && Vulkan
-
 # Bug: https://github.com/llvm/offload-test-suite/issues/981
 # XFAIL: Clang
 

--- a/test/WaveOps/WaveActiveAllEqual.fp64.test
+++ b/test/WaveOps/WaveActiveAllEqual.fp64.test
@@ -150,9 +150,6 @@ DescriptorSets:
 # Bug: https://github.com/llvm/offload-test-suite/issues/944
 # XFAIL: Intel && DirectX
 
-# Bug: https://github.com/llvm/offload-test-suite/issues/943
-# XFAIL: Intel && Vulkan
-
 # Bug: https://github.com/llvm/offload-test-suite/issues/981
 # XFAIL: Clang
 

--- a/test/WaveOps/WaveActiveAllEqual.int16.test
+++ b/test/WaveOps/WaveActiveAllEqual.int16.test
@@ -250,9 +250,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug: https://github.com/llvm/offload-test-suite/issues/943
-# XFAIL: Intel && Vulkan
-
 # Bug: https://github.com/llvm/offload-test-suite/issues/981
 # XFAIL: Clang
 

--- a/test/WaveOps/WaveActiveAllEqual.int64.test
+++ b/test/WaveOps/WaveActiveAllEqual.int64.test
@@ -253,9 +253,6 @@ DescriptorSets:
 # Bug: https://github.com/llvm/offload-test-suite/issues/944
 # XFAIL: Intel && DirectX
 
-# Bug: https://github.com/llvm/offload-test-suite/issues/943
-# XFAIL: Intel && Vulkan
-
 # Bug: https://github.com/llvm/offload-test-suite/issues/981
 # XFAIL: Clang
 


### PR DESCRIPTION
There were some mistakes when copying over the stride and fillsize during the construction of the tests for this intrinsic.
This PR makes those fixes.