### PR TITLE
Remove unused pWaitDstStageMask from Vulkan submit

### DIFF
--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -1154,8 +1154,7 @@ public:
     return llvm::Error::success();
   }
 
-  llvm::Error executeCommandBuffer(InvocationState &IS,
-                                   VkPipelineStageFlags WaitMask = 0) {
+  llvm::Error executeCommandBuffer(InvocationState &IS) {
     if (vkEndCommandBuffer(IS.CmdBuffer))
       return llvm::createStringError(std::errc::device_or_resource_busy,
                                      "Could not end command buffer.");
@@ -1164,7 +1163,6 @@ public:
     SubmitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
     SubmitInfo.commandBufferCount = 1;
     SubmitInfo.pCommandBuffers = &IS.CmdBuffer;
-    SubmitInfo.pWaitDstStageMask = &WaitMask;
     VkFenceCreateInfo FenceInfo = {};
     FenceInfo.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
     VkFence Fence;
@@ -2365,7 +2363,7 @@ public:
     if (auto Err = createCommands(P, State))
       return Err;
     llvm::outs() << "Commands created.\n";
-    if (auto Err = executeCommandBuffer(State, VK_PIPELINE_STAGE_TRANSFER_BIT))
+    if (auto Err = executeCommandBuffer(State))
       return Err;
     llvm::outs() << "Executed compute command buffer.\n";
     if (auto Err = readBackData(P, State))


### PR DESCRIPTION
`pWaitDstStageMask` is only meaningful when wait semaphores are used, which this submit path does not use. This wasn't causing errors in practice because `vkWaitForFences()` is called after every submit, preventing concurrent in-flight command buffers.

The compute dispatch submit passed `VK_PIPELINE_STAGE_TRANSFER_BIT`, intending to wait for the prior buffer transfer submit to complete, but `pWaitDstStageMask` is a **destination stage mask** — it specifies which stages in the current submit to block until a wait semaphore signals, **not** which prior stages to wait on. Without semaphores this had no effect.
