### PR TITLE
Mark tests that use WaveSize attribute as unsupported on Vulkan & Metal

### DIFF
--- a/test/WaveOps/WaveActiveAllEqual.Wave128.test
+++ b/test/WaveOps/WaveActiveAllEqual.Wave128.test
@@ -325,6 +325,7 @@ DescriptorSets:
 #--- end
 
 # REQUIRES: WaveSize_128
+# These platforms do not support the WaveSize attribute.
 # UNSUPPORTED: Vulkan || Metal
 
 # RUN: split-file %s %t

--- a/test/WaveOps/WaveActiveAllEqual.Wave32.test
+++ b/test/WaveOps/WaveActiveAllEqual.Wave32.test
@@ -235,6 +235,7 @@ DescriptorSets:
 #--- end
 
 # REQUIRES: WaveSize_32
+# These platforms do not support the WaveSize attribute.
 # UNSUPPORTED: Vulkan || Metal
 
 # RUN: split-file %s %t

--- a/test/WaveOps/WaveActiveAllEqual.Wave64.test
+++ b/test/WaveOps/WaveActiveAllEqual.Wave64.test
@@ -265,6 +265,7 @@ DescriptorSets:
 #--- end
 
 # REQUIRES: WaveSize_64
+# These platforms do not support the WaveSize attribute.
 # UNSUPPORTED: Vulkan || Metal
 
 # RUN: split-file %s %t

--- a/test/WaveOps/WaveActiveBallot.Modulo.Wave128.test
+++ b/test/WaveOps/WaveActiveBallot.Modulo.Wave128.test
@@ -41,6 +41,7 @@ DescriptorSets:
 #--- end
 
 # REQUIRES: WaveSize_128
+# These platforms do not support the WaveSize attribute.
 # UNSUPPORTED: Vulkan || Metal
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/711

--- a/test/WaveOps/WaveActiveBallot.Modulo.Wave32.test
+++ b/test/WaveOps/WaveActiveBallot.Modulo.Wave32.test
@@ -41,6 +41,7 @@ DescriptorSets:
 #--- end
 
 # REQUIRES: WaveSize_32
+# These platforms do not support the WaveSize attribute.
 # UNSUPPORTED: Vulkan || Metal
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/711

--- a/test/WaveOps/WaveActiveBallot.Modulo.Wave64.test
+++ b/test/WaveOps/WaveActiveBallot.Modulo.Wave64.test
@@ -41,6 +41,7 @@ DescriptorSets:
 #--- end
 
 # REQUIRES: WaveSize_64
+# These platforms do not support the WaveSize attribute.
 # UNSUPPORTED: Vulkan || Metal
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/711

--- a/test/WaveOps/WaveActiveBallot.Wave128.test
+++ b/test/WaveOps/WaveActiveBallot.Wave128.test
@@ -50,6 +50,7 @@ DescriptorSets:
 #--- end
 
 # REQUIRES: WaveSize_128
+# These platforms do not support the WaveSize attribute.
 # UNSUPPORTED: Vulkan || Metal
 
 # RUN: split-file %s %t

--- a/test/WaveOps/WaveActiveBallot.Wave32.test
+++ b/test/WaveOps/WaveActiveBallot.Wave32.test
@@ -48,6 +48,7 @@ DescriptorSets:
 #--- end
 
 # REQUIRES: WaveSize_32
+# These platforms do not support the WaveSize attribute.
 # UNSUPPORTED: Vulkan || Metal
 
 # RUN: split-file %s %t

--- a/test/WaveOps/WaveActiveBallot.Wave64.test
+++ b/test/WaveOps/WaveActiveBallot.Wave64.test
@@ -48,6 +48,7 @@ DescriptorSets:
 #--- end
 
 # REQUIRES: WaveSize_64
+# These platforms do not support the WaveSize attribute.
 # UNSUPPORTED: Vulkan || Metal
 
 # RUN: split-file %s %t

--- a/test/WaveOps/WavePrefixCountBits.Wave128.test
+++ b/test/WaveOps/WavePrefixCountBits.Wave128.test
@@ -76,6 +76,7 @@ DescriptorSets:
 #--- end
 
 # REQUIRES: WaveSize_128
+# These platforms do not support the WaveSize attribute.
 # UNSUPPORTED: Vulkan || Metal
 
 # RUN: split-file %s %t

--- a/test/WaveOps/WavePrefixCountBits.Wave32.test
+++ b/test/WaveOps/WavePrefixCountBits.Wave32.test
@@ -64,6 +64,7 @@ DescriptorSets:
 #--- end
 
 # REQUIRES: WaveSize_32
+# These platforms do not support the WaveSize attribute.
 # UNSUPPORTED: Vulkan || Metal
 
 # RUN: split-file %s %t

--- a/test/WaveOps/WavePrefixCountBits.Wave64.test
+++ b/test/WaveOps/WavePrefixCountBits.Wave64.test
@@ -68,6 +68,7 @@ DescriptorSets:
 #--- end
 
 # REQUIRES: WaveSize_64
+# These platforms do not support the WaveSize attribute.
 # UNSUPPORTED: Vulkan || Metal
 
 # RUN: split-file %s %t

--- a/test/WaveOps/WaveReadLaneFirst.128Threads.test
+++ b/test/WaveOps/WaveReadLaneFirst.128Threads.test
@@ -252,6 +252,7 @@ DescriptorSets:
 #--- end
 
 # REQUIRES: WaveSize_32
+# These platforms do not support the WaveSize attribute.
 # UNSUPPORTED: Vulkan || Metal
 
 # Bug https://github.com/llvm/llvm-project/issues/156775


### PR DESCRIPTION
The WaveSize attribute is currently only fully supported on D3D. Some tests may be passing, or not running, by accident due to other requirements. This change explicitly marks these tests as unsupported on Metal and Vulkan.

#611 tracks adding the required support to Vulkan to be able to enable these tests.

Assisted-by: Copilot
