### PR TITLE
Add split build/test callable workflow for validation

### DIFF
--- a/.github/workflows/build-and-test-split-callable.yaml
+++ b/.github/workflows/build-and-test-split-callable.yaml
@@ -220,7 +220,7 @@ jobs:
               DXC/build/bin llvm-project/build
       - name: Upload build artifacts
         if: inputs.OS == 'windows'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: build-${{ inputs.SKU }}-${{ inputs.TestTarget }}
           path: ${{ runner.temp }}/build-artifacts.tar
@@ -269,7 +269,7 @@ jobs:
       # --touch ensures extracted files get current timestamps so ninja
       # sees build outputs as newer than source files (no rebuild).
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: build-${{ inputs.SKU }}-${{ inputs.TestTarget }}
           path: ${{ runner.temp }}
@@ -315,7 +315,7 @@ jobs:
           Write-Host "DxDiag report saved to $output"
       - name: Upload dxdiag artifact
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dxdiag-${{ inputs.SKU }}-${{inputs.TestTarget}}.txt
           path: ${{ runner.temp }}/dxdiag.txt

--- a/.github/workflows/build-and-test-split-callable.yaml
+++ b/.github/workflows/build-and-test-split-callable.yaml
@@ -1,0 +1,326 @@
+name: HLSL Test (Split Build/Test)
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+    inputs:
+      OffloadTest-branch:
+        description: 'Test Suite Branch'
+        required: false
+        default: 'main'
+        type: string
+      LLVM-branch:
+        description: 'LLVM Branch'
+        required: false
+        default: 'main'
+        type: string
+      LLVM-fork:
+        description: 'LLVM fork'
+        required: false
+        default: 'llvm'
+        type: string
+      DXC-branch:
+        description: 'DXC Branch'
+        required: false
+        default: 'main'
+        type: string
+      BuildType:
+        description: 'Build Type'
+        required: false
+        default: 'RelWithDebInfo'
+        type: choice
+        options:
+        - Release
+        - RelWithDebInfo
+        - Debug
+      TestTarget:
+        required: false
+        default: 'check-hlsl'
+        type: string
+      OS:
+        required: true
+        type: choice
+        options:
+        - macOS
+        - windows
+      SKU:
+        required: true
+        type: choice
+        options:
+        - macos
+        - windows-amd
+        - windows-intel
+        - windows-nvidia
+        - windows-qc
+      LLVM-ExtraCMakeArgs:
+        description: 'Extra CMake Args for LLVM'
+        required: false
+        default: ''
+        type: string
+  workflow_call:
+    inputs:
+      OffloadTest-branch:
+        description: 'Test Suite Branch'
+        required: false
+        default: 'main'
+        type: string
+      LLVM-branch:
+        description: 'LLVM Branch'
+        required: false
+        default: 'main'
+        type: string
+      LLVM-fork:
+        description: 'LLVM For'
+        required: false
+        default: 'llvm'
+        type: string
+      DXC-branch:
+        description: 'DXC Branch'
+        required: false
+        default: 'main'
+        type: string
+      OS:
+        required: true
+        type: string
+      SKU:
+        required: true
+        type: string
+      BuildType:
+        description: 'Build Config'
+        required: false
+        default: 'RelWithDebInfo'
+        type: string
+      TestTarget:
+        required: false
+        default: 'check-hlsl'
+        type: string
+      LLVM-ExtraCMakeArgs:
+        description: 'Extra CMake Args for LLVM'
+        required: false
+        default: ''
+        type: string
+
+# ============================================================================
+# Split Build/Test Architecture:
+#
+# Windows: Build job runs on ANY available runner of the right architecture
+#   (load-balanced via generic labels), then test job runs on the specific
+#   GPU runner. This frees GPU runners during the build phase.
+#
+# macOS: Single combined job (builds are fast ~1 min, split not worth it).
+# ============================================================================
+
+jobs:
+  build:
+    permissions:
+      checks: write
+    # macOS: use the specific macOS runner (single combined job)
+    # Windows QC (ARM64): use any ARM64 Windows runner
+    # Windows x64: use any x64 Windows runner (load-balanced across Intel/NVIDIA/AMD)
+    runs-on: ${{ fromJSON(inputs.OS == 'macOS' && '["self-hosted", "hlsl-macos"]' || inputs.SKU == 'windows-qc' && '["self-hosted", "ARM64", "Windows"]' || '["self-hosted", "Windows", "X64"]') }}
+    steps:
+      - name: Checkout DXC
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          repository: Microsoft/DirectXShaderCompiler
+          ref: ${{ inputs.DXC-branch }}
+          path: DXC
+          fetch-depth: 1
+          submodules: true
+      - name: Checkout LLVM
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          repository: ${{ inputs.LLVM-fork }}/llvm-project
+          ref: ${{ inputs.LLVM-branch }}
+          path: llvm-project
+          fetch-depth: 1
+      - name: Checkout OffloadTest
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          repository: llvm/offload-test-suite
+          ref: ${{ inputs.OffloadTest-branch }}
+          path: OffloadTest
+          fetch-depth: 1
+      - name: Checkout Golden Images
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          repository: llvm/offload-golden-images
+          ref: main
+          path: golden-images
+          fetch-depth: 1
+      - name: Setup Windows x64
+        if: inputs.OS == 'windows' && runner.arch != 'ARM64'
+        uses: llvm/actions/setup-windows@89a8cf80982d830faab019237860b344a6390c30 # main
+        with:
+          arch: amd64
+      - name: Setup Windows
+        if: inputs.OS == 'windows' && runner.arch == 'ARM64'
+        uses: llvm/actions/setup-windows@89a8cf80982d830faab019237860b344a6390c30 # main
+        with:
+          arch: arm64
+      - name: Detect Clang
+        id: Test-Clang
+        shell: bash
+        if: contains(inputs.TestTarget, 'clang')
+        run: echo TEST_CLANG=On >> $GITHUB_OUTPUT
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          pip-install: -r ${{ github.workspace }}/OffloadTest/test/requirements.txt
+      - name: Build DXC
+        run: |
+            cd DXC
+            mkdir build
+            cd build
+            cmake -G Ninja -DCMAKE_BUILD_TYPE=${{ inputs.BuildType }} -DLLVM_ENABLE_ASSERTIONS=On -C ${{ github.workspace }}/DXC/cmake/caches/PredefinedParams.cmake -C ${{ github.workspace }}/OffloadTest/cmake/caches/sccache.cmake -DHLSL_DISABLE_SOURCE_GENERATION=On ${{ github.workspace }}/DXC/
+            ninja
+      - name: Build LLVM
+        run: |
+            cd llvm-project
+            mkdir build
+            cd build
+            cmake -G Ninja ${{ inputs.LLVM-ExtraCMakeArgs }} -DCMAKE_BUILD_TYPE=${{ inputs.BuildType }} -DLLVM_ENABLE_ASSERTIONS=On -C ${{ github.workspace }}/llvm-project/clang/cmake/caches/HLSL.cmake -C ${{ github.workspace }}/OffloadTest/cmake/caches/sccache.cmake -DDXC_DIR=${{ github.workspace }}/DXC/build/bin -DLLVM_EXTERNAL_OFFLOADTEST_SOURCE_DIR=${{ github.workspace }}/OffloadTest -DLLVM_EXTERNAL_PROJECTS="OffloadTest" -DLLVM_LIT_ARGS="--xunit-xml-output=testresults.xunit.xml -v" -DOFFLOADTEST_TEST_CLANG=${{steps.Test-Clang.outputs.TEST_CLANG || 'Off' }} -DGOLDENIMAGE_DIR=${{ github.workspace }}/golden-images ${{ github.workspace }}/llvm-project/llvm/
+            ninja hlsl-test-depends
+
+      # === macOS: run tests in this job (no split) ===
+      - name: Dump GPU Info
+        if: inputs.OS == 'macOS'
+        run: |
+            cd llvm-project
+            cd build
+            ./bin/api-query
+      - name: Run HLSL Tests
+        if: inputs.OS == 'macOS'
+        run: |
+            cd llvm-project
+            cd build
+            ninja check-hlsl-unit
+            ninja ${{ inputs.TestTarget }}
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action/macos@34d7c956a59aed1bfebf31df77b8de55db9bbaaf # v2.21.0
+        if: always() && inputs.OS == 'macOS'
+        with:
+          comment_mode: off
+          files: llvm-project/build/**/testresults.xunit.xml
+
+      # === Windows: package and upload build artifacts for the test job ===
+      - name: Package build artifacts
+        if: inputs.OS == 'windows'
+        shell: bash
+        run: |
+            cd $GITHUB_WORKSPACE
+            tar cf $RUNNER_TEMP/build-artifacts.tar \
+              --exclude='*.obj' \
+              --exclude='*.o' \
+              --exclude='*.ilk' \
+              --exclude='CMakeFiles' \
+              DXC/build/bin llvm-project/build
+      - name: Upload build artifacts
+        if: inputs.OS == 'windows'
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-${{ inputs.SKU }}-${{ inputs.TestTarget }}
+          path: ${{ runner.temp }}/build-artifacts.tar
+          retention-days: 1
+
+  test:
+    if: inputs.OS != 'macOS'
+    needs: build
+    permissions:
+      checks: write
+    runs-on: [self-hosted, "hlsl-${{ inputs.SKU }}"]
+    steps:
+      # Checkout all repos: source files are needed for ninja dependency
+      # tracking and lit test sources.
+      - name: Checkout DXC
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          repository: Microsoft/DirectXShaderCompiler
+          ref: ${{ inputs.DXC-branch }}
+          path: DXC
+          fetch-depth: 1
+          submodules: true
+      - name: Checkout LLVM
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          repository: ${{ inputs.LLVM-fork }}/llvm-project
+          ref: ${{ inputs.LLVM-branch }}
+          path: llvm-project
+          fetch-depth: 1
+      - name: Checkout OffloadTest
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          repository: llvm/offload-test-suite
+          ref: ${{ inputs.OffloadTest-branch }}
+          path: OffloadTest
+          fetch-depth: 1
+      - name: Checkout Golden Images
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          repository: llvm/offload-golden-images
+          ref: main
+          path: golden-images
+          fetch-depth: 1
+
+      # Download and extract build artifacts over the source checkouts.
+      # --touch ensures extracted files get current timestamps so ninja
+      # sees build outputs as newer than source files (no rebuild).
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-${{ inputs.SKU }}-${{ inputs.TestTarget }}
+          path: ${{ runner.temp }}
+      - name: Extract build artifacts
+        shell: bash
+        run: |
+            cd $GITHUB_WORKSPACE
+            tar xf $RUNNER_TEMP/build-artifacts.tar --touch
+
+      - name: Setup Windows x64
+        if: runner.arch != 'ARM64'
+        uses: llvm/actions/setup-windows@89a8cf80982d830faab019237860b344a6390c30 # main
+        with:
+          arch: amd64
+      - name: Setup Windows
+        if: runner.arch == 'ARM64'
+        uses: llvm/actions/setup-windows@89a8cf80982d830faab019237860b344a6390c30 # main
+        with:
+          arch: arm64
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          pip-install: -r ${{ github.workspace }}/OffloadTest/test/requirements.txt
+
+      - name: Dump GPU Info
+        run: |
+            cd llvm-project
+            cd build
+            ./bin/api-query
+      - name: Run HLSL Tests
+        run: |
+            cd llvm-project
+            cd build
+            ninja check-hlsl-unit
+            ninja ${{ inputs.TestTarget }}
+      - name: Run dxdiag (Windows only)
+        if: failure()
+        shell: powershell
+        run: |
+          $fileName = "dxdiag.txt"
+          $output = Join-Path $env:RUNNER_TEMP $fileName
+          dxdiag /t $output | Out-Null
+          Write-Host "DxDiag report saved to $output"
+      - name: Upload dxdiag artifact
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dxdiag-${{ inputs.SKU }}-${{inputs.TestTarget}}.txt
+          path: ${{ runner.temp }}/dxdiag.txt
+      #- name: Publish Test Results
+      #  uses: EnricoMi/publish-unit-test-result-action/windows@34d7c956a59aed1bfebf31df77b8de55db9bbaaf # v2.21.0
+      #  if: always() && inputs.OS == 'windows'
+      #  with:
+      #    comment_mode: off
+      #    files: llvm-project/build/**/testresults.xunit.xml

