### PR TITLE
Remove XFAIL for Texture2D Operator for Vulkan

### DIFF
--- a/test/Feature/Textures/Texture2D.OperatorIndex.test.yaml
+++ b/test/Feature/Textures/Texture2D.OperatorIndex.test.yaml
@@ -74,7 +74,7 @@ Results:
 # Unimplemented: Clang + DX: https://github.com/llvm/llvm-project/issues/101558
 # XFAIL: Clang && DirectX
 
-# Unimplemented: https://github.com/llvm/wg-hlsl/issues/400
+# Unimplemented: https://github.com/llvm/offload-test-suite/issues/1039
 # XFAIL: DirectX
 
 # XFAIL: Metal


### PR DESCRIPTION
This functionality was implemented for vulkan in:

- https://github.com/llvm/llvm-project/pull/186110
- https://github.com/llvm/llvm-project/pull/186143