### PR TITLE
Abstract Pipeline creation (including pipeline layouts and root signatures)

### DIFF
--- a/include/API/Device.h
+++ b/include/API/Device.h
@@ -46,16 +46,16 @@ struct DeviceConfig {
   bool EnableValidationLayer = false;
 };
 
-struct DXBinding {
-  uint32_t Register;
-  uint32_t Space;
-};
-
 struct InputLayoutDesc {
   std::string Name;
   Format Format;
   uint32_t OffsetInBytes;
   std::optional<uint32_t> InstanceStepRate;
+};
+
+struct DXBinding {
+  uint32_t Register;
+  uint32_t Space;
 };
 
 struct ResourceBindingDesc {

--- a/include/API/Device.h
+++ b/include/API/Device.h
@@ -46,7 +46,7 @@ struct DeviceConfig {
   bool EnableValidationLayer = false;
 };
 
-struct DXBinding { // TODO(manon): rename
+struct DXBinding {
   uint32_t Register;
   uint32_t Space;
 };
@@ -58,7 +58,6 @@ struct InputLayoutDesc {
   std::optional<uint32_t> InstanceStepRate;
 };
 
-// TODO(manon): Come up with a good name
 struct ResourceBindingDesc {
   ResourceKind Kind;
   DXBinding DXBinding;
@@ -156,11 +155,11 @@ public:
 
   virtual Queue &getGraphicsQueue() = 0;
 
-  virtual llvm::Expected<std::shared_ptr<PipelineState>>
+  virtual llvm::Expected<std::unique_ptr<PipelineState>>
   createPipelineCs(llvm::StringRef Name, const BindingsDesc &BindingsDesc,
                    ShaderContainer CS) = 0;
 
-  virtual llvm::Expected<std::shared_ptr<PipelineState>>
+  virtual llvm::Expected<std::unique_ptr<PipelineState>>
   createPipelineVsPs(llvm::StringRef Name, const BindingsDesc &BindingsDesc,
                      llvm::ArrayRef<InputLayoutDesc> InputLayout,
                      llvm::ArrayRef<Format> RTFormats,

--- a/include/API/Device.h
+++ b/include/API/Device.h
@@ -48,7 +48,7 @@ struct DeviceConfig {
 
 struct InputLayoutDesc {
   std::string Name;
-  Format Format;
+  Format Fmt;
   uint32_t OffsetInBytes;
   std::optional<uint32_t> InstanceStepRate;
 };

--- a/include/API/Device.h
+++ b/include/API/Device.h
@@ -19,12 +19,18 @@
 #include "API/Capabilities.h"
 #include "API/CommandBuffer.h"
 #include "API/Texture.h"
+
 #include "Support/Pipeline.h"
+
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/iterator_range.h"
 #include "llvm/Support/Error.h"
+#include "llvm/Support/MemoryBuffer.h"
 
+#include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
 
 namespace llvm {
@@ -38,6 +44,57 @@ struct Pipeline;
 struct DeviceConfig {
   bool EnableDebugLayer = false;
   bool EnableValidationLayer = false;
+};
+
+struct DXBinding { // TODO(manon): rename
+  uint32_t Register;
+  uint32_t Space;
+};
+
+struct InputLayoutDesc {
+  std::string Name;
+  Format Format;
+  uint32_t OffsetInBytes;
+  std::optional<uint32_t> InstanceStepRate;
+};
+
+// TODO(manon): Come up with a good name
+struct ResourceBindingDesc {
+  ResourceKind Kind;
+  DXBinding DXBinding;
+  std::optional<VulkanBinding> VKBinding;
+  uint32_t DescriptorCount;
+};
+
+struct DescriptorSetLayoutDesc {
+  llvm::SmallVector<ResourceBindingDesc> ResourceBindings;
+};
+
+struct PushConstantsRange {
+  uint32_t OffsetInBytes; // Must be multiple of 4
+  uint32_t SizeInBytes;   // Must be multiple of 4
+};
+
+struct BindingsDesc {
+  llvm::SmallVector<DescriptorSetLayoutDesc> DescriptorSetDescs;
+  llvm::SmallVector<PushConstantsRange> PushConstantRanges;
+};
+
+struct ShaderContainer {
+  std::string EntryPoint;
+  const llvm::MemoryBuffer *Shader;
+  llvm::SmallVector<SpecializationConstant> SpecializationConstants;
+};
+
+class PipelineState {
+public:
+  virtual ~PipelineState() = default;
+
+  PipelineState(const Buffer &) = delete;
+  PipelineState &operator=(const Buffer &) = delete;
+
+protected:
+  PipelineState() = default;
 };
 
 class Fence {
@@ -98,6 +155,17 @@ public:
   virtual llvm::Error executeProgram(Pipeline &P) = 0;
 
   virtual Queue &getGraphicsQueue() = 0;
+
+  virtual llvm::Expected<std::shared_ptr<PipelineState>>
+  createPipelineCs(llvm::StringRef Name, const BindingsDesc &BindingsDesc,
+                   ShaderContainer CS) = 0;
+
+  virtual llvm::Expected<std::shared_ptr<PipelineState>>
+  createPipelineVsPs(llvm::StringRef Name, const BindingsDesc &BindingsDesc,
+                     llvm::ArrayRef<InputLayoutDesc> InputLayout,
+                     llvm::ArrayRef<Format> RTFormats,
+                     std::optional<Format> DSFormat, ShaderContainer VS,
+                     ShaderContainer PS) = 0;
 
   virtual llvm::Expected<std::unique_ptr<Fence>>
   createFence(llvm::StringRef Name) = 0;

--- a/include/API/Device.h
+++ b/include/API/Device.h
@@ -87,13 +87,17 @@ struct ShaderContainer {
 
 class PipelineState {
 public:
+  GPUAPI API;
+
   virtual ~PipelineState() = default;
 
   PipelineState(const Buffer &) = delete;
   PipelineState &operator=(const Buffer &) = delete;
 
+  GPUAPI getAPI() const { return API; }
+
 protected:
-  PipelineState() = default;
+  explicit PipelineState(GPUAPI API) : API(API) {}
 };
 
 class Fence {

--- a/include/API/Enums.h
+++ b/include/API/Enums.h
@@ -1,0 +1,29 @@
+
+#ifndef OFFLOADTEST_API_ENUMS_H
+#define OFFLOADTEST_API_ENUMS_H
+
+namespace offloadtest {
+
+enum class ResourceKind {
+  Buffer,
+  StructuredBuffer,
+  ByteAddressBuffer,
+  Texture2D,
+  RWBuffer,
+  RWStructuredBuffer,
+  RWByteAddressBuffer,
+  RWTexture2D,
+  ConstantBuffer,
+  Sampler,
+  SampledTexture2D,
+};
+
+enum ShaderContainerType {
+  DXIL,
+  SPIRV,
+  Metal,
+};
+
+} // namespace offloadtest
+
+#endif // OFFLOADTEST_API_ENUMS_H

--- a/include/API/Enums.h
+++ b/include/API/Enums.h
@@ -1,3 +1,10 @@
+//===- Enums.h - Offload API Device API -----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
 
 #ifndef OFFLOADTEST_API_ENUMS_H
 #define OFFLOADTEST_API_ENUMS_H

--- a/include/API/FormatConversion.h
+++ b/include/API/FormatConversion.h
@@ -74,6 +74,8 @@ inline llvm::Expected<Format> toFormat(DataFormat Format, int Channels) {
       return Format::R32Float;
     case 2:
       return Format::RG32Float;
+    case 3:
+      return Format::RGB32Float;
     case 4:
       return Format::RGBA32Float;
     }

--- a/include/API/Resources.h
+++ b/include/API/Resources.h
@@ -147,6 +147,32 @@ inline bool isDepthFormat(Format Format) {
   llvm_unreachable("All Format cases handled");
 }
 
+inline bool isStencilFormat(Format Format) {
+  switch (Format) {
+  case Format::R16Sint:
+  case Format::R16Uint:
+  case Format::RG16Sint:
+  case Format::RG16Uint:
+  case Format::R32Sint:
+  case Format::R32Uint:
+  case Format::R32Float:
+  case Format::RGBA16Sint:
+  case Format::RGBA16Uint:
+  case Format::RG32Sint:
+  case Format::RG32Uint:
+  case Format::RG32Float:
+  case Format::RGB32Float:
+  case Format::RGBA32Sint:
+  case Format::RGBA32Uint:
+  case Format::RGBA32Float:
+  case Format::D32Float:
+    return false;
+  case Format::D32FloatS8Uint:
+    return true;
+  }
+  llvm_unreachable("All Format cases handled");
+}
+
 // Returns true if the format can be used as a texture pixel format across all
 // backends. Formats like RGB32Float are valid for vertex attributes but have no
 // pixel format equivalent on some APIs (e.g. Metal).

--- a/include/Support/Pipeline.h
+++ b/include/Support/Pipeline.h
@@ -13,6 +13,7 @@
 #ifndef OFFLOADTEST_SUPPORT_PIPELINE_H
 #define OFFLOADTEST_SUPPORT_PIPELINE_H
 
+#include "API/Enums.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/MemoryBuffer.h"
@@ -46,20 +47,6 @@ enum class DataFormat {
   Float64,
   Depth32,
   Bool,
-};
-
-enum class ResourceKind {
-  Buffer,
-  StructuredBuffer,
-  ByteAddressBuffer,
-  Texture2D,
-  RWBuffer,
-  RWStructuredBuffer,
-  RWByteAddressBuffer,
-  RWTexture2D,
-  ConstantBuffer,
-  Sampler,
-  SampledTexture2D,
 };
 
 enum class FilterMode { Nearest, Linear };

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -796,16 +796,16 @@ public:
     std::vector<D3D12_INPUT_ELEMENT_DESC> DXInputLayout;
     DXInputLayout.reserve(InputLayout.size());
     for (const InputLayoutDesc &Elem : InputLayout) {
+      assert(!Elem.InstanceStepRate &&
+             "Instance step rate is currently not supported.");
+
       D3D12_INPUT_ELEMENT_DESC ElementDesc = {};
       ElementDesc.SemanticName = Elem.Name.c_str();
       ElementDesc.SemanticIndex = 0;
       ElementDesc.Format = getDXGIFormat(Elem.Format);
       ElementDesc.InputSlot = 0;
       ElementDesc.AlignedByteOffset = Elem.OffsetInBytes;
-      ElementDesc.InputSlotClass =
-          Elem.InstanceStepRate ? D3D12_INPUT_CLASSIFICATION_PER_INSTANCE_DATA
-                                : D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA;
-      ElementDesc.InstanceDataStepRate = Elem.InstanceStepRate.value_or(0);
+      ElementDesc.InputSlotClass = D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA;
       DXInputLayout.push_back(ElementDesc);
     }
 

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -598,8 +598,7 @@ private:
   struct InvocationState {
     ComPtr<ID3D12DescriptorHeap> DescHeap;
     std::unique_ptr<DXCommandBuffer> CB;
-
-    std::shared_ptr<PipelineState> Pipeline;
+    std::unique_ptr<PipelineState> Pipeline;
 
     // Resources for graphics pipelines.
     std::unique_ptr<offloadtest::Texture> RT;
@@ -753,7 +752,7 @@ public:
                                                OutRootSignature);
   }
 
-  llvm::Expected<std::shared_ptr<PipelineState>>
+  llvm::Expected<std::unique_ptr<PipelineState>>
   createPipelineCs(llvm::StringRef Name, const BindingsDesc &BindingsDesc,
                    ShaderContainer CS) override {
     ComPtr<ID3D12RootSignature> RootSig;
@@ -778,10 +777,10 @@ public:
             "Failed to create PSO."))
       return Err;
 
-    return std::make_shared<DXPipelineState>(Name, RootSig, PSO);
+    return std::make_unique<DXPipelineState>(Name, RootSig, PSO);
   }
 
-  llvm::Expected<std::shared_ptr<PipelineState>>
+  llvm::Expected<std::unique_ptr<PipelineState>>
   createPipelineVsPs(llvm::StringRef Name, const BindingsDesc &BindingsDesc,
                      llvm::ArrayRef<InputLayoutDesc> InputLayout,
                      llvm::ArrayRef<Format> RTFormats,
@@ -839,7 +838,7 @@ public:
             "Failed to create graphics PSO."))
       return Err;
 
-    return std::make_shared<DXPipelineState>(Name, RootSig, PSO);
+    return std::make_unique<DXPipelineState>(Name, RootSig, PSO);
   }
 
   llvm::Expected<std::unique_ptr<offloadtest::Fence>>
@@ -2023,7 +2022,7 @@ public:
           createPipelineCs("Compute Pipeline State", BindingsDesc, CS);
       if (!PipelineStateOrErr)
         return PipelineStateOrErr.takeError();
-      State.Pipeline = *PipelineStateOrErr;
+      State.Pipeline = std::move(*PipelineStateOrErr);
       llvm::outs() << "Compute Pipeline created.\n";
       if (auto Err = createComputeCommands(P, State))
         return Err;
@@ -2083,7 +2082,7 @@ public:
           Format::D32FloatS8Uint, VS, PS);
       if (!PipelineStateOrErr)
         return PipelineStateOrErr.takeError();
-      State.Pipeline = *PipelineStateOrErr;
+      State.Pipeline = std::move(*PipelineStateOrErr);
       llvm::outs() << "Graphics Pipeline created.\n";
       if (auto Err = createGraphicsCommands(P, State))
         return Err;

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -33,6 +33,7 @@
 
 #include "API/Capabilities.h"
 #include "API/Device.h"
+#include "API/FormatConversion.h"
 #include "DXFeatures.h"
 #include "Support/Pipeline.h"
 #include "Support/WinError.h"
@@ -357,6 +358,17 @@ public:
   }
 };
 
+class DXPipelineState : public offloadtest::PipelineState {
+public:
+  std::string Name;
+  ComPtr<ID3D12RootSignature> RootSig;
+  ComPtr<ID3D12PipelineState> PSO;
+
+  DXPipelineState(llvm::StringRef Name, ComPtr<ID3D12RootSignature> RootSig,
+                  ComPtr<ID3D12PipelineState> PSO)
+      : Name(Name), RootSig(RootSig), PSO(PSO) {}
+};
+
 class DXFence : public offloadtest::Fence {
 public:
 #ifdef _WIN32
@@ -584,10 +596,10 @@ private:
   };
 
   struct InvocationState {
-    ComPtr<ID3D12RootSignature> RootSig;
     ComPtr<ID3D12DescriptorHeap> DescHeap;
-    ComPtr<ID3D12PipelineState> PSO;
     std::unique_ptr<DXCommandBuffer> CB;
+
+    std::shared_ptr<PipelineState> Pipeline;
 
     // Resources for graphics pipelines.
     std::unique_ptr<offloadtest::Texture> RT;
@@ -620,6 +632,215 @@ public:
   GPUAPI getAPI() const override { return GPUAPI::DirectX; }
 
   Queue &getGraphicsQueue() override { return GraphicsQueue; }
+
+  llvm::Error
+  createRootSignatureFromShader(llvm::StringRef, const ShaderContainer &Shader,
+                                ComPtr<ID3D12RootSignature> &OutRootSignature) {
+    // Try pulling a root signature from the DXIL first
+    auto ExContainer =
+        llvm::object::DXContainer::create(Shader.Shader->getMemBufferRef());
+    // If this fails we really have a problem...
+    if (!ExContainer)
+      return ExContainer.takeError();
+
+    bool HasRootSigPart = false;
+    for (const auto &Part : *ExContainer)
+      if (memcmp(Part.Part.Name, "RTS0", 4) == 0)
+        HasRootSigPart = true;
+
+    if (HasRootSigPart) {
+      const llvm::StringRef Binary = Shader.Shader->getBuffer();
+      if (auto Err = HR::toError(
+              Device->CreateRootSignature(0, Binary.data(), Binary.size(),
+                                          IID_PPV_ARGS(&OutRootSignature)),
+              "Failed to create root signature."))
+        return Err;
+    }
+
+    return llvm::Error::success();
+  }
+
+  llvm::Error createRootSignatureFromBindingsDesc(
+      llvm::StringRef, const BindingsDesc &BindingsDesc, bool IsGraphics,
+      ComPtr<ID3D12RootSignature> &OutRootSignature) {
+    uint32_t DescriptorCount = 0;
+    for (auto &D : BindingsDesc.DescriptorSetDescs)
+      DescriptorCount += D.ResourceBindings.size();
+
+    std::vector<D3D12_ROOT_PARAMETER> RootParams;
+    const std::unique_ptr<D3D12_DESCRIPTOR_RANGE[]> Ranges =
+        std::unique_ptr<D3D12_DESCRIPTOR_RANGE[]>(
+            new D3D12_DESCRIPTOR_RANGE[DescriptorCount]);
+    uint32_t RangeIdx = 0;
+    for (const auto &D : BindingsDesc.DescriptorSetDescs) {
+      uint32_t DescriptorIdx = 0;
+      const uint32_t StartRangeIdx = RangeIdx;
+      for (const auto &R : D.ResourceBindings) {
+        switch (getDXKind(R.Kind)) {
+        case SRV:
+          Ranges.get()[RangeIdx].RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SRV;
+          break;
+        case UAV:
+          Ranges.get()[RangeIdx].RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_UAV;
+          break;
+        case CBV:
+          Ranges.get()[RangeIdx].RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_CBV;
+          break;
+        case SAMPLER:
+          llvm_unreachable("Not implemented yet."); // Requires a separate heap
+        }
+        Ranges.get()[RangeIdx].NumDescriptors = R.DescriptorCount;
+        Ranges.get()[RangeIdx].BaseShaderRegister = R.DXBinding.Register;
+        Ranges.get()[RangeIdx].RegisterSpace = R.DXBinding.Space;
+        Ranges.get()[RangeIdx].OffsetInDescriptorsFromTableStart =
+            DescriptorIdx;
+        RangeIdx++;
+        DescriptorIdx += R.DescriptorCount;
+      }
+      RootParams.push_back(D3D12_ROOT_PARAMETER{
+          D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE,
+          {D3D12_ROOT_DESCRIPTOR_TABLE{
+              static_cast<uint32_t>(D.ResourceBindings.size()),
+              &Ranges.get()[StartRangeIdx]}},
+          D3D12_SHADER_VISIBILITY_ALL});
+    }
+
+    CD3DX12_ROOT_SIGNATURE_DESC Desc;
+    Desc.Init(static_cast<uint32_t>(RootParams.size()), RootParams.data(), 0,
+              nullptr,
+              IsGraphics
+                  ? D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT
+                  : D3D12_ROOT_SIGNATURE_FLAG_NONE);
+
+    ComPtr<ID3DBlob> Signature;
+    ComPtr<ID3DBlob> Error;
+    if (auto Err = HR::toError(
+            D3D12SerializeRootSignature(&Desc, D3D_ROOT_SIGNATURE_VERSION_1,
+                                        &Signature, &Error),
+            "Failed to seialize root signature.")) {
+      const std::string Msg =
+          std::string(reinterpret_cast<char *>(Error->GetBufferPointer()),
+                      Error->GetBufferSize() / sizeof(char));
+      return joinErrors(
+          std::move(Err),
+          llvm::createStringError(std::errc::protocol_error, Msg.c_str()));
+    }
+
+    if (auto Err = HR::toError(
+            Device->CreateRootSignature(0, Signature->GetBufferPointer(),
+                                        Signature->GetBufferSize(),
+                                        IID_PPV_ARGS(&OutRootSignature)),
+            "Failed to create root signature."))
+      return Err;
+
+    return llvm::Error::success();
+  }
+
+  llvm::Error
+  createRootSignature(llvm::StringRef Name, const BindingsDesc &BindingsDesc,
+                      const ShaderContainer &Shader, bool IsGraphics,
+                      ComPtr<ID3D12RootSignature> &OutRootSignature) {
+    assert(OutRootSignature.Get() == nullptr);
+
+    if (auto Err =
+            createRootSignatureFromShader(Name, Shader, OutRootSignature))
+      return Err;
+
+    if (OutRootSignature.Get() != nullptr)
+      return llvm::Error::success();
+
+    return createRootSignatureFromBindingsDesc(Name, BindingsDesc, IsGraphics,
+                                               OutRootSignature);
+  }
+
+  llvm::Expected<std::shared_ptr<PipelineState>>
+  createPipelineCs(llvm::StringRef Name, const BindingsDesc &BindingsDesc,
+                   ShaderContainer CS) override {
+    ComPtr<ID3D12RootSignature> RootSig;
+    if (auto Err = createRootSignature(Name, BindingsDesc, CS,
+                                       /*IsGraphics=*/false, RootSig))
+      return Err;
+
+    auto DXIL = CS.Shader->getBuffer();
+    const D3D12_COMPUTE_PIPELINE_STATE_DESC Desc = {
+        RootSig.Get(),
+        {DXIL.data(), DXIL.size()},
+        0,
+        {
+            nullptr,
+            0,
+        },
+        D3D12_PIPELINE_STATE_FLAG_NONE};
+
+    ComPtr<ID3D12PipelineState> PSO;
+    if (auto Err = HR::toError(
+            Device->CreateComputePipelineState(&Desc, IID_PPV_ARGS(&PSO)),
+            "Failed to create PSO."))
+      return Err;
+
+    return std::make_shared<DXPipelineState>(Name, RootSig, PSO);
+  }
+
+  llvm::Expected<std::shared_ptr<PipelineState>>
+  createPipelineVsPs(llvm::StringRef Name, const BindingsDesc &BindingsDesc,
+                     llvm::ArrayRef<InputLayoutDesc> InputLayout,
+                     llvm::ArrayRef<Format> RTFormats,
+                     std::optional<Format> DSFormat, ShaderContainer VS,
+                     ShaderContainer PS) override {
+    assert(RTFormats.size() <= 8);
+
+    ComPtr<ID3D12RootSignature> RootSig;
+    if (auto Err = createRootSignature(Name, BindingsDesc, VS,
+                                       /*IsGraphics=*/true, RootSig))
+      return Err;
+
+    std::vector<D3D12_INPUT_ELEMENT_DESC> DXInputLayout;
+    DXInputLayout.reserve(InputLayout.size());
+    for (const InputLayoutDesc &Elem : InputLayout) {
+      D3D12_INPUT_ELEMENT_DESC ElementDesc = {};
+      ElementDesc.SemanticName = Elem.Name.c_str();
+      ElementDesc.SemanticIndex = 0;
+      ElementDesc.Format = getDXGIFormat(Elem.Format);
+      ElementDesc.InputSlot = 0;
+      ElementDesc.AlignedByteOffset = Elem.OffsetInBytes;
+      ElementDesc.InputSlotClass =
+          Elem.InstanceStepRate ? D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA
+                                : D3D12_INPUT_CLASSIFICATION_PER_INSTANCE_DATA;
+      ElementDesc.InstanceDataStepRate = Elem.InstanceStepRate.value_or(0);
+      DXInputLayout.push_back(ElementDesc);
+    }
+
+    D3D12_GRAPHICS_PIPELINE_STATE_DESC PSODesc = {};
+    PSODesc.InputLayout = {DXInputLayout.data(), (UINT)DXInputLayout.size()};
+    PSODesc.pRootSignature = RootSig.Get();
+    PSODesc.VS = {VS.Shader->getBuffer().data(), VS.Shader->getBuffer().size()};
+    PSODesc.PS = {PS.Shader->getBuffer().data(), PS.Shader->getBuffer().size()};
+    if (PSODesc.VS.BytecodeLength == 0 || PSODesc.PS.BytecodeLength == 0)
+      return llvm::createStringError(std::errc::invalid_argument,
+                                     "Graphics pipeline requires both a vertex "
+                                     "shader and a pixel shader.");
+
+    PSODesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
+    PSODesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
+    PSODesc.DepthStencilState.DepthEnable = false;
+    PSODesc.DepthStencilState.StencilEnable = false;
+    PSODesc.SampleMask = UINT_MAX;
+    PSODesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+    PSODesc.NumRenderTargets = static_cast<UINT>(RTFormats.size());
+    if (DSFormat)
+      PSODesc.DSVFormat = getDXGIFormat(*DSFormat);
+    for (size_t I = 0; I < RTFormats.size(); ++I)
+      PSODesc.RTVFormats[I] = getDXGIFormat(RTFormats[I]);
+    PSODesc.SampleDesc.Count = 1;
+
+    ComPtr<ID3D12PipelineState> PSO;
+    if (auto Err = HR::toError(
+            Device->CreateGraphicsPipelineState(&PSODesc, IID_PPV_ARGS(&PSO)),
+            "Failed to create graphics PSO."))
+      return Err;
+
+    return std::make_shared<DXPipelineState>(Name, RootSig, PSO);
+  }
 
   llvm::Expected<std::unique_ptr<offloadtest::Fence>>
   createFence(llvm::StringRef Name) override {
@@ -827,101 +1048,6 @@ public:
     return llvm::Error::success();
   }
 
-  llvm::Error createRootSignature(Pipeline &P, InvocationState &State) {
-    // Try pulling a root signature from the DXIL first
-
-    auto ExContainer = llvm::object::DXContainer::create(
-        P.Shaders[0].Shader->getMemBufferRef());
-    // If this fails we really have a problem...
-    if (!ExContainer)
-      return ExContainer.takeError();
-
-    bool HasRootSigPart = false;
-    for (const auto &Part : *ExContainer)
-      if (memcmp(Part.Part.Name, "RTS0", 4) == 0)
-        HasRootSigPart = true;
-
-    if (HasRootSigPart) {
-      const llvm::StringRef Binary = P.Shaders[0].Shader->getBuffer();
-      if (auto Err = HR::toError(
-              Device->CreateRootSignature(0, Binary.data(), Binary.size(),
-                                          IID_PPV_ARGS(&State.RootSig)),
-              "Failed to create root signature."))
-        return Err;
-      return llvm::Error::success();
-    }
-
-    std::vector<D3D12_ROOT_PARAMETER> RootParams;
-    const uint32_t DescriptorCount = P.getDescriptorCount();
-    const std::unique_ptr<D3D12_DESCRIPTOR_RANGE[]> Ranges =
-        std::unique_ptr<D3D12_DESCRIPTOR_RANGE[]>(
-            new D3D12_DESCRIPTOR_RANGE[DescriptorCount]);
-
-    uint32_t RangeIdx = 0;
-    for (const auto &D : P.Sets) {
-      uint32_t DescriptorIdx = 0;
-      const uint32_t StartRangeIdx = RangeIdx;
-      for (const auto &R : D.Resources) {
-        switch (getDXKind(R.Kind)) {
-        case SRV:
-          Ranges.get()[RangeIdx].RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SRV;
-          break;
-        case UAV:
-          Ranges.get()[RangeIdx].RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_UAV;
-          break;
-        case CBV:
-          Ranges.get()[RangeIdx].RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_CBV;
-          break;
-        case SAMPLER:
-          llvm_unreachable("Not implemented yet.");
-        }
-        Ranges.get()[RangeIdx].NumDescriptors = R.getArraySize();
-        Ranges.get()[RangeIdx].BaseShaderRegister = R.DXBinding.Register;
-        Ranges.get()[RangeIdx].RegisterSpace = R.DXBinding.Space;
-        Ranges.get()[RangeIdx].OffsetInDescriptorsFromTableStart =
-            DescriptorIdx;
-        RangeIdx++;
-        DescriptorIdx += R.getArraySize();
-      }
-      RootParams.push_back(
-          D3D12_ROOT_PARAMETER{D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE,
-                               {D3D12_ROOT_DESCRIPTOR_TABLE{
-                                   static_cast<uint32_t>(D.Resources.size()),
-                                   &Ranges.get()[StartRangeIdx]}},
-                               D3D12_SHADER_VISIBILITY_ALL});
-    }
-
-    CD3DX12_ROOT_SIGNATURE_DESC Desc;
-    Desc.Init(static_cast<uint32_t>(RootParams.size()), RootParams.data(), 0,
-              nullptr,
-              P.isGraphics()
-                  ? D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT
-                  : D3D12_ROOT_SIGNATURE_FLAG_NONE);
-
-    ComPtr<ID3DBlob> Signature;
-    ComPtr<ID3DBlob> Error;
-    if (auto Err = HR::toError(
-            D3D12SerializeRootSignature(&Desc, D3D_ROOT_SIGNATURE_VERSION_1,
-                                        &Signature, &Error),
-            "Failed to seialize root signature.")) {
-      const std::string Msg =
-          std::string(reinterpret_cast<char *>(Error->GetBufferPointer()),
-                      Error->GetBufferSize() / sizeof(char));
-      return joinErrors(
-          std::move(Err),
-          llvm::createStringError(std::errc::protocol_error, Msg.c_str()));
-    }
-
-    if (auto Err = HR::toError(
-            Device->CreateRootSignature(0, Signature->GetBufferPointer(),
-                                        Signature->GetBufferSize(),
-                                        IID_PPV_ARGS(&State.RootSig)),
-            "Failed to create root signature."))
-      return Err;
-
-    return llvm::Error::success();
-  }
-
   llvm::Error createDescriptorHeap(Pipeline &P, InvocationState &State) {
     if (P.getDescriptorCount() == 0)
       return llvm::Error::success();
@@ -932,23 +1058,6 @@ public:
     if (auto Err = HR::toError(Device->CreateDescriptorHeap(
                                    &HeapDesc, IID_PPV_ARGS(&State.DescHeap)),
                                "Failed to create descriptor heap."))
-      return Err;
-    return llvm::Error::success();
-  }
-
-  llvm::Error createComputePSO(llvm::StringRef DXIL, InvocationState &State) {
-    const D3D12_COMPUTE_PIPELINE_STATE_DESC Desc = {
-        State.RootSig.Get(),
-        {DXIL.data(), DXIL.size()},
-        0,
-        {
-            nullptr,
-            0,
-        },
-        D3D12_PIPELINE_STATE_FLAG_NONE};
-    if (auto Err = HR::toError(
-            Device->CreateComputePipelineState(&Desc, IID_PPV_ARGS(&State.PSO)),
-            "Failed to create PSO."))
       return Err;
     return llvm::Error::success();
   }
@@ -1493,8 +1602,10 @@ public:
       IS.CB->CmdList->SetDescriptorHeaps(1, Heaps);
       Handle = IS.DescHeap->GetGPUDescriptorHandleForHeapStart();
     }
-    IS.CB->CmdList->SetComputeRootSignature(IS.RootSig.Get());
-    IS.CB->CmdList->SetPipelineState(IS.PSO.Get());
+    const DXPipelineState *DXPipeline =
+        static_cast<const DXPipelineState *>(IS.Pipeline.get());
+    IS.CB->CmdList->SetComputeRootSignature(DXPipeline->RootSig.Get());
+    IS.CB->CmdList->SetPipelineState(DXPipeline->PSO.Get());
 
     const uint32_t Inc = Device->GetDescriptorHandleIncrementSize(
         D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
@@ -1761,80 +1872,21 @@ public:
     return llvm::Error::success();
   }
 
-  llvm::Error createGraphicsPSO(Pipeline &P, InvocationState &IS) {
-    // Create the input layout based on the vertex attributes.
-    std::vector<D3D12_INPUT_ELEMENT_DESC> InputLayout;
-    for (size_t I = 0; I < P.Bindings.VertexAttributes.size(); ++I) {
-      const VertexAttribute &Attr = P.Bindings.VertexAttributes[I];
-      InputLayout.push_back({Attr.Name.c_str(), 0,
-                             getDXFormat(Attr.Format, Attr.Channels), 0,
-                             static_cast<UINT>(Attr.Offset),
-                             D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0});
-    }
-
-    D3D12_GRAPHICS_PIPELINE_STATE_DESC PSODesc = {};
-    PSODesc.InputLayout = {InputLayout.data(), (UINT)InputLayout.size()};
-    PSODesc.pRootSignature = IS.RootSig.Get();
-
-    for (auto &S : P.Shaders) {
-      switch (S.Stage) {
-      case Stages::Vertex:
-        PSODesc.VS = {S.Shader->getBuffer().data(),
-                      S.Shader->getBuffer().size()};
-        break;
-      case Stages::Pixel:
-        PSODesc.PS = {S.Shader->getBuffer().data(),
-                      S.Shader->getBuffer().size()};
-        break;
-      default:
-        return llvm::createStringError(
-            std::errc::invalid_argument,
-            "Unsupported shader type in graphics pipeline.");
-      }
-    }
-
-    // TODO: Add support for more shader stages and different pipeline shapes.
-    if (PSODesc.VS.BytecodeLength == 0 || PSODesc.PS.BytecodeLength == 0)
-      return llvm::createStringError(std::errc::invalid_argument,
-                                     "Graphics pipeline requires both a vertex "
-                                     "shader and a pixel shader.");
-
-    PSODesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
-    PSODesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
-    PSODesc.DepthStencilState.DepthEnable = true;
-    PSODesc.DepthStencilState.DepthWriteMask = D3D12_DEPTH_WRITE_MASK_ALL;
-    PSODesc.DepthStencilState.DepthFunc = D3D12_COMPARISON_FUNC_LESS;
-    PSODesc.DepthStencilState.StencilEnable = false;
-    auto &DS = llvm::cast<DXTexture>(*IS.DS);
-    PSODesc.DSVFormat = getDXGIFormat(DS.Desc.Fmt);
-    PSODesc.SampleMask = UINT_MAX;
-    PSODesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
-    PSODesc.NumRenderTargets = 1;
-    PSODesc.RTVFormats[0] = getDXFormat(P.Bindings.RTargetBufferPtr->Format,
-                                        P.Bindings.RTargetBufferPtr->Channels);
-    PSODesc.SampleDesc.Count = 1;
-
-    if (auto Err = HR::toError(Device->CreateGraphicsPipelineState(
-                                   &PSODesc, IID_PPV_ARGS(&IS.PSO)),
-                               "Failed to create graphics PSO."))
-      return Err;
-
-    return llvm::Error::success();
-  }
-
   llvm::Error createGraphicsCommands(Pipeline &P, InvocationState &IS) {
     auto &RT = llvm::cast<DXTexture>(*IS.RT);
     auto &DS = llvm::cast<DXTexture>(*IS.DS);
     auto &RTReadback = llvm::cast<DXBuffer>(*IS.RTReadback);
 
-    IS.CB->CmdList->SetGraphicsRootSignature(IS.RootSig.Get());
+    const DXPipelineState *DXPipeline =
+        static_cast<const DXPipelineState *>(IS.Pipeline.get());
+    IS.CB->CmdList->SetGraphicsRootSignature(DXPipeline->RootSig.Get());
     if (IS.DescHeap) {
       ID3D12DescriptorHeap *const Heaps[] = {IS.DescHeap.Get()};
       IS.CB->CmdList->SetDescriptorHeaps(1, Heaps);
       IS.CB->CmdList->SetGraphicsRootDescriptorTable(
           0, IS.DescHeap->GetGPUDescriptorHandleForHeapStart());
     }
-    IS.CB->CmdList->SetPipelineState(IS.PSO.Get());
+    IS.CB->CmdList->SetPipelineState(DXPipeline->PSO.Get());
 
     IS.CB->CmdList->OMSetRenderTargets(1, &RT.RTVHandle, false, &DS.DSVHandle);
 
@@ -1925,9 +1977,6 @@ public:
   llvm::Error executeProgram(Pipeline &P) override {
     InvocationState State;
     llvm::outs() << "Configuring execution on device: " << Description << "\n";
-    if (auto Err = createRootSignature(P, State))
-      return Err;
-    llvm::outs() << "RootSignature created.\n";
     if (auto Err = createDescriptorHeap(P, State))
       return Err;
     llvm::outs() << "Descriptor heap created.\n";
@@ -1942,15 +1991,39 @@ public:
       return Err;
     llvm::outs() << "Buffers created.\n";
 
+    BindingsDesc BindingsDesc = {};
+    for (auto &S : P.Sets) {
+      DescriptorSetLayoutDesc Layout;
+      for (auto &R : S.Resources) {
+        ResourceBindingDesc ResourceBinding = {};
+        ResourceBinding.Kind = R.Kind;
+        ResourceBinding.DXBinding.Register = R.DXBinding.Register;
+        ResourceBinding.DXBinding.Space = R.DXBinding.Space;
+        ResourceBinding.DescriptorCount = R.getArraySize();
+
+        Layout.ResourceBindings.push_back(ResourceBinding);
+      }
+
+      BindingsDesc.DescriptorSetDescs.push_back(Layout);
+    }
+
     if (P.isCompute()) {
       // This is an arbitrary distinction that we could alter in the future.
       if (P.Shaders.size() != 1 || P.Shaders[0].Stage != Stages::Compute)
         return llvm::createStringError(
             std::errc::invalid_argument,
             "Compute pipeline must have exactly one compute shader.");
-      if (auto Err = createComputePSO(P.Shaders[0].Shader->getBuffer(), State))
-        return Err;
-      llvm::outs() << "PSO created.\n";
+
+      ShaderContainer CS = {};
+      CS.EntryPoint = P.Shaders[0].Entry;
+      CS.Shader = P.Shaders[0].Shader.get();
+
+      auto PipelineStateOrErr =
+          createPipelineCs("Compute Pipeline State", BindingsDesc, CS);
+      if (!PipelineStateOrErr)
+        return PipelineStateOrErr.takeError();
+      State.Pipeline = *PipelineStateOrErr;
+      llvm::outs() << "Compute Pipeline created.\n";
       if (auto Err = createComputeCommands(P, State))
         return Err;
       llvm::outs() << "Compute command list created.\n";
@@ -1969,9 +2042,48 @@ public:
       if (auto Err = createVertexBuffer(P, State))
         return Err;
       llvm::outs() << "Vertex buffer created.\n";
-      if (auto Err = createGraphicsPSO(P, State))
-        return Err;
-      llvm::outs() << "Graphics PSO created.\n";
+
+      ShaderContainer VS = {};
+      ShaderContainer PS = {};
+      for (auto &Shader : P.Shaders) {
+        if (Shader.Stage == Stages::Vertex) {
+          VS.EntryPoint = Shader.Entry;
+          VS.Shader = Shader.Shader.get();
+        } else if (Shader.Stage == Stages::Pixel) {
+          PS.EntryPoint = Shader.Entry;
+          PS.Shader = Shader.Shader.get();
+        }
+      }
+
+      // Create the input layout based on the vertex attributes.
+      llvm::SmallVector<InputLayoutDesc> InputLayout;
+      for (auto &Attr : P.Bindings.VertexAttributes) {
+        auto FormatOrErr = toFormat(Attr.Format, Attr.Channels);
+        if (!FormatOrErr)
+          return FormatOrErr.takeError();
+
+        InputLayoutDesc Desc = {};
+        Desc.Name = Attr.Name;
+        Desc.Format = *FormatOrErr;
+        Desc.OffsetInBytes = Attr.Offset;
+        InputLayout.push_back(Desc);
+      }
+
+      auto FormatOrErr = toFormat(P.Bindings.RTargetBufferPtr->Format,
+                                  P.Bindings.RTargetBufferPtr->Channels);
+      if (!FormatOrErr)
+        return FormatOrErr.takeError();
+
+      llvm::SmallVector<Format> RTFormats;
+      RTFormats.push_back(*FormatOrErr);
+
+      auto PipelineStateOrErr = createPipelineVsPs(
+          "Graphics Pipeline State", BindingsDesc, InputLayout, RTFormats,
+          Format::D32FloatS8Uint, VS, PS);
+      if (!PipelineStateOrErr)
+        return PipelineStateOrErr.takeError();
+      State.Pipeline = *PipelineStateOrErr;
+      llvm::outs() << "Graphics Pipeline created.\n";
       if (auto Err = createGraphicsCommands(P, State))
         return Err;
       llvm::outs() << "Graphics command list created complete.\n";

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -1999,6 +1999,7 @@ public:
         ResourceBinding.Kind = R.Kind;
         ResourceBinding.DXBinding.Register = R.DXBinding.Register;
         ResourceBinding.DXBinding.Space = R.DXBinding.Space;
+        ResourceBinding.VKBinding = R.VKBinding;
         ResourceBinding.DescriptorCount = R.getArraySize();
 
         Layout.ResourceBindings.push_back(ResourceBinding);

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -821,7 +821,9 @@ public:
 
     PSODesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
     PSODesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
-    PSODesc.DepthStencilState.DepthEnable = false;
+    PSODesc.DepthStencilState.DepthEnable = true;
+    PSODesc.DepthStencilState.DepthWriteMask = D3D12_DEPTH_WRITE_MASK_ALL;
+    PSODesc.DepthStencilState.DepthFunc = D3D12_COMPARISON_FUNC_LESS;
     PSODesc.DepthStencilState.StencilEnable = false;
     PSODesc.SampleMask = UINT_MAX;
     PSODesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -366,7 +366,12 @@ public:
 
   DXPipelineState(llvm::StringRef Name, ComPtr<ID3D12RootSignature> RootSig,
                   ComPtr<ID3D12PipelineState> PSO)
-      : Name(Name), RootSig(RootSig), PSO(PSO) {}
+      : offloadtest::PipelineState(GPUAPI::DirectX), Name(Name),
+        RootSig(RootSig), PSO(PSO) {}
+
+  static bool classof(const offloadtest::PipelineState *B) {
+    return B->getAPI() == GPUAPI::DirectX;
+  }
 };
 
 class DXFence : public offloadtest::Fence {

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -672,15 +672,14 @@ public:
       DescriptorCount += D.ResourceBindings.size();
 
     std::vector<D3D12_ROOT_PARAMETER> RootParams;
-    const std::unique_ptr<D3D12_DESCRIPTOR_RANGE[]> Ranges =
-        std::unique_ptr<D3D12_DESCRIPTOR_RANGE[]>(
-            new D3D12_DESCRIPTOR_RANGE[DescriptorCount]);
+    const std::unique_ptr<D3D12_DESCRIPTOR_RANGE[]> Ranges(
+        new D3D12_DESCRIPTOR_RANGE[DescriptorCount]);
     uint32_t RangeIdx = 0;
-    for (const auto &D : BindingsDesc.DescriptorSetDescs) {
+    for (const auto &Set : BindingsDesc.DescriptorSetDescs) {
       uint32_t DescriptorIdx = 0;
       const uint32_t StartRangeIdx = RangeIdx;
-      for (const auto &R : D.ResourceBindings) {
-        switch (getDXKind(R.Kind)) {
+      for (const auto &Binding : Set.ResourceBindings) {
+        switch (getDXKind(Binding.Kind)) {
         case SRV:
           Ranges.get()[RangeIdx].RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SRV;
           break;
@@ -693,18 +692,18 @@ public:
         case SAMPLER:
           llvm_unreachable("Not implemented yet."); // Requires a separate heap
         }
-        Ranges.get()[RangeIdx].NumDescriptors = R.DescriptorCount;
-        Ranges.get()[RangeIdx].BaseShaderRegister = R.DXBinding.Register;
-        Ranges.get()[RangeIdx].RegisterSpace = R.DXBinding.Space;
+        Ranges.get()[RangeIdx].NumDescriptors = Binding.DescriptorCount;
+        Ranges.get()[RangeIdx].BaseShaderRegister = Binding.DXBinding.Register;
+        Ranges.get()[RangeIdx].RegisterSpace = Binding.DXBinding.Space;
         Ranges.get()[RangeIdx].OffsetInDescriptorsFromTableStart =
             DescriptorIdx;
         RangeIdx++;
-        DescriptorIdx += R.DescriptorCount;
+        DescriptorIdx += Binding.DescriptorCount;
       }
       RootParams.push_back(D3D12_ROOT_PARAMETER{
           D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE,
           {D3D12_ROOT_DESCRIPTOR_TABLE{
-              static_cast<uint32_t>(D.ResourceBindings.size()),
+              static_cast<uint32_t>(Set.ResourceBindings.size()),
               &Ranges.get()[StartRangeIdx]}},
           D3D12_SHADER_VISIBILITY_ALL});
     }
@@ -1608,10 +1607,10 @@ public:
       IS.CB->CmdList->SetDescriptorHeaps(1, Heaps);
       Handle = IS.DescHeap->GetGPUDescriptorHandleForHeapStart();
     }
-    const DXPipelineState *DXPipeline =
-        static_cast<const DXPipelineState *>(IS.Pipeline.get());
-    IS.CB->CmdList->SetComputeRootSignature(DXPipeline->RootSig.Get());
-    IS.CB->CmdList->SetPipelineState(DXPipeline->PSO.Get());
+    const DXPipelineState &DXPipeline =
+        llvm::cast<DXPipelineState>(*IS.Pipeline.get());
+    IS.CB->CmdList->SetComputeRootSignature(DXPipeline.RootSig.Get());
+    IS.CB->CmdList->SetPipelineState(DXPipeline.PSO.Get());
 
     const uint32_t Inc = Device->GetDescriptorHandleIncrementSize(
         D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
@@ -1883,16 +1882,16 @@ public:
     auto &DS = llvm::cast<DXTexture>(*IS.DS);
     auto &RTReadback = llvm::cast<DXBuffer>(*IS.RTReadback);
 
-    const DXPipelineState *DXPipeline =
-        static_cast<const DXPipelineState *>(IS.Pipeline.get());
-    IS.CB->CmdList->SetGraphicsRootSignature(DXPipeline->RootSig.Get());
+    const DXPipelineState &DXPipeline =
+        llvm::cast<DXPipelineState>(*IS.Pipeline.get());
+    IS.CB->CmdList->SetGraphicsRootSignature(DXPipeline.RootSig.Get());
     if (IS.DescHeap) {
       ID3D12DescriptorHeap *const Heaps[] = {IS.DescHeap.Get()};
       IS.CB->CmdList->SetDescriptorHeaps(1, Heaps);
       IS.CB->CmdList->SetGraphicsRootDescriptorTable(
           0, IS.DescHeap->GetGPUDescriptorHandleForHeapStart());
     }
-    IS.CB->CmdList->SetPipelineState(DXPipeline->PSO.Get());
+    IS.CB->CmdList->SetPipelineState(DXPipeline.PSO.Get());
 
     IS.CB->CmdList->OMSetRenderTargets(1, &RT.RTVHandle, false, &DS.DSVHandle);
 

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -802,7 +802,7 @@ public:
       D3D12_INPUT_ELEMENT_DESC ElementDesc = {};
       ElementDesc.SemanticName = Elem.Name.c_str();
       ElementDesc.SemanticIndex = 0;
-      ElementDesc.Format = getDXGIFormat(Elem.Format);
+      ElementDesc.Format = getDXGIFormat(Elem.Fmt);
       ElementDesc.InputSlot = 0;
       ElementDesc.AlignedByteOffset = Elem.OffsetInBytes;
       ElementDesc.InputSlotClass = D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA;
@@ -2066,7 +2066,7 @@ public:
 
         InputLayoutDesc Desc = {};
         Desc.Name = Attr.Name;
-        Desc.Format = *FormatOrErr;
+        Desc.Fmt = *FormatOrErr;
         Desc.OffsetInBytes = Attr.Offset;
         InputLayout.push_back(Desc);
       }

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -804,8 +804,8 @@ public:
       ElementDesc.InputSlot = 0;
       ElementDesc.AlignedByteOffset = Elem.OffsetInBytes;
       ElementDesc.InputSlotClass =
-          Elem.InstanceStepRate ? D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA
-                                : D3D12_INPUT_CLASSIFICATION_PER_INSTANCE_DATA;
+          Elem.InstanceStepRate ? D3D12_INPUT_CLASSIFICATION_PER_INSTANCE_DATA
+                                : D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA;
       ElementDesc.InstanceDataStepRate = Elem.InstanceStepRate.value_or(0);
       DXInputLayout.push_back(ElementDesc);
     }

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -257,7 +257,7 @@ class MTLDevice : public offloadtest::Device {
     std::unique_ptr<offloadtest::Buffer> FrameBufferReadback;
     std::unique_ptr<offloadtest::Texture> DepthStencil;
     std::unique_ptr<MTLCommandBuffer> CB;
-    std::shared_ptr<PipelineState> Pipeline;
+    std::unique_ptr<PipelineState> Pipeline;
   };
 
   llvm::Error createDescriptor(Resource &R, InvocationState &IS,
@@ -662,7 +662,7 @@ public:
     return MTLCommandBuffer::create(GraphicsQueue.Queue);
   }
 
-  llvm::Expected<std::shared_ptr<PipelineState>>
+  llvm::Expected<std::unique_ptr<PipelineState>>
   createPipelineCs(llvm::StringRef Name,
                    const BindingsDesc & /*unused on metal*/,
                    ShaderContainer CS) override {
@@ -693,10 +693,10 @@ public:
     if (Error)
       return toError(Error);
 
-    return std::make_shared<MTLPipelineState>(Name, PSO);
+    return std::make_unique<MTLPipelineState>(Name, PSO);
   }
 
-  llvm::Expected<std::shared_ptr<PipelineState>> createPipelineVsPs(
+  llvm::Expected<std::unique_ptr<PipelineState>> createPipelineVsPs(
       llvm::StringRef Name, const BindingsDesc & /*unused on metal*/,
       llvm::ArrayRef<InputLayoutDesc> InputLayout,
       llvm::ArrayRef<Format> RTFormats, std::optional<Format> DSFormat,
@@ -805,7 +805,7 @@ public:
     if (Error)
       return toError(Error);
 
-    return std::make_shared<MTLPipelineState>(Name, PSO);
+    return std::make_unique<MTLPipelineState>(Name, PSO);
   }
 
   llvm::Error executeProgram(Pipeline &P) override {
@@ -848,7 +848,7 @@ public:
           createPipelineCs("Compute Pipeline State", Bindings, CS);
       if (!PipelineStateOrErr)
         return PipelineStateOrErr.takeError();
-      IS.Pipeline = *PipelineStateOrErr;
+      IS.Pipeline = std::move(*PipelineStateOrErr);
       llvm::outs() << "Compute Pipeline created.\n";
 
       if (auto Err = createComputeCommands(P, IS))
@@ -891,7 +891,7 @@ public:
           "Graphics Pipeline State", Bindings, InputLayout, RTFormats, VS, PS);
       if (!PipelineStateOrErr)
         return PipelineStateOrErr.takeError();
-      IS.Pipeline = *PipelineStateOrErr;
+      IS.Pipeline = std::move(*PipelineStateOrErr);
 
       if (auto Err = createGraphicsCommands(P, IS))
         return Err;

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -755,17 +755,54 @@ public:
 
     // Build vertex descriptor from InputLayout.
     if (!InputLayout.empty()) {
+      NS::Array *FnAttrs = VSFn->vertexAttributes();
+      // I'm not really sure if there's any valid case for a vertex shader with
+      // no vertex attributes, so we just error if that ever occurs.
+      // NOTE(manon): There is a very valid use case, loading vertices from a
+      // raw buffer using just the index acquried from the index buffer. A lot
+      // of modern hardware have the driver just turns this input layout vertex
+      // loading into shader code anyway.
+      if (!FnAttrs)
+        return llvm::createStringError(
+            std::errc::invalid_argument,
+            "Vertex shader has no vertex attributes.");
+
+      if (FnAttrs->count() != InputLayout.size())
+        return llvm::createStringError(
+            std::errc::invalid_argument,
+            "Mismatch between vertex shader attribute count and pipeline "
+            "vertex input count.");
+
+      // Collect the attribute indices the shader expects so that we can map the
+      // specified attributes onto the correct indices.
+      llvm::StringMap<uint32_t> ShaderAttrIndices;
+      for (uint32_t Ai = 0; Ai < FnAttrs->count(); ++Ai) {
+        auto *A = static_cast<MTL::VertexAttribute *>(FnAttrs->object(Ai));
+        if (A && A->isActive()) {
+          ShaderAttrIndices.insert(std::make_pair(
+              llvm::StringRef(A->name()->utf8String()), A->attributeIndex()));
+          llvm::errs() << "Shader attr: " << A->name()->utf8String()
+                       << " at index " << A->attributeIndex() << "\n";
+        }
+      }
+
       MTL::VertexDescriptor *VtxDesc = MTL::VertexDescriptor::alloc()->init();
       uint32_t Stride = 0;
       for (uint32_t I = 0; I < static_cast<uint32_t>(InputLayout.size()); ++I) {
         const InputLayoutDesc &Elem = InputLayout[I];
+        llvm::SmallString<32> AttrName(Elem.Name);
+        llvm::transform(AttrName, AttrName.begin(), tolower);
+        // Append a zero since we're only supporting one attribute per name.
+        // We'll need to revisit this if we ever support indexed attributes.
+        AttrName += "0";
+
         const uint32_t ElemSize = getFormatSizeInBytes(Elem.Format);
         MTL::VertexAttributeDescriptor *AttrDesc =
             MTL::VertexAttributeDescriptor::alloc()->init();
         AttrDesc->setBufferIndex(0);
         AttrDesc->setOffset(Elem.OffsetInBytes);
         AttrDesc->setFormat(getMetalVertexFormat(Elem.Format));
-        VtxDesc->attributes()->setObject(AttrDesc, I);
+        VtxDesc->attributes()->setObject(AttrDesc, ShaderAttrIndices[AttrName]);
         AttrDesc->release();
         Stride = std::max(Stride, Elem.OffsetInBytes + ElemSize);
       }

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -130,7 +130,7 @@ public:
 
   MTLPipelineState(llvm::StringRef Name,
                    MTL::RenderPipelineState *RenderPipeline)
-      : offloadtest::PipelineState(GPUAPI::Vulkan), Name(Name),
+      : offloadtest::PipelineState(GPUAPI::Metal), Name(Name),
         RenderPipeline(RenderPipeline) {}
 
   ~MTLPipelineState() override {

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -226,7 +226,7 @@ llvm::Expected<offloadtest::SubmitResult> MTLQueue::submit(
   const uint64_t SignalValue = ++FenceCounter;
 
   for (size_t I = 0; I < CBs.size(); ++I) {
-    auto &MCB = *llvm::cast<MTLCommandBuffer>(CBs[I].get());
+    auto &MCB = llvm::cast<MTLCommandBuffer>(*CBs[I].get());
     // Signal the submit fence when the last command buffer completes.
     if (I == CBs.size() - 1)
       MCB.CmdBuffer->encodeSignalEvent(SubmitFence->Event, SignalValue);

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -791,7 +791,7 @@ public:
     if (DSFormat) {
       const MTL::PixelFormat DSPixelFormat = getMetalPixelFormat(*DSFormat);
       Desc->setDepthAttachmentPixelFormat(DSPixelFormat);
-      if (*DSFormat == Format::D32FloatS8Uint)
+      if (isStencilFormat(*DSFormat))
         Desc->setStencilAttachmentPixelFormat(DSPixelFormat);
     }
 

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -364,7 +364,7 @@ class MTLDevice : public offloadtest::Device {
     auto CloseCommandEncoder =
         llvm::scope_exit([&]() { CmdEncoder->endEncoding(); });
 
-    auto *PS = static_cast<MTLPipelineState *>(IS.Pipeline.get());
+    const auto &PS = llvm::cast<MTLPipelineState>(IS.Pipeline.get());
     CmdEncoder->setComputePipelineState(PS->ComputePipeline);
     CmdEncoder->setBuffer(IS.ArgBuffer, 0, 2);
     for (uint64_t I = 0; I < IS.Textures.size(); ++I)
@@ -517,7 +517,7 @@ class MTLDevice : public offloadtest::Device {
     MTL::RenderCommandEncoder *CmdEncoder =
         IS.CB->CmdBuffer->renderCommandEncoder(Desc);
 
-    auto *PS = static_cast<MTLPipelineState *>(IS.Pipeline.get());
+    const auto &PS = llvm::cast<MTLPipelineState>(IS.Pipeline.get());
     CmdEncoder->setRenderPipelineState(PS->RenderPipeline);
 
     // Configure depth stencil state: depth test enabled, write all, less.
@@ -681,21 +681,19 @@ public:
     MTL::Library *Lib = Device->newLibrary(Data, &Error);
     if (Error)
       return toError(Error);
+    llvm::scope_exit([&] { Lib->release(); });
 
     MTL::Function *Fn = Lib->newFunction(
         NS::String::string(CS.EntryPoint.c_str(), NS::UTF8StringEncoding));
-    if (!Fn) {
-      Lib->release();
+    if (!Fn)
       return llvm::createStringError(
           std::errc::invalid_argument,
           "Failed to find entry point '%s' in Metal library.",
           CS.EntryPoint.c_str());
-    }
+    llvm::scope_exit([&] { Fn->release(); });
 
     MTL::ComputePipelineState *PSO =
         Device->newComputePipelineState(Fn, &Error);
-    Fn->release();
-    Lib->release();
     if (Error)
       return toError(Error);
 
@@ -718,16 +716,16 @@ public:
     MTL::Library *VSLib = Device->newLibrary(VSData, &Error);
     if (Error)
       return toError(Error);
+    llvm::scope_exit([&] { VSLib->release(); });
 
     MTL::Function *VSFn = VSLib->newFunction(
         NS::String::string(VS.EntryPoint.c_str(), NS::UTF8StringEncoding));
-    if (!VSFn) {
-      VSLib->release();
+    if (!VSFn)
       return llvm::createStringError(
           std::errc::invalid_argument,
           "Failed to find vertex entry point '%s' in Metal library.",
           VS.EntryPoint.c_str());
-    }
+    llvm::scope_exit([&] { VSFn->release(); });
 
     // Load pixel/fragment shader.
     const llvm::StringRef PSProgram = PS.Shader->getBuffer();
@@ -736,38 +734,31 @@ public:
         ^{
         });
     MTL::Library *PSLib = Device->newLibrary(PSData, &Error);
-    if (Error) {
-      VSFn->release();
-      VSLib->release();
+    if (Error)
       return toError(Error);
-    }
+    llvm::scope_exit([&] { PSLib->release(); });
 
     MTL::Function *PSFn = PSLib->newFunction(
         NS::String::string(PS.EntryPoint.c_str(), NS::UTF8StringEncoding));
-    if (!PSFn) {
-      VSFn->release();
-      VSLib->release();
-      PSLib->release();
+    if (!PSFn)
       return llvm::createStringError(
           std::errc::invalid_argument,
           "Failed to find fragment entry point '%s' in Metal library.",
           PS.EntryPoint.c_str());
-    }
+    llvm::scope_exit([&] { PSFn->release(); });
 
     MTL::RenderPipelineDescriptor *Desc =
         MTL::RenderPipelineDescriptor::alloc()->init();
+    llvm::scope_exit([&] { Desc->release(); });
     Desc->setVertexFunction(VSFn);
     Desc->setFragmentFunction(PSFn);
 
     // Build vertex descriptor from InputLayout.
     if (!InputLayout.empty()) {
       NS::Array *FnAttrs = VSFn->vertexAttributes();
-      // I'm not really sure if there's any valid case for a vertex shader with
-      // no vertex attributes, so we just error if that ever occurs.
-      // NOTE(manon): There is a very valid use case, loading vertices from a
-      // raw buffer using just the index acquried from the index buffer. A lot
-      // of modern hardware have the driver just turns this input layout vertex
-      // loading into shader code anyway.
+      // Currently we error on vertex shaders without any vertex attributes.
+      // However, this is a valid use case that should be supported in the
+      // future.
       if (!FnAttrs)
         return llvm::createStringError(
             std::errc::invalid_argument,
@@ -782,8 +773,8 @@ public:
       // Collect the attribute indices the shader expects so that we can map the
       // specified attributes onto the correct indices.
       llvm::StringMap<uint32_t> ShaderAttrIndices;
-      for (uint32_t Ai = 0; Ai < FnAttrs->count(); ++Ai) {
-        auto *A = static_cast<MTL::VertexAttribute *>(FnAttrs->object(Ai));
+      for (uint32_t I = 0; I < FnAttrs->count(); ++I) {
+        auto *A = static_cast<MTL::VertexAttribute *>(FnAttrs->object(I));
         if (A && A->isActive()) {
           ShaderAttrIndices.insert(std::make_pair(
               llvm::StringRef(A->name()->utf8String()), A->attributeIndex()));
@@ -793,6 +784,7 @@ public:
       }
 
       MTL::VertexDescriptor *VtxDesc = MTL::VertexDescriptor::alloc()->init();
+      llvm::scope_exit([&] { VtxDesc->release(); });
       uint32_t Stride = 0;
       for (uint32_t I = 0; I < static_cast<uint32_t>(InputLayout.size()); ++I) {
         const InputLayoutDesc &Elem = InputLayout[I];
@@ -847,11 +839,6 @@ public:
 
     MTL::RenderPipelineState *PSO =
         Device->newRenderPipelineState(Desc, &Error);
-    VSFn->release();
-    VSLib->release();
-    PSFn->release();
-    PSLib->release();
-    Desc->release();
     if (Error)
       return toError(Error);
 

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -887,8 +887,9 @@ public:
       llvm::SmallVector<Format> RTFormats;
       RTFormats.push_back(*FormatOrErr);
 
-      auto PipelineStateOrErr = createPipelineVsPs(
-          "Graphics Pipeline State", Bindings, InputLayout, RTFormats, VS, PS);
+      auto PipelineStateOrErr =
+          createPipelineVsPs("Graphics Pipeline State", Bindings, InputLayout,
+                             RTFormats, Format::D32FloatS8Uint, VS, PS);
       if (!PipelineStateOrErr)
         return PipelineStateOrErr.takeError();
       IS.Pipeline = std::move(*PipelineStateOrErr);

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -790,6 +790,9 @@ public:
       uint32_t Stride = 0;
       for (uint32_t I = 0; I < static_cast<uint32_t>(InputLayout.size()); ++I) {
         const InputLayoutDesc &Elem = InputLayout[I];
+        assert(!Elem.InstanceStepRate &&
+               "Instance step rate is currently not supported.");
+
         llvm::SmallString<32> AttrName(Elem.Name);
         llvm::transform(AttrName, AttrName.begin(), tolower);
         // Append a zero since we're only supporting one attribute per name.

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -125,17 +125,23 @@ public:
 
   MTLPipelineState(llvm::StringRef Name,
                    MTL::ComputePipelineState *ComputePipeline)
-      : Name(Name), ComputePipeline(ComputePipeline) {}
+      : offloadtest::PipelineState(GPUAPI::Metal), Name(Name),
+        ComputePipeline(ComputePipeline) {}
 
   MTLPipelineState(llvm::StringRef Name,
                    MTL::RenderPipelineState *RenderPipeline)
-      : Name(Name), RenderPipeline(RenderPipeline) {}
+      : offloadtest::PipelineState(GPUAPI::Vulkan), Name(Name),
+        RenderPipeline(RenderPipeline) {}
 
   ~MTLPipelineState() override {
     if (ComputePipeline)
       ComputePipeline->release();
     if (RenderPipeline)
       RenderPipeline->release();
+  }
+
+  static bool classof(const offloadtest::PipelineState *B) {
+    return B->getAPI() == GPUAPI::Metal;
   }
 };
 

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -681,7 +681,7 @@ public:
     MTL::Library *Lib = Device->newLibrary(Data, &Error);
     if (Error)
       return toError(Error);
-    llvm::scope_exit([&] { Lib->release(); });
+    auto LibScope = llvm::scope_exit([&] { Lib->release(); });
 
     MTL::Function *Fn = Lib->newFunction(
         NS::String::string(CS.EntryPoint.c_str(), NS::UTF8StringEncoding));
@@ -690,7 +690,7 @@ public:
           std::errc::invalid_argument,
           "Failed to find entry point '%s' in Metal library.",
           CS.EntryPoint.c_str());
-    llvm::scope_exit([&] { Fn->release(); });
+    auto FnScope = llvm::scope_exit([&] { Fn->release(); });
 
     MTL::ComputePipelineState *PSO =
         Device->newComputePipelineState(Fn, &Error);
@@ -716,7 +716,7 @@ public:
     MTL::Library *VSLib = Device->newLibrary(VSData, &Error);
     if (Error)
       return toError(Error);
-    llvm::scope_exit([&] { VSLib->release(); });
+    auto VSLibScope = llvm::scope_exit([&] { VSLib->release(); });
 
     MTL::Function *VSFn = VSLib->newFunction(
         NS::String::string(VS.EntryPoint.c_str(), NS::UTF8StringEncoding));
@@ -725,7 +725,7 @@ public:
           std::errc::invalid_argument,
           "Failed to find vertex entry point '%s' in Metal library.",
           VS.EntryPoint.c_str());
-    llvm::scope_exit([&] { VSFn->release(); });
+    auto VSFnScope = llvm::scope_exit([&] { VSFn->release(); });
 
     // Load pixel/fragment shader.
     const llvm::StringRef PSProgram = PS.Shader->getBuffer();
@@ -736,7 +736,7 @@ public:
     MTL::Library *PSLib = Device->newLibrary(PSData, &Error);
     if (Error)
       return toError(Error);
-    llvm::scope_exit([&] { PSLib->release(); });
+    auto PSLibScope = llvm::scope_exit([&] { PSLib->release(); });
 
     MTL::Function *PSFn = PSLib->newFunction(
         NS::String::string(PS.EntryPoint.c_str(), NS::UTF8StringEncoding));
@@ -745,11 +745,11 @@ public:
           std::errc::invalid_argument,
           "Failed to find fragment entry point '%s' in Metal library.",
           PS.EntryPoint.c_str());
-    llvm::scope_exit([&] { PSFn->release(); });
+    auto PSFnScope = llvm::scope_exit([&] { PSFn->release(); });
 
     MTL::RenderPipelineDescriptor *Desc =
         MTL::RenderPipelineDescriptor::alloc()->init();
-    llvm::scope_exit([&] { Desc->release(); });
+    auto DescScope = llvm::scope_exit([&] { Desc->release(); });
     Desc->setVertexFunction(VSFn);
     Desc->setFragmentFunction(PSFn);
 
@@ -784,7 +784,7 @@ public:
       }
 
       MTL::VertexDescriptor *VtxDesc = MTL::VertexDescriptor::alloc()->init();
-      llvm::scope_exit([&] { VtxDesc->release(); });
+      auto VtxDescScope = llvm::scope_exit([&] { VtxDesc->release(); });
       uint32_t Stride = 0;
       for (uint32_t I = 0; I < static_cast<uint32_t>(InputLayout.size()); ++I) {
         const InputLayoutDesc &Elem = InputLayout[I];
@@ -817,7 +817,6 @@ public:
       LDesc->release();
 
       Desc->setVertexDescriptor(VtxDesc);
-      VtxDesc->release();
     }
 
     // Configure render target color attachments.

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -10,6 +10,7 @@
 #include "metal_irconverter_runtime.h"
 
 #include "API/Device.h"
+#include "API/FormatConversion.h"
 #include "MTLResources.h"
 #include "Support/Pipeline.h"
 
@@ -52,26 +53,6 @@ static MTL::PixelFormat getMTLFormat(DataFormat Format, int Channels) {
     llvm_unreachable("Unsupported Resource format specified");
   }
   return MTL::PixelFormatInvalid;
-}
-
-#define MTLVTXFormats(Base)                                                    \
-  if (Channels == 1)                                                           \
-    return MTL::VertexFormat##Base;                                            \
-  if (Channels == 2)                                                           \
-    return MTL::VertexFormat##Base##2;                                         \
-  if (Channels == 3)                                                           \
-    return MTL::VertexFormat##Base##3;                                         \
-  if (Channels == 4)                                                           \
-    return MTL::VertexFormat##Base##4;
-
-static MTL::VertexFormat getMTLVertexFormat(DataFormat Format, int Channels) {
-  switch (Format) {
-  case DataFormat::Float32:
-    MTLVTXFormats(Float) break;
-  default:
-    llvm_unreachable("Unsupported Resource format specified");
-  }
-  return MTL::VertexFormatInvalid;
 }
 
 namespace {
@@ -134,6 +115,28 @@ public:
   llvm::Expected<offloadtest::SubmitResult>
   submit(llvm::SmallVector<std::unique_ptr<offloadtest::CommandBuffer>> CBs)
       override;
+};
+
+class MTLPipelineState : public offloadtest::PipelineState {
+public:
+  std::string Name;
+  MTL::ComputePipelineState *ComputePipeline = nullptr;
+  MTL::RenderPipelineState *RenderPipeline = nullptr;
+
+  MTLPipelineState(llvm::StringRef Name,
+                   MTL::ComputePipelineState *ComputePipeline)
+      : Name(Name), ComputePipeline(ComputePipeline) {}
+
+  MTLPipelineState(llvm::StringRef Name,
+                   MTL::RenderPipelineState *RenderPipeline)
+      : Name(Name), RenderPipeline(RenderPipeline) {}
+
+  ~MTLPipelineState() override {
+    if (ComputePipeline)
+      ComputePipeline->release();
+    if (RenderPipeline)
+      RenderPipeline->release();
+  }
 };
 
 class MTLBuffer : public offloadtest::Buffer {
@@ -241,177 +244,21 @@ class MTLDevice : public offloadtest::Device {
         T->release();
       for (MTL::Buffer *B : Buffers)
         B->release();
-      if (ComputePipeline)
-        ComputePipeline->release();
-      if (RenderPipeline)
-        RenderPipeline->release();
 
       Pool->release();
     }
 
     NS::AutoreleasePool *Pool = nullptr;
-    MTL::ComputePipelineState *ComputePipeline = nullptr;
-    MTL::RenderPipelineState *RenderPipeline = nullptr;
     MTL::Buffer *ArgBuffer;
     MTL::Buffer *VertexBuffer;
-    MTL::VertexDescriptor *VertexDescriptor;
     llvm::SmallVector<MTL::Texture *> Textures;
     llvm::SmallVector<MTL::Buffer *> Buffers;
     std::unique_ptr<offloadtest::Texture> FrameBufferTexture;
     std::unique_ptr<offloadtest::Buffer> FrameBufferReadback;
     std::unique_ptr<offloadtest::Texture> DepthStencil;
     std::unique_ptr<MTLCommandBuffer> CB;
+    std::shared_ptr<PipelineState> Pipeline;
   };
-
-  llvm::Error setupVertexShader(InvocationState &IS, const Pipeline &P,
-                                MTL::Function *Fn) {
-    if (P.Bindings.VertexBufferPtr) {
-      NS::Array *FnAttrs = Fn->vertexAttributes();
-      // I'm not really sure if there's any valid case for a vertex shader with
-      // no vertex attributes, so we just error if that ever occurs.
-      if (!FnAttrs)
-        return llvm::createStringError(
-            std::errc::invalid_argument,
-            "Vertex shader has no vertex attributes.");
-      if (FnAttrs->count() != P.Bindings.VertexAttributes.size())
-        return llvm::createStringError(
-            std::errc::invalid_argument,
-            "Mismatch between vertex shader attribute count and pipeline "
-            "vertex input count.");
-      // Collect the attribute indices the shader expects so that we can map the
-      // specified attributes onto the correct indices.
-      llvm::StringMap<uint32_t> ShaderAttrIndices;
-      for (uint32_t Ai = 0; Ai < FnAttrs->count(); ++Ai) {
-        auto *A = static_cast<MTL::VertexAttribute *>(FnAttrs->object(Ai));
-        if (A && A->isActive()) {
-          ShaderAttrIndices.insert(std::make_pair(
-              llvm::StringRef(A->name()->utf8String()), A->attributeIndex()));
-          llvm::errs() << "Shader attr: " << A->name()->utf8String()
-                       << " at index " << A->attributeIndex() << "\n";
-        }
-      }
-
-      IS.VertexDescriptor = MTL::VertexDescriptor::alloc()->init();
-      const uint32_t Stride = P.Bindings.getVertexStride();
-      for (const VertexAttribute &VA : P.Bindings.VertexAttributes) {
-        llvm::SmallString<32> AttrName(VA.Name);
-        llvm::transform(AttrName, AttrName.begin(), tolower);
-        // Append a zero since we're only supporting one attribute per name.
-        // We'll need to revisit this if we ever support indexed attributes.
-        AttrName += "0";
-        MTL::VertexAttributeDescriptor *VADesc =
-            MTL::VertexAttributeDescriptor::alloc()->init();
-        VADesc->setBufferIndex(0);
-        VADesc->setOffset(VA.Offset);
-        VADesc->setFormat(getMTLVertexFormat(VA.Format, VA.Channels));
-        IS.VertexDescriptor->attributes()->setObject(
-            VADesc, ShaderAttrIndices[AttrName]);
-      }
-
-      MTL::VertexBufferLayoutDescriptor *LDesc =
-          MTL::VertexBufferLayoutDescriptor::alloc()->init();
-      LDesc->setStride(Stride);
-      LDesc->setStepRate(1);
-      LDesc->setStepFunction(MTL::VertexStepFunctionPerVertex);
-      IS.VertexDescriptor->layouts()->setObject(LDesc, 0);
-    }
-    return llvm::Error::success();
-  }
-
-  llvm::Error loadShaders(InvocationState &IS, const Pipeline &P) {
-    NS::Error *Error = nullptr;
-    if (P.isCompute()) {
-      // This is an arbitrary distinction that we could alter in the future.
-      if (P.Shaders.size() != 1)
-        return llvm::createStringError(
-            std::errc::invalid_argument,
-            "Compute pipeline must have exactly one compute shader.");
-      const llvm::StringRef Program = P.Shaders[0].Shader->getBuffer();
-      dispatch_data_t Data = dispatch_data_create(
-          Program.data(), Program.size(), dispatch_get_main_queue(),
-          ^{
-          });
-      MTL::Library *Lib = Device->newLibrary(Data, &Error);
-      if (Error)
-        return toError(Error);
-      IS.Pool->addObject(Lib);
-
-      MTL::Function *Fn = Lib->newFunction(NS::String::string(
-          P.Shaders[0].Entry.c_str(), NS::UTF8StringEncoding));
-      IS.ComputePipeline = Device->newComputePipelineState(Fn, &Error);
-      if (Error)
-        return toError(Error);
-      IS.Pool->addObject(Fn);
-    } else {
-      MTL::RenderPipelineDescriptor *Desc =
-          MTL::RenderPipelineDescriptor::alloc()->init();
-      IS.Pool->addObject(Desc);
-      for (const auto &S : P.Shaders) {
-        const llvm::StringRef Program = S.Shader->getBuffer();
-        dispatch_data_t Data = dispatch_data_create(
-            Program.data(), Program.size(), dispatch_get_main_queue(),
-            ^{
-            });
-        MTL::Library *Lib = Device->newLibrary(Data, &Error);
-        if (Error)
-          return toError(Error);
-        IS.Pool->addObject(Lib);
-
-        MTL::Function *Fn = Lib->newFunction(
-            NS::String::string(S.Entry.c_str(), NS::UTF8StringEncoding));
-        switch (S.Stage) {
-        case Stages::Vertex:
-          Desc->setVertexFunction(Fn);
-          if (llvm::Error Err = setupVertexShader(IS, P, Fn))
-            return Err;
-
-          Desc->setVertexDescriptor(IS.VertexDescriptor);
-          break;
-        case Stages::Pixel:
-          Desc->setFragmentFunction(Fn);
-          break;
-        case Stages::Compute:
-          return llvm::createStringError(
-              std::errc::not_supported,
-              "Metal: Compute shader invalid with render pipeline!");
-        }
-        if (Error)
-          return toError(Error);
-        IS.Pool->addObject(Fn);
-      }
-
-      // TODO: Add support for more shader stages and different pipeline shapes.
-      if (Desc->vertexFunction() == nullptr ||
-          Desc->fragmentFunction() == nullptr)
-        return llvm::createStringError(
-            std::errc::invalid_argument,
-            "Graphics pipeline requires both a vertex shader and a fragment "
-            "shader.");
-
-      if (P.Bindings.RTargetBufferPtr) {
-        // Configure the render target color attachment.
-        const MTL::PixelFormat PF =
-            getMTLFormat(P.Bindings.RTargetBufferPtr->Format,
-                         P.Bindings.RTargetBufferPtr->Channels);
-        MTL::RenderPipelineColorAttachmentDescriptor *RPCA =
-            MTL::RenderPipelineColorAttachmentDescriptor::alloc()->init();
-        RPCA->setPixelFormat(PF);
-        Desc->colorAttachments()->setObject(RPCA, 0);
-
-        // Set the depth/stencil format on the pipeline descriptor.
-        const MTL::PixelFormat DepthFmt =
-            getMetalPixelFormat(Format::D32FloatS8Uint);
-        Desc->setDepthAttachmentPixelFormat(DepthFmt);
-        Desc->setStencilAttachmentPixelFormat(DepthFmt);
-      }
-
-      IS.RenderPipeline = Device->newRenderPipelineState(Desc, &Error);
-      if (Error)
-        return toError(Error);
-    }
-
-    return llvm::Error::success();
-  }
 
   llvm::Error createDescriptor(Resource &R, InvocationState &IS,
                                const uint32_t HeapIdx) {
@@ -511,7 +358,8 @@ class MTLDevice : public offloadtest::Device {
     auto CloseCommandEncoder =
         llvm::scope_exit([&]() { CmdEncoder->endEncoding(); });
 
-    CmdEncoder->setComputePipelineState(IS.ComputePipeline);
+    auto *PS = static_cast<MTLPipelineState *>(IS.Pipeline.get());
+    CmdEncoder->setComputePipelineState(PS->ComputePipeline);
     CmdEncoder->setBuffer(IS.ArgBuffer, 0, 2);
     for (uint64_t I = 0; I < IS.Textures.size(); ++I)
       CmdEncoder->useResource(IS.Textures[I],
@@ -520,7 +368,7 @@ class MTLDevice : public offloadtest::Device {
       CmdEncoder->useResource(IS.Buffers[I],
                               MTL::ResourceUsageRead | MTL::ResourceUsageWrite);
 
-    NS::UInteger TGS[3] = {IS.ComputePipeline->maxTotalThreadsPerThreadgroup(),
+    NS::UInteger TGS[3] = {PS->ComputePipeline->maxTotalThreadsPerThreadgroup(),
                            1, 1};
     if (P.Shaders[0].Reflection) {
       llvm::Expected<llvm::json::Value> E = llvm::json::parse(
@@ -663,7 +511,8 @@ class MTLDevice : public offloadtest::Device {
     MTL::RenderCommandEncoder *CmdEncoder =
         IS.CB->CmdBuffer->renderCommandEncoder(Desc);
 
-    CmdEncoder->setRenderPipelineState(IS.RenderPipeline);
+    auto *PS = static_cast<MTLPipelineState *>(IS.Pipeline.get());
+    CmdEncoder->setRenderPipelineState(PS->RenderPipeline);
 
     // Configure depth stencil state: depth test enabled, write all, less.
     MTL::DepthStencilDescriptor *DSDesc =
@@ -813,6 +662,152 @@ public:
     return MTLCommandBuffer::create(GraphicsQueue.Queue);
   }
 
+  llvm::Expected<std::shared_ptr<PipelineState>>
+  createPipelineCs(llvm::StringRef Name,
+                   const BindingsDesc & /*unused on metal*/,
+                   ShaderContainer CS) override {
+    NS::Error *Error = nullptr;
+    const llvm::StringRef Program = CS.Shader->getBuffer();
+    dispatch_data_t Data = dispatch_data_create(Program.data(), Program.size(),
+                                                dispatch_get_main_queue(),
+                                                ^{
+                                                });
+    MTL::Library *Lib = Device->newLibrary(Data, &Error);
+    if (Error)
+      return toError(Error);
+
+    MTL::Function *Fn = Lib->newFunction(
+        NS::String::string(CS.EntryPoint.c_str(), NS::UTF8StringEncoding));
+    if (!Fn) {
+      Lib->release();
+      return llvm::createStringError(
+          std::errc::invalid_argument,
+          "Failed to find entry point '%s' in Metal library.",
+          CS.EntryPoint.c_str());
+    }
+
+    MTL::ComputePipelineState *PSO =
+        Device->newComputePipelineState(Fn, &Error);
+    Fn->release();
+    Lib->release();
+    if (Error)
+      return toError(Error);
+
+    return std::make_shared<MTLPipelineState>(Name, PSO);
+  }
+
+  llvm::Expected<std::shared_ptr<PipelineState>> createPipelineVsPs(
+      llvm::StringRef Name, const BindingsDesc & /*unused on metal*/,
+      llvm::ArrayRef<InputLayoutDesc> InputLayout,
+      llvm::ArrayRef<Format> RTFormats, std::optional<Format> DSFormat,
+      ShaderContainer VS, ShaderContainer PS) override {
+    NS::Error *Error = nullptr;
+
+    // Load vertex shader.
+    const llvm::StringRef VSProgram = VS.Shader->getBuffer();
+    dispatch_data_t VSData = dispatch_data_create(
+        VSProgram.data(), VSProgram.size(), dispatch_get_main_queue(),
+        ^{
+        });
+    MTL::Library *VSLib = Device->newLibrary(VSData, &Error);
+    if (Error)
+      return toError(Error);
+
+    MTL::Function *VSFn = VSLib->newFunction(
+        NS::String::string(VS.EntryPoint.c_str(), NS::UTF8StringEncoding));
+    if (!VSFn) {
+      VSLib->release();
+      return llvm::createStringError(
+          std::errc::invalid_argument,
+          "Failed to find vertex entry point '%s' in Metal library.",
+          VS.EntryPoint.c_str());
+    }
+
+    // Load pixel/fragment shader.
+    const llvm::StringRef PSProgram = PS.Shader->getBuffer();
+    dispatch_data_t PSData = dispatch_data_create(
+        PSProgram.data(), PSProgram.size(), dispatch_get_main_queue(),
+        ^{
+        });
+    MTL::Library *PSLib = Device->newLibrary(PSData, &Error);
+    if (Error) {
+      VSFn->release();
+      VSLib->release();
+      return toError(Error);
+    }
+
+    MTL::Function *PSFn = PSLib->newFunction(
+        NS::String::string(PS.EntryPoint.c_str(), NS::UTF8StringEncoding));
+    if (!PSFn) {
+      VSFn->release();
+      VSLib->release();
+      PSLib->release();
+      return llvm::createStringError(
+          std::errc::invalid_argument,
+          "Failed to find fragment entry point '%s' in Metal library.",
+          PS.EntryPoint.c_str());
+    }
+
+    MTL::RenderPipelineDescriptor *Desc =
+        MTL::RenderPipelineDescriptor::alloc()->init();
+    Desc->setVertexFunction(VSFn);
+    Desc->setFragmentFunction(PSFn);
+
+    // Build vertex descriptor from InputLayout.
+    if (!InputLayout.empty()) {
+      MTL::VertexDescriptor *VtxDesc = MTL::VertexDescriptor::alloc()->init();
+      uint32_t Stride = 0;
+      for (uint32_t I = 0; I < static_cast<uint32_t>(InputLayout.size()); ++I) {
+        const InputLayoutDesc &Elem = InputLayout[I];
+        const uint32_t ElemSize = getFormatSizeInBytes(Elem.Format);
+        MTL::VertexAttributeDescriptor *AttrDesc =
+            MTL::VertexAttributeDescriptor::alloc()->init();
+        AttrDesc->setBufferIndex(0);
+        AttrDesc->setOffset(Elem.OffsetInBytes);
+        AttrDesc->setFormat(getMetalVertexFormat(Elem.Format));
+        VtxDesc->attributes()->setObject(AttrDesc, I);
+        Stride = std::max(Stride, Elem.OffsetInBytes + ElemSize);
+      }
+
+      MTL::VertexBufferLayoutDescriptor *LDesc =
+          MTL::VertexBufferLayoutDescriptor::alloc()->init();
+      LDesc->setStride(Stride);
+      LDesc->setStepRate(1);
+      LDesc->setStepFunction(MTL::VertexStepFunctionPerVertex);
+      VtxDesc->layouts()->setObject(LDesc, 0);
+
+      Desc->setVertexDescriptor(VtxDesc);
+    }
+
+    // Configure render target color attachments.
+    for (size_t I = 0; I < RTFormats.size(); ++I) {
+      MTL::RenderPipelineColorAttachmentDescriptor *RPCA =
+          MTL::RenderPipelineColorAttachmentDescriptor::alloc()->init();
+      RPCA->setPixelFormat(getMetalPixelFormat(RTFormats[I]));
+      Desc->colorAttachments()->setObject(RPCA, I);
+    }
+
+    // Configure depth/stencil attachment.
+    if (DSFormat) {
+      const MTL::PixelFormat DSPixelFormat = getMetalPixelFormat(*DSFormat);
+      Desc->setDepthAttachmentPixelFormat(DSPixelFormat);
+      if (*DSFormat == Format::D32FloatS8Uint)
+        Desc->setStencilAttachmentPixelFormat(DSPixelFormat);
+    }
+
+    MTL::RenderPipelineState *PSO =
+        Device->newRenderPipelineState(Desc, &Error);
+    VSFn->release();
+    VSLib->release();
+    PSFn->release();
+    PSLib->release();
+    Desc->release();
+    if (Error)
+      return toError(Error);
+
+    return std::make_shared<MTLPipelineState>(Name, PSO);
+  }
+
   llvm::Error executeProgram(Pipeline &P) override {
     InvocationState IS;
 
@@ -824,17 +819,82 @@ public:
     if (auto Err = createBuffers(P, IS))
       return Err;
 
-    if (auto Err = loadShaders(IS, P))
-      return Err;
+    BindingsDesc Bindings = {};
+    for (auto &S : P.Sets) {
+      DescriptorSetLayoutDesc Layout;
+      for (auto &R : S.Resources) {
+        ResourceBindingDesc ResourceBinding = {};
+        ResourceBinding.Kind = R.Kind;
+        ResourceBinding.DXBinding.Register = R.DXBinding.Register;
+        ResourceBinding.DXBinding.Space = R.DXBinding.Space;
+        ResourceBinding.VKBinding = R.VKBinding;
+        ResourceBinding.DescriptorCount = R.getArraySize();
+        Layout.ResourceBindings.push_back(ResourceBinding);
+      }
+      Bindings.DescriptorSetDescs.push_back(Layout);
+    }
 
     if (P.isCompute()) {
+      if (P.Shaders.size() != 1 || P.Shaders[0].Stage != Stages::Compute)
+        return llvm::createStringError(
+            std::errc::invalid_argument,
+            "Compute pipeline must have exactly one compute shader.");
+
+      ShaderContainer CS = {};
+      CS.EntryPoint = P.Shaders[0].Entry;
+      CS.Shader = P.Shaders[0].Shader.get();
+
+      auto PipelineStateOrErr =
+          createPipelineCs("Compute Pipeline State", Bindings, CS);
+      if (!PipelineStateOrErr)
+        return PipelineStateOrErr.takeError();
+      IS.Pipeline = *PipelineStateOrErr;
+      llvm::outs() << "Compute Pipeline created.\n";
+
       if (auto Err = createComputeCommands(P, IS))
         return Err;
-      llvm::outs() << "Created compute commands.\n";
     } else {
+      ShaderContainer VS = {};
+      ShaderContainer PS = {};
+      for (auto &Shader : P.Shaders) {
+        if (Shader.Stage == Stages::Vertex) {
+          VS.EntryPoint = Shader.Entry;
+          VS.Shader = Shader.Shader.get();
+        } else if (Shader.Stage == Stages::Pixel) {
+          PS.EntryPoint = Shader.Entry;
+          PS.Shader = Shader.Shader.get();
+        }
+      }
+
+      llvm::SmallVector<InputLayoutDesc> InputLayout;
+      for (auto &Attr : P.Bindings.VertexAttributes) {
+        auto FormatOrErr = toFormat(Attr.Format, Attr.Channels);
+        if (!FormatOrErr)
+          return FormatOrErr.takeError();
+
+        InputLayoutDesc Desc = {};
+        Desc.Name = Attr.Name;
+        Desc.Format = *FormatOrErr;
+        Desc.OffsetInBytes = Attr.Offset;
+        InputLayout.push_back(Desc);
+      }
+
+      auto FormatOrErr = toFormat(P.Bindings.RTargetBufferPtr->Format,
+                                  P.Bindings.RTargetBufferPtr->Channels);
+      if (!FormatOrErr)
+        return FormatOrErr.takeError();
+
+      llvm::SmallVector<Format> RTFormats;
+      RTFormats.push_back(*FormatOrErr);
+
+      auto PipelineStateOrErr = createPipelineVsPs(
+          "Graphics Pipeline State", Bindings, InputLayout, RTFormats, VS, PS);
+      if (!PipelineStateOrErr)
+        return PipelineStateOrErr.takeError();
+      IS.Pipeline = *PipelineStateOrErr;
+
       if (auto Err = createGraphicsCommands(P, IS))
         return Err;
-      llvm::outs() << "Created graphics commands.\n";
     }
 
     auto SubmitResult = executeCommands(IS);

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -805,12 +805,12 @@ public:
         // We'll need to revisit this if we ever support indexed attributes.
         AttrName += "0";
 
-        const uint32_t ElemSize = getFormatSizeInBytes(Elem.Format);
+        const uint32_t ElemSize = getFormatSizeInBytes(Elem.Fmt);
         MTL::VertexAttributeDescriptor *AttrDesc =
             MTL::VertexAttributeDescriptor::alloc()->init();
         AttrDesc->setBufferIndex(0);
         AttrDesc->setOffset(Elem.OffsetInBytes);
-        AttrDesc->setFormat(getMetalVertexFormat(Elem.Format));
+        AttrDesc->setFormat(getMetalVertexFormat(Elem.Fmt));
         VtxDesc->attributes()->setObject(AttrDesc, ShaderAttrIndices[AttrName]);
         AttrDesc->release();
         Stride = std::max(Stride, Elem.OffsetInBytes + ElemSize);
@@ -924,7 +924,7 @@ public:
 
         InputLayoutDesc Desc = {};
         Desc.Name = Attr.Name;
-        Desc.Format = *FormatOrErr;
+        Desc.Fmt = *FormatOrErr;
         Desc.OffsetInBytes = Attr.Offset;
         InputLayout.push_back(Desc);
       }

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -766,6 +766,7 @@ public:
         AttrDesc->setOffset(Elem.OffsetInBytes);
         AttrDesc->setFormat(getMetalVertexFormat(Elem.Format));
         VtxDesc->attributes()->setObject(AttrDesc, I);
+        AttrDesc->release();
         Stride = std::max(Stride, Elem.OffsetInBytes + ElemSize);
       }
 
@@ -775,8 +776,10 @@ public:
       LDesc->setStepRate(1);
       LDesc->setStepFunction(MTL::VertexStepFunctionPerVertex);
       VtxDesc->layouts()->setObject(LDesc, 0);
+      LDesc->release();
 
       Desc->setVertexDescriptor(VtxDesc);
+      VtxDesc->release();
     }
 
     // Configure render target color attachments.
@@ -785,6 +788,7 @@ public:
           MTL::RenderPipelineColorAttachmentDescriptor::alloc()->init();
       RPCA->setPixelFormat(getMetalPixelFormat(RTFormats[I]));
       Desc->colorAttachments()->setObject(RPCA, I);
+      RPCA->release();
     }
 
     // Configure depth/stencil attachment.

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -10,6 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "API/Device.h"
+#include "API/FormatConversion.h"
 #include "Support/Pipeline.h"
 #include "Support/VkError.h"
 #include "VKResources.h"
@@ -19,6 +20,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <map>
 #include <memory>
 #include <numeric>
 #include <system_error>
@@ -69,17 +71,22 @@ static VkDescriptorType getDescriptorType(const ResourceKind RK) {
     return VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER;
   case ResourceKind::RWBuffer:
     return VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER;
+
   case ResourceKind::Texture2D:
     return VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
+
   case ResourceKind::RWTexture2D:
     return VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+
   case ResourceKind::ByteAddressBuffer:
   case ResourceKind::RWByteAddressBuffer:
   case ResourceKind::StructuredBuffer:
   case ResourceKind::RWStructuredBuffer:
     return VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+
   case ResourceKind::ConstantBuffer:
     return VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+
   case ResourceKind::Sampler:
     return VK_DESCRIPTOR_TYPE_SAMPLER;
   case ResourceKind::SampledTexture2D:
@@ -566,6 +573,29 @@ private:
   VulkanCommandBuffer() : CommandBuffer(GPUAPI::Vulkan) {}
 };
 
+class VulkanPipelineState : public offloadtest::PipelineState {
+public:
+  std::string Name;
+  VkDevice Dev;
+  VkPipeline Pipeline;
+  VkPipelineLayout Layout;
+  llvm::SmallVector<VkDescriptorSetLayout>
+      SetLayouts; // Do we need to keep these alive?
+
+  VulkanPipelineState(llvm::StringRef Name, VkDevice Dev, VkPipeline Pipeline,
+                      VkPipelineLayout Layout,
+                      llvm::SmallVector<VkDescriptorSetLayout> SetLayouts)
+      : Name(Name.str()), Dev(Dev), Pipeline(Pipeline), Layout(Layout),
+        SetLayouts(std::move(SetLayouts)) {}
+
+  ~VulkanPipelineState() override {
+    vkDestroyPipeline(Dev, Pipeline, nullptr);
+    vkDestroyPipelineLayout(Dev, Layout, nullptr);
+    for (VkDescriptorSetLayout L : SetLayouts)
+      vkDestroyDescriptorSetLayout(Dev, L, nullptr);
+  }
+};
+
 class VulkanDevice : public offloadtest::Device {
 private:
   std::shared_ptr<VulkanInstance> Instance;
@@ -640,18 +670,11 @@ private:
     llvm::SmallVector<ResourceRef> CounterResourceRefs;
   };
 
-  struct CompiledShader {
-    Stages Stage;
-    std::string Entry;
-    VkShaderModule Shader;
-  };
-
   struct InvocationState {
     std::unique_ptr<VulkanCommandBuffer> CB;
-    VkPipelineLayout PipelineLayout = VK_NULL_HANDLE;
     VkDescriptorPool Pool = VK_NULL_HANDLE;
-    VkPipelineCache PipelineCache = VK_NULL_HANDLE;
-    VkPipeline Pipeline = VK_NULL_HANDLE;
+
+    std::shared_ptr<PipelineState> Pipeline;
 
     // FrameBuffer associated data for offscreen rendering.
     VkFramebuffer FrameBuffer = VK_NULL_HANDLE;
@@ -663,20 +686,10 @@ private:
     VkRenderPass RenderPass = VK_NULL_HANDLE;
     uint32_t ShaderStageMask = 0;
 
-    llvm::SmallVector<CompiledShader> Shaders;
-    llvm::SmallVector<VkDescriptorSetLayout> DescriptorSetLayouts;
     llvm::SmallVector<ResourceBundle> Resources;
     llvm::SmallVector<VkDescriptorSet> DescriptorSets;
     llvm::SmallVector<VkBufferView> BufferViews;
     llvm::SmallVector<VkImageView> ImageViews;
-
-    uint32_t getFullShaderStageMask() {
-      if (0 != ShaderStageMask)
-        return ShaderStageMask;
-      for (const auto &S : Shaders)
-        ShaderStageMask |= getShaderStageFlag(S.Stage);
-      return ShaderStageMask;
-    }
   };
 
 public:
@@ -825,6 +838,390 @@ public:
   GPUAPI getAPI() const override { return GPUAPI::Vulkan; }
 
   Queue &getGraphicsQueue() override { return GraphicsQueue; }
+
+  llvm::Error
+  createPipelineLayout(const BindingsDesc &BindingsDesc,
+                       VkShaderStageFlags StageFlags,
+                       llvm::SmallVectorImpl<VkDescriptorSetLayout> &SetLayouts,
+                       VkPipelineLayout &PipelineLayout) {
+    // Build descriptor set layouts from BindingsDesc.
+    for (const DescriptorSetLayoutDesc &SetDesc :
+         BindingsDesc.DescriptorSetDescs) {
+      std::vector<VkDescriptorSetLayoutBinding> Binds;
+      for (const ResourceBindingDesc &RB : SetDesc.ResourceBindings) {
+        const VulkanBinding VKBinding = RB.VKBinding.value();
+
+        VkDescriptorSetLayoutBinding B = {};
+        B.binding = VKBinding.Binding;
+        B.descriptorType = getDescriptorType(RB.Kind);
+        B.descriptorCount = RB.DescriptorCount;
+        B.stageFlags = StageFlags;
+        Binds.push_back(B);
+
+        if (VKBinding.CounterBinding) {
+          VkDescriptorSetLayoutBinding CB = {};
+          CB.binding = *VKBinding.CounterBinding;
+          CB.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+          CB.descriptorCount = RB.DescriptorCount;
+          CB.stageFlags = StageFlags;
+          Binds.push_back(CB);
+        }
+      }
+      VkDescriptorSetLayoutCreateInfo SetCI = {};
+      SetCI.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+      SetCI.bindingCount = static_cast<uint32_t>(Binds.size());
+      SetCI.pBindings = Binds.data();
+      VkDescriptorSetLayout SetLayout = VK_NULL_HANDLE;
+      if (auto Err = VK::toError(
+              vkCreateDescriptorSetLayout(Device, &SetCI, nullptr, &SetLayout),
+              "Failed to create descriptor set layout.")) {
+        for (auto *L : SetLayouts)
+          vkDestroyDescriptorSetLayout(Device, L, nullptr);
+        return Err;
+      }
+      SetLayouts.push_back(SetLayout);
+    }
+
+    llvm::SmallVector<VkPushConstantRange> Ranges;
+    for (const auto &PCR : BindingsDesc.PushConstantRanges) {
+      const VkPushConstantRange R = {
+          static_cast<VkShaderStageFlags>(StageFlags), PCR.OffsetInBytes,
+          PCR.SizeInBytes};
+      Ranges.emplace_back(std::move(R));
+    }
+
+    VkPipelineLayoutCreateInfo LayoutCI = {};
+    LayoutCI.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+    LayoutCI.setLayoutCount = static_cast<uint32_t>(SetLayouts.size());
+    LayoutCI.pSetLayouts = SetLayouts.empty() ? nullptr : SetLayouts.data();
+    LayoutCI.pushConstantRangeCount = static_cast<uint32_t>(Ranges.size());
+    LayoutCI.pPushConstantRanges = Ranges.empty() ? nullptr : Ranges.data();
+    if (auto Err = VK::toError(
+            vkCreatePipelineLayout(Device, &LayoutCI, nullptr, &PipelineLayout),
+            "Failed to create pipeline layout.")) {
+      for (auto *L : SetLayouts)
+        vkDestroyDescriptorSetLayout(Device, L, nullptr);
+      return Err;
+    }
+
+    return llvm::Error::success();
+  }
+
+  llvm::Expected<VkShaderModule>
+  createShaderModule(const llvm::MemoryBuffer *Shader, const char *Kind) {
+    const llvm::StringRef Bytecode = Shader->getBuffer();
+    VkShaderModuleCreateInfo ModuleCI = {};
+    ModuleCI.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
+    ModuleCI.codeSize = Bytecode.size();
+    ModuleCI.pCode = reinterpret_cast<const uint32_t *>(Bytecode.data());
+    VkShaderModule Module = VK_NULL_HANDLE;
+    if (vkCreateShaderModule(Device, &ModuleCI, nullptr, &Module))
+      return llvm::createStringError(
+          std::errc::not_supported, "Failed to create %s shader module.", Kind);
+    return Module;
+  }
+
+  llvm::Expected<std::shared_ptr<PipelineState>>
+  createPipelineCs(llvm::StringRef Name, const BindingsDesc &BindingsDesc,
+                   ShaderContainer CS) override {
+    llvm::SmallVector<VkDescriptorSetLayout> SetLayouts;
+    VkPipelineLayout PipelineLayout = VK_NULL_HANDLE;
+    if (auto Err =
+            createPipelineLayout(BindingsDesc, VK_SHADER_STAGE_COMPUTE_BIT,
+                                 SetLayouts, PipelineLayout))
+      return Err;
+
+    // Create compute shader module.
+    auto CSModOrErr = createShaderModule(CS.Shader, "compute");
+    if (!CSModOrErr) {
+      vkDestroyPipelineLayout(Device, PipelineLayout, nullptr);
+      for (auto *L : SetLayouts)
+        vkDestroyDescriptorSetLayout(Device, L, nullptr);
+      return CSModOrErr.takeError();
+    }
+    VkShaderModule CSModule = *CSModOrErr;
+
+    VkPipelineShaderStageCreateInfo StageCI = {};
+    StageCI.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+    StageCI.stage = VK_SHADER_STAGE_COMPUTE_BIT;
+    StageCI.module = CSModule;
+    StageCI.pName = CS.EntryPoint.c_str();
+
+    llvm::SmallVector<VkSpecializationMapEntry> SpecEntries;
+    llvm::SmallVector<char> SpecData;
+    VkSpecializationInfo SpecInfo = {};
+    if (!CS.SpecializationConstants.empty()) {
+      llvm::DenseSet<uint32_t> SeenConstantIDs;
+
+      for (const auto &SpecConst : CS.SpecializationConstants) {
+        if (!SeenConstantIDs.insert(SpecConst.ConstantID).second)
+          return llvm::createStringError(
+              std::errc::invalid_argument,
+              "Test configuration contains multiple entries for "
+              "specialization constant ID %u.",
+              SpecConst.ConstantID);
+
+        VkSpecializationMapEntry Entry;
+        if (auto Err = parseSpecializationConstant(SpecConst, Entry, SpecData))
+          return Err;
+        SpecEntries.push_back(Entry);
+      }
+      SpecInfo.mapEntryCount = SpecEntries.size();
+      SpecInfo.pMapEntries = SpecEntries.data();
+      SpecInfo.dataSize = SpecData.size();
+      SpecInfo.pData = SpecData.data();
+      StageCI.pSpecializationInfo = &SpecInfo;
+    }
+
+    VkComputePipelineCreateInfo PipelineCI = {};
+    PipelineCI.sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO;
+    PipelineCI.stage = StageCI;
+    PipelineCI.layout = PipelineLayout;
+    VkPipeline Pipeline = VK_NULL_HANDLE;
+    if (auto Err = VK::toError(vkCreateComputePipelines(Device, VK_NULL_HANDLE,
+                                                        1, &PipelineCI, nullptr,
+                                                        &Pipeline),
+                               "Failed to create compute pipeline.")) {
+      vkDestroyShaderModule(Device, CSModule, nullptr);
+      vkDestroyPipelineLayout(Device, PipelineLayout, nullptr);
+      for (auto *L : SetLayouts)
+        vkDestroyDescriptorSetLayout(Device, L, nullptr);
+      return Err;
+    }
+
+    // No longer need shader modules after pipeline compilation.
+    vkDestroyShaderModule(Device, CSModule, nullptr);
+
+    return std::make_shared<VulkanPipelineState>(
+        Name, Device, Pipeline, PipelineLayout, std::move(SetLayouts));
+  }
+
+  llvm::Expected<std::shared_ptr<PipelineState>>
+  createPipelineVsPs(llvm::StringRef Name, const BindingsDesc &BindingsDesc,
+                     llvm::ArrayRef<InputLayoutDesc> InputLayout,
+                     llvm::ArrayRef<Format> RTFormats,
+                     std::optional<Format> DSFormat, ShaderContainer VS,
+                     ShaderContainer PS) override {
+    const VkShaderStageFlags GraphicsFlags =
+        VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT;
+
+    llvm::SmallVector<VkDescriptorSetLayout> SetLayouts;
+    VkPipelineLayout PipelineLayout = VK_NULL_HANDLE;
+    if (auto Err = createPipelineLayout(BindingsDesc, GraphicsFlags, SetLayouts,
+                                        PipelineLayout))
+      return Err;
+
+    std::vector<VkShaderModule> ShaderModules;
+    auto VSModOrErr = createShaderModule(VS.Shader, "vertex");
+    if (!VSModOrErr) {
+      vkDestroyPipelineLayout(Device, PipelineLayout, nullptr);
+      for (auto *L : SetLayouts)
+        vkDestroyDescriptorSetLayout(Device, L, nullptr);
+      return VSModOrErr.takeError();
+    }
+    ShaderModules.push_back(*VSModOrErr);
+
+    auto PSModOrErr = createShaderModule(PS.Shader, "pixel");
+    if (!PSModOrErr) {
+      for (auto *M : ShaderModules)
+        vkDestroyShaderModule(Device, M, nullptr);
+      vkDestroyPipelineLayout(Device, PipelineLayout, nullptr);
+      for (auto *L : SetLayouts)
+        vkDestroyDescriptorSetLayout(Device, L, nullptr);
+      return PSModOrErr.takeError();
+    }
+    ShaderModules.push_back(*PSModOrErr);
+
+    // Build specialization info for vertex shader.
+    llvm::SmallVector<VkSpecializationMapEntry> VSSpecEntries;
+    llvm::SmallVector<char> VSSpecData;
+    VkSpecializationInfo VSSpecInfo = {};
+    if (!VS.SpecializationConstants.empty()) {
+      llvm::DenseSet<uint32_t> SeenConstantIDs;
+      for (const auto &SpecConst : VS.SpecializationConstants) {
+        if (!SeenConstantIDs.insert(SpecConst.ConstantID).second)
+          return llvm::createStringError(
+              std::errc::invalid_argument,
+              "Test configuration contains multiple entries for "
+              "specialization constant ID %u.",
+              SpecConst.ConstantID);
+
+        VkSpecializationMapEntry Entry;
+        if (auto Err =
+                parseSpecializationConstant(SpecConst, Entry, VSSpecData))
+          return Err;
+        VSSpecEntries.push_back(Entry);
+      }
+      VSSpecInfo.mapEntryCount = VSSpecEntries.size();
+      VSSpecInfo.pMapEntries = VSSpecEntries.data();
+      VSSpecInfo.dataSize = VSSpecData.size();
+      VSSpecInfo.pData = VSSpecData.data();
+    }
+
+    // Build specialization info for pixel/fragment shader.
+    llvm::SmallVector<VkSpecializationMapEntry> PSSpecEntries;
+    llvm::SmallVector<char> PSSpecData;
+    VkSpecializationInfo PSSpecInfo = {};
+    if (!PS.SpecializationConstants.empty()) {
+      llvm::DenseSet<uint32_t> SeenConstantIDs;
+      for (const auto &SpecConst : PS.SpecializationConstants) {
+        if (!SeenConstantIDs.insert(SpecConst.ConstantID).second)
+          return llvm::createStringError(
+              std::errc::invalid_argument,
+              "Test configuration contains multiple entries for "
+              "specialization constant ID %u.",
+              SpecConst.ConstantID);
+
+        VkSpecializationMapEntry Entry;
+        if (auto Err =
+                parseSpecializationConstant(SpecConst, Entry, PSSpecData))
+          return Err;
+        PSSpecEntries.push_back(Entry);
+      }
+      PSSpecInfo.mapEntryCount = PSSpecEntries.size();
+      PSSpecInfo.pMapEntries = PSSpecEntries.data();
+      PSSpecInfo.dataSize = PSSpecData.size();
+      PSSpecInfo.pData = PSSpecData.data();
+    }
+
+    const std::array<VkPipelineShaderStageCreateInfo, 2> Stages = {{
+        {VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO, nullptr, 0,
+         VK_SHADER_STAGE_VERTEX_BIT, ShaderModules[0], VS.EntryPoint.c_str(),
+         VS.SpecializationConstants.empty() ? nullptr : &VSSpecInfo},
+        {VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO, nullptr, 0,
+         VK_SHADER_STAGE_FRAGMENT_BIT, ShaderModules[1], PS.EntryPoint.c_str(),
+         PS.SpecializationConstants.empty() ? nullptr : &PSSpecInfo},
+    }};
+
+    // Build vertex input attribute and binding descriptions from InputLayout.
+    uint32_t Stride = 0;
+    std::vector<VkVertexInputAttributeDescription> Attributes;
+    Attributes.reserve(InputLayout.size());
+    for (uint32_t I = 0; I < static_cast<uint32_t>(InputLayout.size()); ++I) {
+      const InputLayoutDesc &Elem = InputLayout[I];
+      const uint32_t ElemSize = getFormatSizeInBytes(Elem.Format);
+      VkVertexInputAttributeDescription Attr = {};
+      Attr.location = I;
+      Attr.binding = 0;
+      Attr.format = getVulkanFormat(Elem.Format);
+      Attr.offset = Elem.OffsetInBytes;
+      Attributes.push_back(Attr);
+      Stride = std::max(Stride, Elem.OffsetInBytes + ElemSize);
+    }
+
+    VkVertexInputBindingDescription BindingDesc = {};
+    BindingDesc.binding = 0;
+    BindingDesc.stride = Stride;
+    BindingDesc.inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
+
+    VkPipelineVertexInputStateCreateInfo VertexInputCI = {};
+    VertexInputCI.sType =
+        VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO;
+    VertexInputCI.vertexBindingDescriptionCount = InputLayout.empty() ? 0 : 1;
+    VertexInputCI.pVertexBindingDescriptions =
+        InputLayout.empty() ? nullptr : &BindingDesc;
+    VertexInputCI.vertexAttributeDescriptionCount =
+        static_cast<uint32_t>(Attributes.size());
+    VertexInputCI.pVertexAttributeDescriptions =
+        Attributes.empty() ? nullptr : Attributes.data();
+
+    VkPipelineInputAssemblyStateCreateInfo InputAssemblyCI = {};
+    InputAssemblyCI.sType =
+        VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
+    InputAssemblyCI.topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
+
+    VkPipelineViewportStateCreateInfo ViewportCI = {};
+    ViewportCI.sType = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO;
+    ViewportCI.viewportCount = 1;
+    ViewportCI.scissorCount = 1;
+
+    const VkDynamicState DynStates[] = {VK_DYNAMIC_STATE_VIEWPORT,
+                                        VK_DYNAMIC_STATE_SCISSOR};
+    VkPipelineDynamicStateCreateInfo DynamicCI = {};
+    DynamicCI.sType = VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO;
+    DynamicCI.dynamicStateCount = 2;
+    DynamicCI.pDynamicStates = DynStates;
+
+    VkPipelineRasterizationStateCreateInfo RastCI = {};
+    RastCI.sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
+    RastCI.polygonMode = VK_POLYGON_MODE_FILL;
+    RastCI.cullMode = VK_CULL_MODE_NONE;
+    RastCI.frontFace = VK_FRONT_FACE_COUNTER_CLOCKWISE;
+    RastCI.lineWidth = 1.0f;
+
+    VkPipelineMultisampleStateCreateInfo MultisampleCI = {};
+    MultisampleCI.sType =
+        VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;
+    MultisampleCI.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
+
+    VkPipelineDepthStencilStateCreateInfo DepthStencilCI = {};
+    DepthStencilCI.sType =
+        VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO;
+    DepthStencilCI.depthTestEnable = VK_TRUE;
+    DepthStencilCI.depthWriteEnable = VK_TRUE;
+    DepthStencilCI.depthCompareOp = VK_COMPARE_OP_LESS_OR_EQUAL;
+    DepthStencilCI.back.failOp = VK_STENCIL_OP_KEEP;
+    DepthStencilCI.back.passOp = VK_STENCIL_OP_KEEP;
+    DepthStencilCI.back.compareOp = VK_COMPARE_OP_ALWAYS;
+    DepthStencilCI.front = DepthStencilCI.back;
+
+    llvm::SmallVector<VkPipelineColorBlendAttachmentState> BlendAttachments(
+        RTFormats.size());
+    for (auto &BA : BlendAttachments)
+      BA.colorWriteMask = 0xf;
+    VkPipelineColorBlendStateCreateInfo BlendCI = {};
+    BlendCI.sType = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;
+    BlendCI.attachmentCount = static_cast<uint32_t>(BlendAttachments.size());
+    BlendCI.pAttachments = BlendAttachments.data();
+
+    // Use dynamic rendering (Vulkan 1.3 core): no render pass object required.
+    llvm::SmallVector<VkFormat> ColorFormats;
+    for (const Format F : RTFormats)
+      ColorFormats.push_back(getVulkanFormat(F));
+    VkPipelineRenderingCreateInfo DynRenderCI = {};
+    DynRenderCI.sType = VK_STRUCTURE_TYPE_PIPELINE_RENDERING_CREATE_INFO;
+    DynRenderCI.colorAttachmentCount =
+        static_cast<uint32_t>(ColorFormats.size());
+    DynRenderCI.pColorAttachmentFormats = ColorFormats.data();
+    if (DSFormat)
+      DynRenderCI.depthAttachmentFormat = getVulkanFormat(*DSFormat);
+
+    VkGraphicsPipelineCreateInfo PipelineCI = {};
+    PipelineCI.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
+    PipelineCI.pNext = &DynRenderCI;
+    PipelineCI.stageCount = static_cast<uint32_t>(Stages.size());
+    PipelineCI.pStages = Stages.data();
+    PipelineCI.pVertexInputState = &VertexInputCI;
+    PipelineCI.pInputAssemblyState = &InputAssemblyCI;
+    PipelineCI.pViewportState = &ViewportCI;
+    PipelineCI.pRasterizationState = &RastCI;
+    PipelineCI.pMultisampleState = &MultisampleCI;
+    PipelineCI.pDepthStencilState = &DepthStencilCI;
+    PipelineCI.pColorBlendState = &BlendCI;
+    PipelineCI.pDynamicState = &DynamicCI;
+    PipelineCI.layout = PipelineLayout;
+    PipelineCI.renderPass = VK_NULL_HANDLE;
+
+    VkPipeline Pipeline = VK_NULL_HANDLE;
+    if (auto Err = VK::toError(vkCreateGraphicsPipelines(Device, VK_NULL_HANDLE,
+                                                         1, &PipelineCI,
+                                                         nullptr, &Pipeline),
+                               "Failed to create graphics pipeline.")) {
+      for (auto *M : ShaderModules)
+        vkDestroyShaderModule(Device, M, nullptr);
+      vkDestroyPipelineLayout(Device, PipelineLayout, nullptr);
+      for (auto *L : SetLayouts)
+        vkDestroyDescriptorSetLayout(Device, L, nullptr);
+      return Err;
+    }
+
+    // No longer need shader modules after pipeline compilation.
+    for (auto *M : ShaderModules)
+      vkDestroyShaderModule(Device, M, nullptr);
+
+    return std::make_shared<VulkanPipelineState>(
+        Name, Device, Pipeline, PipelineLayout, std::move(SetLayouts));
+  }
 
   llvm::Expected<std::unique_ptr<offloadtest::Fence>>
   createFence(llvm::StringRef Name) override {
@@ -1410,81 +1807,22 @@ public:
   }
 
   llvm::Error createDescriptorSets(Pipeline &P, InvocationState &IS) {
-    for (const auto &S : P.Sets) {
-      std::vector<VkDescriptorSetLayoutBinding> Bindings;
-      for (const auto &R : S.Resources) {
-        VkDescriptorSetLayoutBinding Binding = {};
-        if (!R.VKBinding.has_value())
-          return llvm::createStringError(std::errc::invalid_argument,
-                                         "No VulkanBinding provided for '%s'",
-                                         R.Name.c_str());
-        if (R.HasCounter && !R.VKBinding->CounterBinding)
-          return llvm::createStringError(
-              std::errc::invalid_argument,
-              "No CounterBinding provided for resource '%s' with a counter",
-              R.Name.c_str());
-        Binding.binding = R.VKBinding->Binding;
-        Binding.descriptorType = getDescriptorType(R.Kind);
-        Binding.descriptorCount = R.getArraySize();
-        Binding.stageFlags = IS.getFullShaderStageMask();
-        Bindings.push_back(Binding);
-        if (R.HasCounter) {
-          VkDescriptorSetLayoutBinding CounterBinding = {};
-          CounterBinding.binding = *R.VKBinding->CounterBinding;
-          CounterBinding.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-          CounterBinding.descriptorCount = R.getArraySize();
-          CounterBinding.stageFlags = IS.getFullShaderStageMask();
-          Bindings.push_back(CounterBinding);
-        }
-      }
-      VkDescriptorSetLayoutCreateInfo LayoutCreateInfo = {};
-      LayoutCreateInfo.sType =
-          VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
-      LayoutCreateInfo.bindingCount = Bindings.size();
-      LayoutCreateInfo.pBindings = Bindings.data();
-      llvm::outs() << "Binding " << Bindings.size() << " descriptors.\n";
-      VkDescriptorSetLayout Layout;
-      if (auto Err =
-              VK::toError(vkCreateDescriptorSetLayout(Device, &LayoutCreateInfo,
-                                                      nullptr, &Layout),
-                          "Failed to create descriptor set layout."))
-        return Err;
-      IS.DescriptorSetLayouts.push_back(Layout);
-    }
-
-    VkPipelineLayoutCreateInfo PipelineCreateInfo = {};
-    PipelineCreateInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
-    PipelineCreateInfo.setLayoutCount = IS.DescriptorSetLayouts.size();
-    PipelineCreateInfo.pSetLayouts = IS.DescriptorSetLayouts.data();
-
-    llvm::SmallVector<VkPushConstantRange, 1> Ranges;
-    for (const auto &PCB : P.PushConstants) {
-      const VkPushConstantRange R = {
-          static_cast<VkShaderStageFlags>(getShaderStageFlag(PCB.Stage)),
-          /* offset= */ 0, static_cast<uint32_t>(PCB.size())};
-      Ranges.emplace_back(std::move(R));
-    }
-    PipelineCreateInfo.pushConstantRangeCount = Ranges.size();
-    PipelineCreateInfo.pPushConstantRanges = Ranges.data();
-
-    if (auto Err =
-            VK::toError(vkCreatePipelineLayout(Device, &PipelineCreateInfo,
-                                               nullptr, &IS.PipelineLayout),
-                        "Failed to create pipeline layout."))
-      return Err;
-
     if (P.Sets.size() == 0)
       return llvm::Error::success();
+
+    const VulkanPipelineState *VulkanPipeline =
+        static_cast<VulkanPipelineState *>(IS.Pipeline.get());
 
     VkDescriptorSetAllocateInfo DSAllocInfo = {};
     DSAllocInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
     DSAllocInfo.descriptorPool = IS.Pool;
-    DSAllocInfo.descriptorSetCount = IS.DescriptorSetLayouts.size();
-    DSAllocInfo.pSetLayouts = IS.DescriptorSetLayouts.data();
+    DSAllocInfo.descriptorSetCount = VulkanPipeline->SetLayouts.size(); // error
+    DSAllocInfo.pSetLayouts = VulkanPipeline->SetLayouts.data();
     assert(IS.DescriptorSets.empty());
     IS.DescriptorSets.insert(IS.DescriptorSets.begin(),
-                             IS.DescriptorSetLayouts.size(), VkDescriptorSet());
-    llvm::outs() << "Num Descriptor sets: " << IS.DescriptorSetLayouts.size()
+                             VulkanPipeline->SetLayouts.size(),
+                             VkDescriptorSet());
+    llvm::outs() << "Num Descriptor sets: " << VulkanPipeline->SetLayouts.size()
                  << "\n";
     if (auto Err =
             VK::toError(vkAllocateDescriptorSets(Device, &DSAllocInfo,
@@ -1646,24 +1984,6 @@ public:
     llvm::outs() << "WriteDescriptors: " << WriteDescriptors.size() << "\n";
     vkUpdateDescriptorSets(Device, WriteDescriptors.size(),
                            WriteDescriptors.data(), 0, nullptr);
-    return llvm::Error::success();
-  }
-
-  llvm::Error createShaderModules(Pipeline &P, InvocationState &IS) {
-    for (const auto &Shader : P.Shaders) {
-      const llvm::StringRef Program = Shader.Shader->getBuffer();
-      VkShaderModuleCreateInfo ShaderCreateInfo = {};
-      ShaderCreateInfo.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
-      ShaderCreateInfo.codeSize = Program.size();
-      ShaderCreateInfo.pCode =
-          reinterpret_cast<const uint32_t *>(Program.data());
-      CompiledShader CS = {Shader.Stage, Shader.Entry, 0};
-      if (auto Err = VK::toError(vkCreateShaderModule(Device, &ShaderCreateInfo,
-                                                      nullptr, &CS.Shader),
-                                 "Failed to create shader module."))
-        return Err;
-      IS.Shaders.emplace_back(CS);
-    }
     return llvm::Error::success();
   }
 
@@ -1871,181 +2191,6 @@ public:
     default:
       llvm_unreachable("Unsupported specialization constant type");
     }
-    return llvm::Error::success();
-  }
-
-  llvm::Error createPipeline(Pipeline &P, InvocationState &IS) {
-    VkPipelineCacheCreateInfo CacheCreateInfo = {};
-    CacheCreateInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO;
-    if (auto Err =
-            VK::toError(vkCreatePipelineCache(Device, &CacheCreateInfo, nullptr,
-                                              &IS.PipelineCache),
-                        "Failed to create pipeline cache."))
-      return Err;
-
-    if (P.isCompute()) {
-      const offloadtest::Shader &Shader = P.Shaders[0];
-      assert(IS.Shaders.size() == 1 &&
-             "Currently only support one compute shader");
-      const CompiledShader &S = IS.Shaders[0];
-      VkPipelineShaderStageCreateInfo StageInfo = {};
-      StageInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
-      StageInfo.stage = VK_SHADER_STAGE_COMPUTE_BIT;
-      StageInfo.module = S.Shader;
-      StageInfo.pName = S.Entry.c_str();
-
-      llvm::SmallVector<VkSpecializationMapEntry> SpecEntries;
-      llvm::SmallVector<char> SpecData;
-      VkSpecializationInfo SpecInfo = {};
-      if (!Shader.SpecializationConstants.empty()) {
-        llvm::DenseSet<uint32_t> SeenConstantIDs;
-        for (const auto &SpecConst : Shader.SpecializationConstants) {
-          if (!SeenConstantIDs.insert(SpecConst.ConstantID).second)
-            return llvm::createStringError(
-                std::errc::invalid_argument,
-                "Test configuration contains multiple entries for "
-                "specialization constant ID %u.",
-                SpecConst.ConstantID);
-
-          VkSpecializationMapEntry Entry;
-          if (auto Err =
-                  parseSpecializationConstant(SpecConst, Entry, SpecData))
-            return Err;
-          SpecEntries.push_back(Entry);
-        }
-
-        SpecInfo.mapEntryCount = SpecEntries.size();
-        SpecInfo.pMapEntries = SpecEntries.data();
-        SpecInfo.dataSize = SpecData.size();
-        SpecInfo.pData = SpecData.data();
-        StageInfo.pSpecializationInfo = &SpecInfo;
-      }
-
-      VkComputePipelineCreateInfo PipelineCreateInfo = {};
-      PipelineCreateInfo.sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO;
-      PipelineCreateInfo.stage = StageInfo;
-      PipelineCreateInfo.layout = IS.PipelineLayout;
-      if (auto Err =
-              VK::toError(vkCreateComputePipelines(Device, IS.PipelineCache, 1,
-                                                   &PipelineCreateInfo, nullptr,
-                                                   &IS.Pipeline),
-                          "Failed to create pipeline."))
-        return Err;
-      return llvm::Error::success();
-    }
-
-    llvm::SmallVector<VkPipelineShaderStageCreateInfo> Stages;
-    for (const auto &S : IS.Shaders) {
-      VkPipelineShaderStageCreateInfo StageInfo = {};
-      StageInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
-      StageInfo.stage = getShaderStageFlag(S.Stage);
-      StageInfo.module = S.Shader;
-      StageInfo.pName = S.Entry.c_str();
-      Stages.emplace_back(StageInfo);
-    }
-
-    VkPipelineInputAssemblyStateCreateInfo InputAssemblyCI = {};
-    InputAssemblyCI.sType =
-        VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
-    InputAssemblyCI.topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
-
-    VkPipelineRasterizationStateCreateInfo RastStateCI = {};
-    RastStateCI.sType =
-        VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
-    RastStateCI.polygonMode = VK_POLYGON_MODE_FILL;
-    RastStateCI.cullMode = VK_CULL_MODE_NONE;
-    RastStateCI.frontFace = VK_FRONT_FACE_COUNTER_CLOCKWISE;
-    RastStateCI.depthClampEnable = VK_FALSE;
-    RastStateCI.rasterizerDiscardEnable = VK_FALSE;
-    RastStateCI.depthBiasEnable = VK_FALSE;
-    RastStateCI.lineWidth = 1.0f;
-
-    VkPipelineColorBlendAttachmentState BlendState = {};
-    BlendState.colorWriteMask = 0xf;
-    BlendState.blendEnable = VK_FALSE;
-    VkPipelineColorBlendStateCreateInfo BlendStateCI = {};
-    BlendStateCI.sType =
-        VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;
-    BlendStateCI.attachmentCount = 1;
-    BlendStateCI.pAttachments = &BlendState;
-
-    VkPipelineViewportStateCreateInfo ViewStateCI = {};
-    ViewStateCI.sType = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO;
-    ViewStateCI.viewportCount = 1;
-    ViewStateCI.scissorCount = 1;
-
-    const VkDynamicState DynamicStates[] = {VK_DYNAMIC_STATE_VIEWPORT,
-                                            VK_DYNAMIC_STATE_SCISSOR};
-    VkPipelineDynamicStateCreateInfo DynamicStateCI = {};
-    DynamicStateCI.sType = VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO;
-    DynamicStateCI.pDynamicStates = &DynamicStates[0];
-    DynamicStateCI.dynamicStateCount = 2;
-
-    VkPipelineDepthStencilStateCreateInfo DepthStencilStateCI = {};
-    DepthStencilStateCI.sType =
-        VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO;
-    DepthStencilStateCI.depthTestEnable = VK_TRUE;
-    DepthStencilStateCI.depthWriteEnable = VK_TRUE;
-    DepthStencilStateCI.depthCompareOp = VK_COMPARE_OP_LESS_OR_EQUAL;
-    DepthStencilStateCI.depthBoundsTestEnable = VK_FALSE;
-    DepthStencilStateCI.back.failOp = VK_STENCIL_OP_KEEP;
-    DepthStencilStateCI.back.passOp = VK_STENCIL_OP_KEEP;
-    DepthStencilStateCI.back.compareOp = VK_COMPARE_OP_ALWAYS;
-    DepthStencilStateCI.stencilTestEnable = VK_FALSE;
-    DepthStencilStateCI.front = DepthStencilStateCI.back;
-
-    VkPipelineMultisampleStateCreateInfo MultisampleStateCI = {};
-    MultisampleStateCI.sType =
-        VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;
-    MultisampleStateCI.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
-
-    const uint32_t Stride = P.Bindings.getVertexStride();
-
-    VkVertexInputBindingDescription VertexInputBinding{};
-    VertexInputBinding.binding = 0;
-    VertexInputBinding.stride = Stride;
-    VertexInputBinding.inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
-
-    llvm::SmallVector<VkVertexInputAttributeDescription> Attributes;
-    for (size_t I = 0; I < P.Bindings.VertexAttributes.size(); ++I) {
-      const VertexAttribute &VA = P.Bindings.VertexAttributes[I];
-      VkVertexInputAttributeDescription VkVA = {};
-      VkVA.location = I;
-      VkVA.binding = 0;
-      VkVA.format = getVKFormat(VA.Format, VA.Channels);
-      VkVA.offset = VA.Offset;
-      Attributes.push_back(VkVA);
-    }
-
-    VkPipelineVertexInputStateCreateInfo VertexInputStateCi = {};
-    VertexInputStateCi.sType =
-        VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO;
-    VertexInputStateCi.vertexBindingDescriptionCount = 1;
-    VertexInputStateCi.pVertexBindingDescriptions = &VertexInputBinding;
-    VertexInputStateCi.vertexAttributeDescriptionCount = Attributes.size();
-    VertexInputStateCi.pVertexAttributeDescriptions = Attributes.data();
-
-    VkGraphicsPipelineCreateInfo PipelineCreateInfo = {};
-    PipelineCreateInfo.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
-    PipelineCreateInfo.stageCount = Stages.size();
-    PipelineCreateInfo.pStages = Stages.data();
-    PipelineCreateInfo.pVertexInputState = &VertexInputStateCi;
-    PipelineCreateInfo.pInputAssemblyState = &InputAssemblyCI;
-    PipelineCreateInfo.pRasterizationState = &RastStateCI;
-    PipelineCreateInfo.pColorBlendState = &BlendStateCI;
-    PipelineCreateInfo.pMultisampleState = &MultisampleStateCI;
-    PipelineCreateInfo.pViewportState = &ViewStateCI;
-    PipelineCreateInfo.pDepthStencilState = &DepthStencilStateCI;
-    PipelineCreateInfo.pDynamicState = &DynamicStateCI;
-    PipelineCreateInfo.renderPass = IS.RenderPass;
-    PipelineCreateInfo.layout = IS.PipelineLayout;
-
-    if (auto Err = VK::toError(vkCreateGraphicsPipelines(
-                                   Device, IS.PipelineCache, 1,
-                                   &PipelineCreateInfo, nullptr, &IS.Pipeline),
-                               "Failed to create graphics pipeline."))
-      return Err;
-
     return llvm::Error::success();
   }
 
@@ -2372,16 +2517,18 @@ public:
     const VkPipelineBindPoint BindPoint = P.isGraphics()
                                               ? VK_PIPELINE_BIND_POINT_GRAPHICS
                                               : VK_PIPELINE_BIND_POINT_COMPUTE;
-    vkCmdBindPipeline(IS.CB->CmdBuffer, BindPoint, IS.Pipeline);
+    const VulkanPipelineState *VulkanPipeline =
+        static_cast<VulkanPipelineState *>(IS.Pipeline.get());
+    vkCmdBindPipeline(IS.CB->CmdBuffer, BindPoint, VulkanPipeline->Pipeline);
     if (IS.DescriptorSets.size() > 0)
-      vkCmdBindDescriptorSets(IS.CB->CmdBuffer, BindPoint, IS.PipelineLayout, 0,
-                              IS.DescriptorSets.size(),
-                              IS.DescriptorSets.data(), 0, 0);
+      vkCmdBindDescriptorSets(
+          IS.CB->CmdBuffer, BindPoint, VulkanPipeline->Layout, 0,
+          IS.DescriptorSets.size(), IS.DescriptorSets.data(), 0, 0);
 
     for (const auto &PCB : P.PushConstants) {
       llvm::SmallVector<uint8_t, 4> Data;
       PCB.getContent(Data);
-      vkCmdPushConstants(IS.CB->CmdBuffer, IS.PipelineLayout,
+      vkCmdPushConstants(IS.CB->CmdBuffer, VulkanPipeline->Layout,
                          getShaderStageFlag(PCB.Stage), 0, Data.size(),
                          Data.data());
     }
@@ -2517,31 +2664,16 @@ public:
       }
     }
 
-    if (IS.getFullShaderStageMask() != VK_SHADER_STAGE_COMPUTE_BIT) {
-      if (IS.VertexBuffer.has_value()) {
-        vkDestroyBuffer(Device, IS.VertexBuffer->Device.Buffer, nullptr);
-        vkFreeMemory(Device, IS.VertexBuffer->Device.Memory, nullptr);
-        vkDestroyBuffer(Device, IS.VertexBuffer->Host.Buffer, nullptr);
-        vkFreeMemory(Device, IS.VertexBuffer->Host.Memory, nullptr);
-      }
-      vkDestroyFramebuffer(Device, IS.FrameBuffer, nullptr);
-      vkDestroyRenderPass(Device, IS.RenderPass, nullptr);
+    if (IS.VertexBuffer.has_value()) {
+      vkDestroyBuffer(Device, IS.VertexBuffer->Device.Buffer, nullptr);
+      vkFreeMemory(Device, IS.VertexBuffer->Device.Memory, nullptr);
+      vkDestroyBuffer(Device, IS.VertexBuffer->Host.Buffer, nullptr);
+      vkFreeMemory(Device, IS.VertexBuffer->Host.Memory, nullptr);
     }
-
-    if (IS.Pipeline)
-      vkDestroyPipeline(Device, IS.Pipeline, nullptr);
-
-    for (auto &S : IS.Shaders)
-      vkDestroyShaderModule(Device, S.Shader, nullptr);
-
-    if (IS.PipelineCache)
-      vkDestroyPipelineCache(Device, IS.PipelineCache, nullptr);
-
-    if (IS.PipelineLayout)
-      vkDestroyPipelineLayout(Device, IS.PipelineLayout, nullptr);
-
-    for (auto &L : IS.DescriptorSetLayouts)
-      vkDestroyDescriptorSetLayout(Device, L, nullptr);
+    if (IS.FrameBuffer)
+      vkDestroyFramebuffer(Device, IS.FrameBuffer, nullptr);
+    if (IS.RenderPass)
+      vkDestroyRenderPass(Device, IS.RenderPass, nullptr);
 
     if (IS.Pool)
       vkDestroyDescriptorPool(Device, IS.Pool, nullptr);
@@ -2561,10 +2693,6 @@ public:
     State.CB = std::move(*CBOrErr);
     llvm::outs() << "Command buffer created.\n";
 
-    if (auto Err = createShaderModules(P, State))
-      return Err;
-    llvm::outs() << "Shader module created.\n";
-    llvm::outs() << "Copy command buffer created.\n";
     if (auto Err = createResources(P, State))
       return Err;
     if (P.isGraphics()) {
@@ -2575,6 +2703,101 @@ public:
         return Err;
       llvm::outs() << "Frame buffer created.\n";
     }
+
+    BindingsDesc BindingsDesc = {};
+    for (auto &S : P.Sets) {
+      DescriptorSetLayoutDesc Layout;
+      for (auto &R : S.Resources) {
+        ResourceBindingDesc ResourceBinding = {};
+        ResourceBinding.Kind = R.Kind;
+        ResourceBinding.VKBinding = R.VKBinding;
+        ResourceBinding.DescriptorCount = R.getArraySize();
+        Layout.ResourceBindings.push_back(ResourceBinding);
+
+        if (R.HasCounter && !R.VKBinding->CounterBinding)
+          return llvm::createStringError(
+              std::errc::invalid_argument,
+              "No CounterBinding provided for resource '%s' with a counter",
+              R.Name.c_str());
+      }
+      BindingsDesc.DescriptorSetDescs.push_back(Layout);
+    }
+    for (const auto &PCB : P.PushConstants) {
+      PushConstantsRange Range = {};
+      Range.OffsetInBytes = 0;
+      Range.SizeInBytes = PCB.size();
+      BindingsDesc.PushConstantRanges.push_back(Range);
+    }
+
+    if (P.isCompute()) {
+      // This is an arbitrary distinction that we could alter in the future.
+      if (P.Shaders.size() != 1 || P.Shaders[0].Stage != Stages::Compute)
+        return llvm::createStringError(
+            std::errc::invalid_argument,
+            "Compute pipeline must have exactly one compute shader.");
+
+      ShaderContainer CS = {};
+      CS.EntryPoint = P.Shaders[0].Entry;
+      CS.Shader = P.Shaders[0].Shader.get();
+      CS.SpecializationConstants = P.Shaders[0].SpecializationConstants;
+      if (CS.Shader == nullptr) {
+        llvm::outs() << "CS is null :(\n";
+        llvm::outs() << "Shader count: " << P.Shaders.size() << "\n";
+      }
+      assert(CS.Shader != nullptr);
+
+      auto PipelineStateOrErr =
+          createPipelineCs("Compute Pipeline State", BindingsDesc, CS);
+      if (!PipelineStateOrErr)
+        return PipelineStateOrErr.takeError();
+      State.Pipeline = *PipelineStateOrErr;
+      llvm::outs() << "Compute Pipeline created.\n";
+    } else {
+      ShaderContainer VS = {};
+      ShaderContainer PS = {};
+      for (auto &Shader : P.Shaders) {
+        if (Shader.Stage == Stages::Vertex) {
+          VS.EntryPoint = Shader.Entry;
+          VS.Shader = Shader.Shader.get();
+          VS.SpecializationConstants = Shader.SpecializationConstants;
+        } else if (Shader.Stage == Stages::Pixel) {
+          PS.EntryPoint = Shader.Entry;
+          PS.Shader = Shader.Shader.get();
+          PS.SpecializationConstants = Shader.SpecializationConstants;
+        }
+      }
+
+      // Create the input layout based on the vertex attributes.
+      llvm::SmallVector<InputLayoutDesc> InputLayout;
+      for (auto &Attr : P.Bindings.VertexAttributes) {
+        auto FormatOrErr = toFormat(Attr.Format, Attr.Channels);
+        if (!FormatOrErr)
+          return FormatOrErr.takeError();
+
+        InputLayoutDesc Desc = {};
+        Desc.Name = Attr.Name;
+        Desc.Format = *FormatOrErr;
+        Desc.OffsetInBytes = Attr.Offset;
+        InputLayout.push_back(Desc);
+      }
+
+      auto FormatOrErr = toFormat(P.Bindings.RTargetBufferPtr->Format,
+                                  P.Bindings.RTargetBufferPtr->Channels);
+      if (!FormatOrErr)
+        return FormatOrErr.takeError();
+
+      llvm::SmallVector<Format> RTFormats;
+      RTFormats.push_back(*FormatOrErr);
+
+      auto PipelineStateOrErr = createPipelineVsPs(
+          "Graphics Pipeline State", BindingsDesc, InputLayout, RTFormats,
+          Format::D32FloatS8Uint, VS, PS);
+      if (!PipelineStateOrErr)
+        return PipelineStateOrErr.takeError();
+      State.Pipeline = *PipelineStateOrErr;
+      llvm::outs() << "Graphics Pipeline created.\n";
+    }
+
     llvm::outs() << "Memory buffers created.\n";
     // No explicit wait: the next submit's GPU-side timeline semaphore
     // dependency ensures the copy completes before the dispatch runs.
@@ -2594,9 +2817,6 @@ public:
     if (auto Err = createDescriptorSets(P, State))
       return Err;
     llvm::outs() << "Descriptor sets created.\n";
-    if (auto Err = createPipeline(P, State))
-      return Err;
-    llvm::outs() << "Compute pipeline created.\n";
     if (auto Err = createCommands(P, State))
       return Err;
     llvm::outs() << "Commands created.\n";

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -850,6 +850,8 @@ public:
                        VkShaderStageFlags StageFlags,
                        llvm::SmallVectorImpl<VkDescriptorSetLayout> &SetLayouts,
                        VkPipelineLayout &PipelineLayout) {
+    assert(SetLayouts.empty() && "Output vector SetLayouts must be empty.");
+
     // Build descriptor set layouts from BindingsDesc.
     for (const DescriptorSetLayoutDesc &SetDesc :
          BindingsDesc.DescriptorSetDescs) {
@@ -937,12 +939,15 @@ public:
                                  SetLayouts, PipelineLayout))
       return Err;
 
+    auto CleanupState = llvm::scope_exit([&]() {
+      for (auto &Layout : SetLayouts)
+        vkDestroyDescriptorSetLayout(Device, Layout, nullptr);
+    });
+
     // Create compute shader module.
     auto CSModOrErr = createShaderModule(CS.Shader, "compute");
     if (!CSModOrErr) {
       vkDestroyPipelineLayout(Device, PipelineLayout, nullptr);
-      for (auto *L : SetLayouts)
-        vkDestroyDescriptorSetLayout(Device, L, nullptr);
       return CSModOrErr.takeError();
     }
     VkShaderModule CSModule = *CSModOrErr;
@@ -972,8 +977,6 @@ public:
                 parseSpecializationConstant(SpecConst, Entry, SpecData)) {
           vkDestroyShaderModule(Device, CSModule, nullptr);
           vkDestroyPipelineLayout(Device, PipelineLayout, nullptr);
-          for (auto *L : SetLayouts)
-            vkDestroyDescriptorSetLayout(Device, L, nullptr);
           return Err;
         }
         SpecEntries.push_back(Entry);
@@ -996,8 +999,6 @@ public:
                                "Failed to create compute pipeline.")) {
       vkDestroyShaderModule(Device, CSModule, nullptr);
       vkDestroyPipelineLayout(Device, PipelineLayout, nullptr);
-      for (auto *L : SetLayouts)
-        vkDestroyDescriptorSetLayout(Device, L, nullptr);
       return Err;
     }
 
@@ -1841,19 +1842,19 @@ public:
     if (P.Sets.size() == 0)
       return llvm::Error::success();
 
-    const VulkanPipelineState *VulkanPipeline =
-        static_cast<VulkanPipelineState *>(IS.Pipeline.get());
+    const VulkanPipelineState &VulkanPipeline =
+        llvm::cast<VulkanPipelineState>(*IS.Pipeline.get());
 
     VkDescriptorSetAllocateInfo DSAllocInfo = {};
     DSAllocInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
     DSAllocInfo.descriptorPool = IS.Pool;
-    DSAllocInfo.descriptorSetCount = VulkanPipeline->SetLayouts.size();
-    DSAllocInfo.pSetLayouts = VulkanPipeline->SetLayouts.data();
+    DSAllocInfo.descriptorSetCount = VulkanPipeline.SetLayouts.size();
+    DSAllocInfo.pSetLayouts = VulkanPipeline.SetLayouts.data();
     assert(IS.DescriptorSets.empty());
     IS.DescriptorSets.insert(IS.DescriptorSets.begin(),
-                             VulkanPipeline->SetLayouts.size(),
+                             VulkanPipeline.SetLayouts.size(),
                              VkDescriptorSet());
-    llvm::outs() << "Num Descriptor sets: " << VulkanPipeline->SetLayouts.size()
+    llvm::outs() << "Num Descriptor sets: " << VulkanPipeline.SetLayouts.size()
                  << "\n";
     if (auto Err =
             VK::toError(vkAllocateDescriptorSets(Device, &DSAllocInfo,
@@ -2535,18 +2536,18 @@ public:
     const VkPipelineBindPoint BindPoint = P.isGraphics()
                                               ? VK_PIPELINE_BIND_POINT_GRAPHICS
                                               : VK_PIPELINE_BIND_POINT_COMPUTE;
-    const VulkanPipelineState *VulkanPipeline =
-        static_cast<VulkanPipelineState *>(IS.Pipeline.get());
-    vkCmdBindPipeline(IS.CB->CmdBuffer, BindPoint, VulkanPipeline->Pipeline);
+    const VulkanPipelineState &VulkanPipeline =
+        llvm::cast<VulkanPipelineState>(*IS.Pipeline.get());
+    vkCmdBindPipeline(IS.CB->CmdBuffer, BindPoint, VulkanPipeline.Pipeline);
     if (IS.DescriptorSets.size() > 0)
       vkCmdBindDescriptorSets(
-          IS.CB->CmdBuffer, BindPoint, VulkanPipeline->Layout, 0,
+          IS.CB->CmdBuffer, BindPoint, VulkanPipeline.Layout, 0,
           IS.DescriptorSets.size(), IS.DescriptorSets.data(), 0, 0);
 
     for (const auto &PCB : P.PushConstants) {
       llvm::SmallVector<uint8_t, 4> Data;
       PCB.getContent(Data);
-      vkCmdPushConstants(IS.CB->CmdBuffer, VulkanPipeline->Layout,
+      vkCmdPushConstants(IS.CB->CmdBuffer, VulkanPipeline.Layout,
                          getShaderStageFlag(PCB.Stage), 0, Data.size(),
                          Data.data());
     }

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -1185,7 +1185,7 @@ public:
     DynRenderCI.pColorAttachmentFormats = ColorFormats.data();
     if (DSFormat) {
       DynRenderCI.depthAttachmentFormat = getVulkanFormat(*DSFormat);
-      if (*DSFormat == Format::D32FloatS8Uint)
+      if (isStencilFormat(*DSFormat))
         DynRenderCI.stencilAttachmentFormat = getVulkanFormat(*DSFormat);
     }
 

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -580,15 +580,19 @@ public:
   VkPipeline Pipeline;
   VkPipelineLayout Layout;
   llvm::SmallVector<VkDescriptorSetLayout> SetLayouts;
+  VkRenderPass RenderPass;
 
   VulkanPipelineState(llvm::StringRef Name, VkDevice Dev, VkPipeline Pipeline,
                       VkPipelineLayout Layout,
-                      llvm::SmallVector<VkDescriptorSetLayout> SetLayouts)
+                      llvm::SmallVector<VkDescriptorSetLayout> SetLayouts,
+                      VkRenderPass RenderPass)
       : offloadtest::PipelineState(GPUAPI::Vulkan), Name(Name.str()), Dev(Dev),
-        Pipeline(Pipeline), Layout(Layout), SetLayouts(std::move(SetLayouts)) {}
+        Pipeline(Pipeline), Layout(Layout), SetLayouts(std::move(SetLayouts)),
+        RenderPass(RenderPass) {}
 
   ~VulkanPipelineState() override {
     vkDestroyPipeline(Dev, Pipeline, nullptr);
+    vkDestroyRenderPass(Dev, RenderPass, nullptr);
     vkDestroyPipelineLayout(Dev, Layout, nullptr);
     for (VkDescriptorSetLayout L : SetLayouts)
       vkDestroyDescriptorSetLayout(Dev, L, nullptr);
@@ -686,7 +690,6 @@ private:
     std::unique_ptr<offloadtest::Texture> DepthStencil;
     std::optional<ResourceRef> VertexBuffer = std::nullopt;
 
-    VkRenderPass RenderPass = VK_NULL_HANDLE;
     uint32_t ShaderStageMask = 0;
 
     llvm::SmallVector<ResourceBundle> Resources;
@@ -1002,7 +1005,8 @@ public:
     vkDestroyShaderModule(Device, CSModule, nullptr);
 
     return std::make_unique<VulkanPipelineState>(
-        Name, Device, Pipeline, PipelineLayout, std::move(SetLayouts));
+        Name, Device, Pipeline, PipelineLayout, std::move(SetLayouts),
+        VK_NULL_HANDLE);
   }
 
   llvm::Expected<std::unique_ptr<PipelineState>>
@@ -1020,9 +1024,20 @@ public:
                                         PipelineLayout))
       return Err;
 
+    auto RenderPassOrErr = createRenderPass(RTFormats, DSFormat);
+    if (!RenderPassOrErr) {
+      vkDestroyPipelineLayout(Device, PipelineLayout, nullptr);
+      for (auto *L : SetLayouts)
+        vkDestroyDescriptorSetLayout(Device, L, nullptr);
+      return RenderPassOrErr.takeError();
+    }
+    VkRenderPass RenderPass = *RenderPassOrErr;
+    llvm::outs() << "Render pass created.\n";
+
     std::vector<VkShaderModule> ShaderModules;
     auto VSModOrErr = createShaderModule(VS.Shader, "vertex");
     if (!VSModOrErr) {
+      vkDestroyRenderPass(Device, RenderPass, nullptr);
       vkDestroyPipelineLayout(Device, PipelineLayout, nullptr);
       for (auto *L : SetLayouts)
         vkDestroyDescriptorSetLayout(Device, L, nullptr);
@@ -1034,6 +1049,7 @@ public:
     if (!PSModOrErr) {
       for (auto *M : ShaderModules)
         vkDestroyShaderModule(Device, M, nullptr);
+      vkDestroyRenderPass(Device, RenderPass, nullptr);
       vkDestroyPipelineLayout(Device, PipelineLayout, nullptr);
       for (auto *L : SetLayouts)
         vkDestroyDescriptorSetLayout(Device, L, nullptr);
@@ -1060,6 +1076,7 @@ public:
                 parseSpecializationConstant(SpecConst, Entry, VSSpecData)) {
           for (auto *M : ShaderModules)
             vkDestroyShaderModule(Device, M, nullptr);
+          vkDestroyRenderPass(Device, RenderPass, nullptr);
           vkDestroyPipelineLayout(Device, PipelineLayout, nullptr);
           for (auto *L : SetLayouts)
             vkDestroyDescriptorSetLayout(Device, L, nullptr);
@@ -1092,6 +1109,7 @@ public:
                 parseSpecializationConstant(SpecConst, Entry, PSSpecData)) {
           for (auto *M : ShaderModules)
             vkDestroyShaderModule(Device, M, nullptr);
+          vkDestroyRenderPass(Device, RenderPass, nullptr);
           vkDestroyPipelineLayout(Device, PipelineLayout, nullptr);
           for (auto *L : SetLayouts)
             vkDestroyDescriptorSetLayout(Device, L, nullptr);
@@ -1198,24 +1216,8 @@ public:
     BlendCI.attachmentCount = static_cast<uint32_t>(BlendAttachments.size());
     BlendCI.pAttachments = BlendAttachments.data();
 
-    // Use dynamic rendering (Vulkan 1.3 core): no render pass object required.
-    llvm::SmallVector<VkFormat> ColorFormats;
-    for (const Format F : RTFormats)
-      ColorFormats.push_back(getVulkanFormat(F));
-    VkPipelineRenderingCreateInfo DynRenderCI = {};
-    DynRenderCI.sType = VK_STRUCTURE_TYPE_PIPELINE_RENDERING_CREATE_INFO;
-    DynRenderCI.colorAttachmentCount =
-        static_cast<uint32_t>(ColorFormats.size());
-    DynRenderCI.pColorAttachmentFormats = ColorFormats.data();
-    if (DSFormat) {
-      DynRenderCI.depthAttachmentFormat = getVulkanFormat(*DSFormat);
-      if (isStencilFormat(*DSFormat))
-        DynRenderCI.stencilAttachmentFormat = getVulkanFormat(*DSFormat);
-    }
-
     VkGraphicsPipelineCreateInfo PipelineCI = {};
     PipelineCI.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
-    PipelineCI.pNext = &DynRenderCI;
     PipelineCI.stageCount = static_cast<uint32_t>(Stages.size());
     PipelineCI.pStages = Stages.data();
     PipelineCI.pVertexInputState = &VertexInputCI;
@@ -1227,7 +1229,7 @@ public:
     PipelineCI.pColorBlendState = &BlendCI;
     PipelineCI.pDynamicState = &DynamicCI;
     PipelineCI.layout = PipelineLayout;
-    PipelineCI.renderPass = VK_NULL_HANDLE;
+    PipelineCI.renderPass = RenderPass;
 
     VkPipeline Pipeline = VK_NULL_HANDLE;
     if (auto Err = VK::toError(vkCreateGraphicsPipelines(Device, VK_NULL_HANDLE,
@@ -1236,6 +1238,7 @@ public:
                                "Failed to create graphics pipeline.")) {
       for (auto *M : ShaderModules)
         vkDestroyShaderModule(Device, M, nullptr);
+      vkDestroyRenderPass(Device, RenderPass, nullptr);
       vkDestroyPipelineLayout(Device, PipelineLayout, nullptr);
       for (auto *L : SetLayouts)
         vkDestroyDescriptorSetLayout(Device, L, nullptr);
@@ -1247,7 +1250,8 @@ public:
       vkDestroyShaderModule(Device, M, nullptr);
 
     return std::make_unique<VulkanPipelineState>(
-        Name, Device, Pipeline, PipelineLayout, std::move(SetLayouts));
+        Name, Device, Pipeline, PipelineLayout, std::move(SetLayouts),
+        RenderPass);
   }
 
   llvm::Expected<std::unique_ptr<offloadtest::Fence>>
@@ -2014,75 +2018,59 @@ public:
     return llvm::Error::success();
   }
 
-  llvm::Error createRenderPass(InvocationState &IS) {
-    auto &RT = llvm::cast<VulkanTexture>(*IS.RenderTarget);
-    auto &DS = llvm::cast<VulkanTexture>(*IS.DepthStencil);
+  llvm::Expected<VkRenderPass>
+  createRenderPass(llvm::ArrayRef<Format> RTFormats,
+                   std::optional<Format> DSFormat) {
+    // Only 8 render targets can be bound + 1 depth stencil target.
+    llvm::SmallVector<VkAttachmentDescription, 9> Attachments;
+    llvm::SmallVector<VkAttachmentReference, 8> ColorReferences;
+    for (size_t I = 0, N = RTFormats.size(); I < N; ++I) {
+      VkAttachmentDescription AttachmentDesc = {};
+      AttachmentDesc.format = getVulkanFormat(RTFormats[I]);
+      AttachmentDesc.samples = VK_SAMPLE_COUNT_1_BIT;
+      AttachmentDesc.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+      AttachmentDesc.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+      AttachmentDesc.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+      AttachmentDesc.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+      AttachmentDesc.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+      AttachmentDesc.finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+      Attachments.push_back(AttachmentDesc);
 
-    std::array<VkAttachmentDescription, 2> Attachments = {};
-
-    Attachments[0].format = getVulkanFormat(RT.Desc.Fmt);
-    Attachments[0].samples = VK_SAMPLE_COUNT_1_BIT;
-    Attachments[0].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
-    Attachments[0].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
-    Attachments[0].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-    Attachments[0].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-    Attachments[0].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-    Attachments[0].finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
-
-    Attachments[1].format = getVulkanFormat(DS.Desc.Fmt);
-    Attachments[1].samples = VK_SAMPLE_COUNT_1_BIT;
-    Attachments[1].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
-    Attachments[1].storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-    Attachments[1].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-    Attachments[1].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-    Attachments[1].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-    Attachments[1].finalLayout =
-        VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
-
-    VkAttachmentReference ColorReference = {};
-    ColorReference.attachment = 0;
-    ColorReference.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+      VkAttachmentReference ColorReference = {};
+      ColorReference.attachment = I;
+      ColorReference.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+      ColorReferences.push_back(ColorReference);
+    }
 
     VkAttachmentReference DepthReference = {};
-    DepthReference.attachment = 1;
-    DepthReference.layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+    if (DSFormat.has_value()) {
+      VkAttachmentDescription AttachmentDesc = {};
+      AttachmentDesc.format = getVulkanFormat(*DSFormat);
+      AttachmentDesc.samples = VK_SAMPLE_COUNT_1_BIT;
+      AttachmentDesc.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+      AttachmentDesc.storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+      AttachmentDesc.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+      AttachmentDesc.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+      AttachmentDesc.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+      AttachmentDesc.finalLayout =
+          VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+      Attachments.push_back(AttachmentDesc);
+
+      DepthReference.attachment = Attachments.size() - 1;
+      DepthReference.layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+    }
 
     VkSubpassDescription SubpassDescription = {};
     SubpassDescription.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
-    SubpassDescription.colorAttachmentCount = 1;
-    SubpassDescription.pColorAttachments = &ColorReference;
-    SubpassDescription.pDepthStencilAttachment = &DepthReference;
+    SubpassDescription.colorAttachmentCount = ColorReferences.size();
+    SubpassDescription.pColorAttachments = ColorReferences.data();
+    SubpassDescription.pDepthStencilAttachment =
+        DSFormat.has_value() ? &DepthReference : nullptr;
     SubpassDescription.inputAttachmentCount = 0;
     SubpassDescription.pInputAttachments = nullptr;
     SubpassDescription.preserveAttachmentCount = 0;
     SubpassDescription.pPreserveAttachments = nullptr;
     SubpassDescription.pResolveAttachments = nullptr;
-
-    std::array<VkSubpassDependency, 2> Dependencies = {};
-
-    Dependencies[0].srcSubpass = VK_SUBPASS_EXTERNAL;
-    Dependencies[0].dstSubpass = 0;
-    Dependencies[0].srcStageMask = VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT |
-                                   VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT;
-    Dependencies[0].dstStageMask = VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT |
-                                   VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT;
-    Dependencies[0].srcAccessMask =
-        VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
-    Dependencies[0].dstAccessMask =
-        VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT |
-        VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT;
-    Dependencies[0].dependencyFlags = 0;
-
-    Dependencies[1].srcSubpass = VK_SUBPASS_EXTERNAL;
-    Dependencies[1].dstSubpass = 0;
-    Dependencies[1].srcStageMask =
-        VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-    Dependencies[1].dstStageMask =
-        VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-    Dependencies[1].srcAccessMask = 0;
-    Dependencies[1].dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT |
-                                    VK_ACCESS_COLOR_ATTACHMENT_READ_BIT;
-    Dependencies[1].dependencyFlags = 0;
 
     VkRenderPassCreateInfo RPCI = {};
     RPCI.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
@@ -2090,25 +2078,27 @@ public:
     RPCI.pAttachments = Attachments.data();
     RPCI.subpassCount = 1;
     RPCI.pSubpasses = &SubpassDescription;
-    RPCI.dependencyCount = static_cast<uint32_t>(Dependencies.size());
-    RPCI.pDependencies = Dependencies.data();
+    // RPCI.dependencyCount = static_cast<uint32_t>(Dependencies.size());
+    // RPCI.pDependencies = Dependencies.data();
 
-    if (auto Err = VK::toError(
-            vkCreateRenderPass(Device, &RPCI, nullptr, &IS.RenderPass),
-            "Failed to create render pass."))
+    VkRenderPass RenderPass = VK_NULL_HANDLE;
+    if (auto Err =
+            VK::toError(vkCreateRenderPass(Device, &RPCI, nullptr, &RenderPass),
+                        "Failed to create render pass."))
       return Err;
-    return llvm::Error::success();
+    return RenderPass;
   }
 
   llvm::Error createFrameBuffer(InvocationState &IS) {
     auto &RT = llvm::cast<VulkanTexture>(*IS.RenderTarget);
     auto &DS = llvm::cast<VulkanTexture>(*IS.DepthStencil);
+    auto &PipelineState = llvm::cast<VulkanPipelineState>(*IS.Pipeline);
 
     std::array<VkImageView, 2> Views = {RT.View, DS.View};
 
     VkFramebufferCreateInfo FbufCreateInfo = {};
     FbufCreateInfo.sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
-    FbufCreateInfo.renderPass = IS.RenderPass;
+    FbufCreateInfo.renderPass = PipelineState.RenderPass;
     FbufCreateInfo.attachmentCount = Views.size();
     FbufCreateInfo.pAttachments = Views.data();
     FbufCreateInfo.width = RT.Desc.Width;
@@ -2492,6 +2482,7 @@ public:
     if (P.isGraphics()) {
       auto &RT = llvm::cast<VulkanTexture>(*IS.RenderTarget);
       auto &DS = llvm::cast<VulkanTexture>(*IS.DepthStencil);
+      auto &PipelineState = llvm::cast<VulkanPipelineState>(*IS.Pipeline);
 
       const auto *ColorCV =
           std::get_if<ClearColor>(&*RT.Desc.OptimizedClearValue);
@@ -2511,7 +2502,7 @@ public:
 
       VkRenderPassBeginInfo RenderPassBeginInfo = {};
       RenderPassBeginInfo.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
-      RenderPassBeginInfo.renderPass = IS.RenderPass;
+      RenderPassBeginInfo.renderPass = PipelineState.RenderPass;
       RenderPassBeginInfo.framebuffer = IS.FrameBuffer;
       RenderPassBeginInfo.renderArea.extent.width =
           P.Bindings.RTargetBufferPtr->OutputProps.Width;
@@ -2699,8 +2690,6 @@ public:
     }
     if (IS.FrameBuffer)
       vkDestroyFramebuffer(Device, IS.FrameBuffer, nullptr);
-    if (IS.RenderPass)
-      vkDestroyRenderPass(Device, IS.RenderPass, nullptr);
 
     if (IS.Pool)
       vkDestroyDescriptorPool(Device, IS.Pool, nullptr);
@@ -2722,14 +2711,6 @@ public:
 
     if (auto Err = createResources(P, State))
       return Err;
-    if (P.isGraphics()) {
-      if (auto Err = createRenderPass(State))
-        return Err;
-      llvm::outs() << "Render pass created.\n";
-      if (auto Err = createFrameBuffer(State))
-        return Err;
-      llvm::outs() << "Frame buffer created.\n";
-    }
 
     BindingsDesc BindingsDesc = {};
     for (auto &S : P.Sets) {
@@ -2825,6 +2806,10 @@ public:
         return PipelineStateOrErr.takeError();
       State.Pipeline = std::move(*PipelineStateOrErr);
       llvm::outs() << "Graphics Pipeline created.\n";
+
+      if (auto Err = createFrameBuffer(State))
+        return Err;
+      llvm::outs() << "Frame buffer created.\n";
     }
 
     llvm::outs() << "Memory buffers created.\n";

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -1819,7 +1819,7 @@ public:
     VkDescriptorSetAllocateInfo DSAllocInfo = {};
     DSAllocInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
     DSAllocInfo.descriptorPool = IS.Pool;
-    DSAllocInfo.descriptorSetCount = VulkanPipeline->SetLayouts.size(); // error
+    DSAllocInfo.descriptorSetCount = VulkanPipeline->SetLayouts.size();
     DSAllocInfo.pSetLayouts = VulkanPipeline->SetLayouts.data();
     assert(IS.DescriptorSets.empty());
     IS.DescriptorSets.insert(IS.DescriptorSets.begin(),

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -1117,6 +1117,9 @@ public:
     Attributes.reserve(InputLayout.size());
     for (uint32_t I = 0; I < static_cast<uint32_t>(InputLayout.size()); ++I) {
       const InputLayoutDesc &Elem = InputLayout[I];
+      assert(!Elem.InstanceStepRate &&
+             "Instance step rate is currently not supported.");
+
       const uint32_t ElemSize = getFormatSizeInBytes(Elem.Format);
       VkVertexInputAttributeDescription Attr = {};
       Attr.location = I;

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -584,14 +584,18 @@ public:
   VulkanPipelineState(llvm::StringRef Name, VkDevice Dev, VkPipeline Pipeline,
                       VkPipelineLayout Layout,
                       llvm::SmallVector<VkDescriptorSetLayout> SetLayouts)
-      : Name(Name.str()), Dev(Dev), Pipeline(Pipeline), Layout(Layout),
-        SetLayouts(std::move(SetLayouts)) {}
+      : offloadtest::PipelineState(GPUAPI::Vulkan), Name(Name.str()), Dev(Dev),
+        Pipeline(Pipeline), Layout(Layout), SetLayouts(std::move(SetLayouts)) {}
 
   ~VulkanPipelineState() override {
     vkDestroyPipeline(Dev, Pipeline, nullptr);
     vkDestroyPipelineLayout(Dev, Layout, nullptr);
     for (VkDescriptorSetLayout L : SetLayouts)
       vkDestroyDescriptorSetLayout(Dev, L, nullptr);
+  }
+
+  static bool classof(const offloadtest::PipelineState *B) {
+    return B->getAPI() == GPUAPI::Vulkan;
   }
 };
 

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -674,7 +674,7 @@ private:
     std::unique_ptr<VulkanCommandBuffer> CB;
     VkDescriptorPool Pool = VK_NULL_HANDLE;
 
-    std::shared_ptr<PipelineState> Pipeline;
+    std::unique_ptr<PipelineState> Pipeline;
 
     // FrameBuffer associated data for offscreen rendering.
     VkFramebuffer FrameBuffer = VK_NULL_HANDLE;
@@ -921,7 +921,7 @@ public:
     return Module;
   }
 
-  llvm::Expected<std::shared_ptr<PipelineState>>
+  llvm::Expected<std::unique_ptr<PipelineState>>
   createPipelineCs(llvm::StringRef Name, const BindingsDesc &BindingsDesc,
                    ShaderContainer CS) override {
     llvm::SmallVector<VkDescriptorSetLayout> SetLayouts;
@@ -992,11 +992,11 @@ public:
     // No longer need shader modules after pipeline compilation.
     vkDestroyShaderModule(Device, CSModule, nullptr);
 
-    return std::make_shared<VulkanPipelineState>(
+    return std::make_unique<VulkanPipelineState>(
         Name, Device, Pipeline, PipelineLayout, std::move(SetLayouts));
   }
 
-  llvm::Expected<std::shared_ptr<PipelineState>>
+  llvm::Expected<std::unique_ptr<PipelineState>>
   createPipelineVsPs(llvm::StringRef Name, const BindingsDesc &BindingsDesc,
                      llvm::ArrayRef<InputLayoutDesc> InputLayout,
                      llvm::ArrayRef<Format> RTFormats,
@@ -1222,7 +1222,7 @@ public:
     for (auto *M : ShaderModules)
       vkDestroyShaderModule(Device, M, nullptr);
 
-    return std::make_shared<VulkanPipelineState>(
+    return std::make_unique<VulkanPipelineState>(
         Name, Device, Pipeline, PipelineLayout, std::move(SetLayouts));
   }
 
@@ -2755,7 +2755,7 @@ public:
           createPipelineCs("Compute Pipeline State", BindingsDesc, CS);
       if (!PipelineStateOrErr)
         return PipelineStateOrErr.takeError();
-      State.Pipeline = *PipelineStateOrErr;
+      State.Pipeline = std::move(*PipelineStateOrErr);
       llvm::outs() << "Compute Pipeline created.\n";
     } else {
       ShaderContainer VS = {};
@@ -2799,7 +2799,7 @@ public:
           Format::D32FloatS8Uint, VS, PS);
       if (!PipelineStateOrErr)
         return PipelineStateOrErr.takeError();
-      State.Pipeline = *PipelineStateOrErr;
+      State.Pipeline = std::move(*PipelineStateOrErr);
       llvm::outs() << "Graphics Pipeline created.\n";
     }
 

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -1119,11 +1119,11 @@ public:
       assert(!Elem.InstanceStepRate &&
              "Instance step rate is currently not supported.");
 
-      const uint32_t ElemSize = getFormatSizeInBytes(Elem.Format);
+      const uint32_t ElemSize = getFormatSizeInBytes(Elem.Fmt);
       VkVertexInputAttributeDescription Attr = {};
       Attr.location = I;
       Attr.binding = 0;
-      Attr.format = getVulkanFormat(Elem.Format);
+      Attr.format = getVulkanFormat(Elem.Fmt);
       Attr.offset = Elem.OffsetInBytes;
       Attributes.push_back(Attr);
       Stride = std::max(Stride, Elem.OffsetInBytes + ElemSize);
@@ -2801,7 +2801,7 @@ public:
 
         InputLayoutDesc Desc = {};
         Desc.Name = Attr.Name;
-        Desc.Format = *FormatOrErr;
+        Desc.Fmt = *FormatOrErr;
         Desc.OffsetInBytes = Attr.Offset;
         InputLayout.push_back(Desc);
       }

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -579,8 +579,7 @@ public:
   VkDevice Dev;
   VkPipeline Pipeline;
   VkPipelineLayout Layout;
-  llvm::SmallVector<VkDescriptorSetLayout>
-      SetLayouts; // Do we need to keep these alive?
+  llvm::SmallVector<VkDescriptorSetLayout> SetLayouts;
 
   VulkanPipelineState(llvm::StringRef Name, VkDevice Dev, VkPipeline Pipeline,
                       VkPipelineLayout Layout,

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -2716,6 +2716,11 @@ public:
     for (auto &S : P.Sets) {
       DescriptorSetLayoutDesc Layout;
       for (auto &R : S.Resources) {
+        if (!R.VKBinding)
+          return llvm::createStringError(std::errc::invalid_argument,
+                                         "No VulkanBinding provided for '%s'",
+                                         R.Name.c_str());
+
         ResourceBindingDesc ResourceBinding = {};
         ResourceBinding.Kind = R.Kind;
         ResourceBinding.DXBinding.Register = R.DXBinding.Register;

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -962,8 +962,14 @@ public:
               SpecConst.ConstantID);
 
         VkSpecializationMapEntry Entry;
-        if (auto Err = parseSpecializationConstant(SpecConst, Entry, SpecData))
+        if (auto Err =
+                parseSpecializationConstant(SpecConst, Entry, SpecData)) {
+          vkDestroyShaderModule(Device, CSModule, nullptr);
+          vkDestroyPipelineLayout(Device, PipelineLayout, nullptr);
+          for (auto *L : SetLayouts)
+            vkDestroyDescriptorSetLayout(Device, L, nullptr);
           return Err;
+        }
         SpecEntries.push_back(Entry);
       }
       SpecInfo.mapEntryCount = SpecEntries.size();
@@ -1048,8 +1054,14 @@ public:
 
         VkSpecializationMapEntry Entry;
         if (auto Err =
-                parseSpecializationConstant(SpecConst, Entry, VSSpecData))
+                parseSpecializationConstant(SpecConst, Entry, VSSpecData)) {
+          for (auto *M : ShaderModules)
+            vkDestroyShaderModule(Device, M, nullptr);
+          vkDestroyPipelineLayout(Device, PipelineLayout, nullptr);
+          for (auto *L : SetLayouts)
+            vkDestroyDescriptorSetLayout(Device, L, nullptr);
           return Err;
+        }
         VSSpecEntries.push_back(Entry);
       }
       VSSpecInfo.mapEntryCount = VSSpecEntries.size();
@@ -1074,8 +1086,14 @@ public:
 
         VkSpecializationMapEntry Entry;
         if (auto Err =
-                parseSpecializationConstant(SpecConst, Entry, PSSpecData))
+                parseSpecializationConstant(SpecConst, Entry, PSSpecData)) {
+          for (auto *M : ShaderModules)
+            vkDestroyShaderModule(Device, M, nullptr);
+          vkDestroyPipelineLayout(Device, PipelineLayout, nullptr);
+          for (auto *L : SetLayouts)
+            vkDestroyDescriptorSetLayout(Device, L, nullptr);
           return Err;
+        }
         PSSpecEntries.push_back(Entry);
       }
       PSSpecInfo.mapEntryCount = PSSpecEntries.size();

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -1183,8 +1183,11 @@ public:
     DynRenderCI.colorAttachmentCount =
         static_cast<uint32_t>(ColorFormats.size());
     DynRenderCI.pColorAttachmentFormats = ColorFormats.data();
-    if (DSFormat)
+    if (DSFormat) {
       DynRenderCI.depthAttachmentFormat = getVulkanFormat(*DSFormat);
+      if (*DSFormat == Format::D32FloatS8Uint)
+        DynRenderCI.stencilAttachmentFormat = getVulkanFormat(*DSFormat);
+    }
 
     VkGraphicsPipelineCreateInfo PipelineCI = {};
     PipelineCI.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
@@ -2710,6 +2713,8 @@ public:
       for (auto &R : S.Resources) {
         ResourceBindingDesc ResourceBinding = {};
         ResourceBinding.Kind = R.Kind;
+        ResourceBinding.DXBinding.Register = R.DXBinding.Register;
+        ResourceBinding.DXBinding.Space = R.DXBinding.Space;
         ResourceBinding.VKBinding = R.VKBinding;
         ResourceBinding.DescriptorCount = R.getArraySize();
         Layout.ResourceBindings.push_back(ResourceBinding);


### PR DESCRIPTION
Add an API-agnostic way of creating compute and graphics pipelines. This includes the creation of pipeline layouts and root signatures. In Metal, there is no real equivalent due to the use of a top-level argument buffer, so the BindingsDesc variable is ignored.