--- a/.github/workflows/build-and-test-split-callable.yaml
+++ b/.github/workflows/build-and-test-split-callable.yaml
@@ -72,7 +72,7 @@ on:
         default: 'main'
         type: string
       LLVM-fork:
-        description: 'LLVM For'
+        description: 'LLVM Fork'
         required: false
         default: 'llvm'
         type: string
@@ -215,6 +215,7 @@ jobs:
               --exclude='*.obj' \
               --exclude='*.o' \
               --exclude='*.ilk' \
+              --exclude='*.pdb' \
               --exclude='CMakeFiles' \
               DXC/build/bin llvm-project/build
       - name: Upload build artifacts

--- a/.github/workflows/validate-split-build-test.yaml
+++ b/.github/workflows/validate-split-build-test.yaml
@@ -1,0 +1,103 @@
+name: Validate Split Build/Test
+
+# Manual-only workflow for validating the split callable on each SKU.
+# Run this via workflow_dispatch, selecting a SKU to test.
+# Compare results against the standard build-and-test-callable.yaml runs.
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+    inputs:
+      SKU:
+        description: 'Runner SKU to test'
+        required: true
+        type: choice
+        options:
+        - windows-intel
+        - windows-nvidia
+        - windows-amd
+        - windows-qc
+        - macos
+
+jobs:
+  # Run the split callable for every test target relevant to the chosen SKU
+  split-intel:
+    if: inputs.SKU == 'windows-intel'
+    permissions:
+      contents: read
+      checks: write
+    strategy:
+      fail-fast: false
+      matrix:
+        TestTarget: [check-hlsl-d3d12, check-hlsl-vk, check-hlsl-clang-d3d12, check-hlsl-clang-vk, check-hlsl-warp-d3d12, check-hlsl-clang-warp-d3d12]
+    uses: ./.github/workflows/build-and-test-split-callable.yaml
+    with:
+      OS: windows
+      SKU: windows-intel
+      TestTarget: ${{ matrix.TestTarget }}
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=On
+
+  split-nvidia:
+    if: inputs.SKU == 'windows-nvidia'
+    permissions:
+      contents: read
+      checks: write
+    strategy:
+      fail-fast: false
+      matrix:
+        TestTarget: [check-hlsl-d3d12, check-hlsl-vk, check-hlsl-clang-d3d12, check-hlsl-clang-vk]
+    uses: ./.github/workflows/build-and-test-split-callable.yaml
+    with:
+      OS: windows
+      SKU: windows-nvidia
+      TestTarget: ${{ matrix.TestTarget }}
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=On
+
+  split-amd:
+    if: inputs.SKU == 'windows-amd'
+    permissions:
+      contents: read
+      checks: write
+    strategy:
+      fail-fast: false
+      matrix:
+        TestTarget: [check-hlsl-d3d12, check-hlsl-vk, check-hlsl-clang-d3d12, check-hlsl-clang-vk]
+    uses: ./.github/workflows/build-and-test-split-callable.yaml
+    with:
+      OS: windows
+      SKU: windows-amd
+      TestTarget: ${{ matrix.TestTarget }}
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=On
+
+  split-qc:
+    if: inputs.SKU == 'windows-qc'
+    permissions:
+      contents: read
+      checks: write
+    strategy:
+      fail-fast: false
+      matrix:
+        TestTarget: [check-hlsl-d3d12, check-hlsl-vk, check-hlsl-clang-d3d12, check-hlsl-clang-vk, check-hlsl-warp-d3d12, check-hlsl-clang-warp-d3d12]
+    uses: ./.github/workflows/build-and-test-split-callable.yaml
+    with:
+      OS: windows
+      SKU: windows-qc
+      TestTarget: ${{ matrix.TestTarget }}
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=On
+
+  split-macos:
+    if: inputs.SKU == 'macos'
+    permissions:
+      contents: read
+      checks: write
+    strategy:
+      fail-fast: false
+      matrix:
+        TestTarget: [check-hlsl-mtl, check-hlsl-clang-mtl]
+    uses: ./.github/workflows/build-and-test-split-callable.yaml
+    with:
+      OS: macOS
+      SKU: macos
+      TestTarget: ${{ matrix.TestTarget }}


### PR DESCRIPTION
 Every PR test job holds a GPU runner for the full build+test duration (7–16 min), even though 67–86% of that time is CPU-only DXC/LLVM compilation. With one self-hosted runner per GPU SKU, this means builds block GPU-dependent test work unnecessarily.

This PR adds two new, standalone workflow files — no existing workflows are modified:

build-and-test-split-callable.yaml — A split version of the callable workflow:

 - Build job: Runs on any available runner of the matching architecture ([self-hosted, Windows, X64] for Intel/NVIDIA/AMD, [self-hosted, ARM64, Windows] for QC). Builds DXC + LLVM, uploads artifacts via tar.
 - Test job: Runs on the GPU-specific runner (hlsl-${{ inputs.SKU }}). Downloads build artifacts, extracts with --touch to preserve ninja timestamp freshness, then runs tests.
 - macOS: Unchanged — stays as a single combined job since builds are only ~1 min.

validate-split-build-test.yaml — A workflow_dispatch workflow to validate the split callable per-SKU before migrating production workflows.

Fixes https://github.com/llvm/offload-test-suite/issues/1081

Assisted by: Github Copilot
