### PR TITLE
Remove XFAILs for llvm/llvm-project#188131

### DIFF
--- a/test/Feature/StructuredBuffer/matrix.test
+++ b/test/Feature/StructuredBuffer/matrix.test
@@ -108,9 +108,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Unimplemented https://github.com/llvm/llvm-project/issues/188131
-# XFAIL: Clang && Vulkan
-
 # Unimplemented https://github.com/llvm/offload-test-suite/issues/1021
 # XFAIL: Metal
 

--- a/test/Feature/StructuredBuffer/matrix_assign.test
+++ b/test/Feature/StructuredBuffer/matrix_assign.test
@@ -97,9 +97,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Unimplemented https://github.com/llvm/llvm-project/issues/188131
-# XFAIL: Clang && Vulkan
-
 # Unimplemented https://github.com/llvm/offload-test-suite/issues/1021
 # XFAIL: Metal
 


### PR DESCRIPTION
This issue is resolved, and these tests no longer fail.