### PR TITLE
Remove XFAIL for CalculateLevelOfDetail and GetDimensions for Vulkan

### DIFF
--- a/test/Feature/Textures/Texture2D.CalculateLevelOfDetail.test.yaml
+++ b/test/Feature/Textures/Texture2D.CalculateLevelOfDetail.test.yaml
@@ -1,4 +1,4 @@
-#--- source.hlsl
+#--- vertex.hlsl
 struct VSInput {
   float3 Pos : POSITION;
 };
@@ -13,16 +13,17 @@ VSOutput mainVS(VSInput input) {
   return output;
 }
 
+#--- pixel.hlsl
 [[vk::binding(0, 0)]] Texture2D<float4> Tex : register(t0);
 [[vk::binding(1, 0)]] SamplerState Samp : register(s0);
 [[vk::binding(2, 0)]] RWBuffer<float> Out : register(u0);
 
-float4 mainPS(VSOutput input) : SV_Target {
+float4 mainPS(float4 Pos : SV_POSITION) : SV_Target {
   // Use SV_Position (pixel coordinates) to simulate the grid logic.
   // Input position is [-1, 1], mapped to viewport 2x2.
   // Pixel centers will be at (0.5, 0.5), (1.5, 0.5), etc.
   
-  uint2 GTid = (uint2)input.Pos.xy;
+  uint2 GTid = (uint2)Pos.xy;
 
   // Case 1: Derivative = 0.5. Texture Size = 4.
   // LOD = log2(0.5 * 4) = 1.0
@@ -126,10 +127,9 @@ Results:
 #--- end
 
 # Unimplemented: Clang + DX: https://github.com/llvm/llvm-project/issues/101558
-# Unimplemented: Clang + VK: https://github.com/llvm/llvm-project/issues/175630
-# XFAIL: DirectX || Metal || Clang
+# XFAIL: DirectX || Metal
 
 # RUN: split-file %s %t
-# RUN: %dxc_target -T vs_6_6 -E mainVS -Fo %t-vs.o %t/source.hlsl
-# RUN: %dxc_target -T ps_6_6 -E mainPS -Fo %t-ps.o %t/source.hlsl
+# RUN: %dxc_target -T vs_6_6 -E mainVS -Fo %t-vs.o %t/vertex.hlsl
+# RUN: %dxc_target -T ps_6_6 -E mainPS -Fo %t-ps.o %t/pixel.hlsl
 # RUN: %offloader %t/pipeline.yaml %t-vs.o %t-ps.o

--- a/test/Feature/Textures/Texture2D.GetDimensions.test.yaml
+++ b/test/Feature/Textures/Texture2D.GetDimensions.test.yaml
@@ -1,4 +1,4 @@
-#--- source.hlsl
+#--- compute.hlsl
 [[vk::binding(0, 0)]] Texture2D<float4> Tex1 : register(t0);
 [[vk::binding(1, 0)]] Texture2D<float4> Tex2 : register(t1);
 [[vk::binding(3, 0)]] Texture2D<float4> Tex3 : register(t2); // 4x4 with 3 mips
@@ -7,6 +7,7 @@
 [numthreads(1, 1, 1)]
 void main() {
   float width, height, levels;
+  uint uwidth, uheight, ulevels;
   
   // Tex1 (4x8, 1 mip)
   Tex1.GetDimensions(0, width, height, levels);
@@ -14,26 +15,37 @@ void main() {
   Out[1] = height;
   Out[2] = levels;
   
-  float w, h;
-  Tex1.GetDimensions(w, h);
-  Out[3] = w;
-  Out[4] = h;
+  Tex1.GetDimensions(uwidth, uheight);
+  Out[3] = (float)uwidth;
+  Out[4] = (float)uheight;
 
   // Tex2 (16x32, 1 mip)
-  Tex2.GetDimensions(0, width, height, levels);
-  Out[5] = width;
-  Out[6] = height;
-  Out[7] = levels;
+  Tex2.GetDimensions(0, uwidth, uheight, ulevels);
+  Out[5] = (float)uwidth;
+  Out[6] = (float)uheight;
+  Out[7] = (float)ulevels;
   
+  float w, h;
   Tex2.GetDimensions(w, h);
   Out[8] = w;
   Out[9] = h;
 
   // Tex3 (4x4, 3 mips)
+  // Mip 0: 4x4
   Tex3.GetDimensions(0, width, height, levels);
   Out[10] = width;
   Out[11] = height;
   Out[12] = levels;
+
+  // Mip 1: 2x2
+  Tex3.GetDimensions(1, uwidth, uheight, ulevels);
+  Out[13] = (float)uwidth;
+  Out[14] = (float)uheight;
+  
+  // Mip 2: 1x1
+  Tex3.GetDimensions(2, w, h, levels);
+  Out[15] = w;
+  Out[16] = h;
 }
 
 //--- pipeline.yaml
@@ -65,14 +77,16 @@ Buffers:
   - Name: Out
     Format: Float32
     Channels: 1
-    FillSize: 52 # 13 * sizeof(float)
+    FillSize: 68 # 17 * sizeof(float)
 
   - Name: Expected
     Format: Float32
     Channels: 1
     Data: [ 4.0, 8.0, 1.0, 4.0, 8.0,    # Tex1
             16.0, 32.0, 1.0, 16.0, 32.0, # Tex2
-            4.0, 4.0, 3.0 ]              # Tex3
+            4.0, 4.0, 3.0,               # Tex3 Mip 0
+            2.0, 2.0,                    # Tex3 Mip 1
+            1.0, 1.0 ]                   # Tex3 Mip 2
 
 DescriptorSets:
   - Resources:
@@ -102,9 +116,8 @@ Results:
 #--- end
 
 # Unimplemented: Clang + DX: https://github.com/llvm/llvm-project/issues/101558
-# Unimplemented: Clang + VK: https://github.com/llvm/llvm-project/issues/175630
-# XFAIL: DirectX || Metal || Clang
+# XFAIL: DirectX || Metal
 
 # RUN: split-file %s %t
-# RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/compute.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
Remove xfail for clang and Vulkan, as these are now implemented in
clang. Improves the tests as well.

- Split CalculateLevelOfDetail test shaders into vertex and pixel files
- Expand GetDimensions tests for Texture2D
