### PR TITLE
Decrease frequency of non-metal workflows that run more frequently than every 4 hours

### DIFF
--- a/.github/workflows/windows-intel-clang-d3d12.yaml
+++ b/.github/workflows/windows-intel-clang-d3d12.yaml
@@ -6,7 +6,7 @@ permissions:
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 */2 * * *' # run every 2 hours
+    - cron: '0 */4 * * *' # run every 4 hours
   pull_request:
     paths:
      - .github/workflows/windows-intel-clang-d3d12.yaml

--- a/.github/workflows/windows-intel-clang-vk.yaml
+++ b/.github/workflows/windows-intel-clang-vk.yaml
@@ -6,7 +6,7 @@ permissions:
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 */2 * * *' # run every 2 hours
+    - cron: '0 */4 * * *' # run every 4 hours
   pull_request:
     paths:
      - .github/workflows/windows-intel-clang-vk.yaml

--- a/.github/workflows/windows-intel-dxc-d3d12.yaml
+++ b/.github/workflows/windows-intel-dxc-d3d12.yaml
@@ -6,7 +6,7 @@ permissions:
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 * * * *' # run every 30 minutes
+    - cron: '0 */4 * * *' # run every 4 hours
   pull_request:
     paths:
      - .github/workflows/windows-intel-dxc-d3d12.yaml

--- a/.github/workflows/windows-intel-dxc-vk.yaml
+++ b/.github/workflows/windows-intel-dxc-vk.yaml
@@ -6,7 +6,7 @@ permissions:
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 */2 * * *' # run every 2 hours
+    - cron: '0 */4 * * *' # run every 4 hours
   pull_request:
     paths:
      - .github/workflows/windows-intel-dxc-vk.yaml

--- a/.github/workflows/windows-nvidia-clang-d3d12.yaml
+++ b/.github/workflows/windows-nvidia-clang-d3d12.yaml
@@ -6,7 +6,7 @@ permissions:
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 */2 * * *' # run every 2 hours
+    - cron: '0 */4 * * *' # run every 4 hours
   pull_request:
     paths:
      - .github/workflows/windows-nvidia-clang-d3d12.yaml

--- a/.github/workflows/windows-nvidia-clang-vk.yaml
+++ b/.github/workflows/windows-nvidia-clang-vk.yaml
@@ -6,7 +6,7 @@ permissions:
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 */2 * * *' # run every 2 hours
+    - cron: '0 */4 * * *' # run every 4 hours
   pull_request:
     paths:
      - .github/workflows/windows-nvidia-clang-vk.yaml

--- a/.github/workflows/windows-nvidia-dxc-d3d12.yaml
+++ b/.github/workflows/windows-nvidia-dxc-d3d12.yaml
@@ -6,7 +6,7 @@ permissions:
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 * * * *' # run every 30 minutes
+    - cron: '0 */4 * * *' # run every 4 hours
   pull_request:
     paths:
      - .github/workflows/windows-nvidia-dxc-d3d12.yaml

--- a/.github/workflows/windows-nvidia-dxc-vk.yaml
+++ b/.github/workflows/windows-nvidia-dxc-vk.yaml
@@ -6,7 +6,7 @@ permissions:
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 */2 * * *' # run every 2 hours
+    - cron: '0 */4 * * *' # run every 4 hours
   pull_request:
     paths:
      - .github/workflows/window-nvidia-dxc-vk.yaml


### PR DESCRIPTION
This PR changes the frequency that certain workflows are scheduled to be run.
Certain workflows are run every 30 minutes, or every hour, or every 2 hours. 
While these frequencies are high, which helps in keeping a pulse on the health of the offload test suite, they are so high that PRs have problems acquiring resources to run their own workflows. There is significant contention between scheduled workflows and PR workflows.
This PR reduces the frequency of workflows that are run more frequently than every 4 hours, except for macOS, since those workflows complete so quickly.

Fixes https://github.com/llvm/offload-test-suite/issues/1065