### PR TITLE
Remove overflow test from dot2add

### DIFF
--- a/test/Feature/HLSLLib/dot2add.test
+++ b/test/Feature/HLSLLib/dot2add.test
@@ -18,7 +18,7 @@ void main(uint3 DTID : SV_DispatchThreadID) {
     Out[15] = dot2add(half2(1, 49152), half2(-49152, 1), float(-2));
   }
 }
-#--- pipeline.yaml
+//--- pipeline.yaml
 
 ---
 Shaders:


### PR DESCRIPTION
This patch changes the input values of dot2add so no values cause overflow.

Fix: #568 