### PR TITLE
Remove ~VulkanDevice and prefer atexit(cleanupVulkanDevices)

### DIFF
--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -2256,9 +2256,6 @@ public:
   }
 
   void cleanup() {
-    // Free devices before destroying the instance
-    Devices.clear();
-
 #ifndef NDEBUG
     auto Func = (PFN_vkDestroyDebugUtilsMessengerEXT)vkGetInstanceProcAddr(
         Instance, "vkDestroyDebugUtilsMessengerEXT");


### PR DESCRIPTION
As per the comment where we set up cleanupVulkanDevices to be called at exit, the vulkan validation layers require us to destroy the vulkan objects in a particular order. Move the destruction of the vulkan device itself back into that logic to avoid crashing on exit.

Fixes #1027