### PR TITLE
Update matrix swizzle tests

### DIFF
--- a/test/Basic/Matrix/matrix_groupthread_swizzle_one_based.test
+++ b/test/Basic/Matrix/matrix_groupthread_swizzle_one_based.test
@@ -111,7 +111,8 @@ DescriptorSets:
 ...
 #--- end
 
-# UNSUPPORTED: Clang
+# XFAIL: Clang
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Basic/Matrix/matrix_groupthread_swizzle_one_based.test
+++ b/test/Basic/Matrix/matrix_groupthread_swizzle_one_based.test
@@ -111,6 +111,8 @@ DescriptorSets:
 ...
 #--- end
 
+# BUG Vulkan  https://github.com/llvm/llvm-project/issues/180258
+# Bug DirectX https://github.com/llvm/llvm-project/issues/180262
 # XFAIL: Clang
 
 # RUN: split-file %s %t

--- a/test/Basic/Matrix/matrix_groupthread_swizzle_one_based.test
+++ b/test/Basic/Matrix/matrix_groupthread_swizzle_one_based.test
@@ -112,8 +112,7 @@ DescriptorSets:
 #--- end
 
 # BUG Vulkan  https://github.com/llvm/llvm-project/issues/180258
-# Bug DirectX https://github.com/llvm/llvm-project/issues/180262
-# XFAIL: Clang
+# XFAIL: Vulkan && Clang
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl

--- a/test/Basic/Matrix/matrix_groupthread_swizzle_one_based.test
+++ b/test/Basic/Matrix/matrix_groupthread_swizzle_one_based.test
@@ -111,8 +111,11 @@ DescriptorSets:
 ...
 #--- end
 
-# BUG Vulkan  https://github.com/llvm/llvm-project/issues/180258
+# BUG https://github.com/llvm/llvm-project/issues/180258
 # XFAIL: Vulkan && Clang
+
+# BUG https://github.com/llvm/llvm-project/issues/191511
+# XFAIL: (Metal || DirectX) && Clang
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl

--- a/test/Basic/Matrix/matrix_groupthread_swizzle_zero_based.test
+++ b/test/Basic/Matrix/matrix_groupthread_swizzle_zero_based.test
@@ -111,7 +111,8 @@ DescriptorSets:
 ...
 #--- end
 
-# UNSUPPORTED: Clang
+# XFAIL: Clang
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Basic/Matrix/matrix_groupthread_swizzle_zero_based.test
+++ b/test/Basic/Matrix/matrix_groupthread_swizzle_zero_based.test
@@ -111,6 +111,8 @@ DescriptorSets:
 ...
 #--- end
 
+# BUG Vulkan  https://github.com/llvm/llvm-project/issues/180258
+# Bug DirectX https://github.com/llvm/llvm-project/issues/180262
 # XFAIL: Clang
 
 # RUN: split-file %s %t

--- a/test/Basic/Matrix/matrix_groupthread_swizzle_zero_based.test
+++ b/test/Basic/Matrix/matrix_groupthread_swizzle_zero_based.test
@@ -112,8 +112,7 @@ DescriptorSets:
 #--- end
 
 # BUG Vulkan  https://github.com/llvm/llvm-project/issues/180258
-# Bug DirectX https://github.com/llvm/llvm-project/issues/180262
-# XFAIL: Clang
+# XFAIL: Vulkan && Clang
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl

--- a/test/Basic/Matrix/matrix_groupthread_swizzle_zero_based.test
+++ b/test/Basic/Matrix/matrix_groupthread_swizzle_zero_based.test
@@ -114,6 +114,9 @@ DescriptorSets:
 # BUG Vulkan  https://github.com/llvm/llvm-project/issues/180258
 # XFAIL: Vulkan && Clang
 
+# BUG https://github.com/llvm/llvm-project/issues/191511
+# XFAIL: (Metal || DirectX) && Clang
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Basic/Matrix/matrix_m-based_getter.test
+++ b/test/Basic/Matrix/matrix_m-based_getter.test
@@ -1,44 +1,73 @@
 #--- source.hlsl
+RWBuffer<float>  In;
+RWBuffer<float>  OutScalar;
+RWBuffer<float2> OutVec2;
+RWBuffer<float3> OutVec3;
+RWBuffer<float4> OutVec4;
 
-RWBuffer<int> In : register(u0);
-RWBuffer<int> Out : register(u1);
+[numthreads(1,1,1)]
+void main() {
+  float3x4 m = float3x4(
+    In[0],  In[1],  In[2],  In[3],
+    In[4],  In[5],  In[6],  In[7],
+    In[8],  In[9],  In[10], In[11]
+  );
 
-[numthreads(4,1,1)]
-void main(uint GI : SV_GroupIndex) {
-  int2x2 A;
-  switch(GI) {
-    case 0:
-      A._m00 = In[GI];
-      break;
-    case 1:
-      A._m01 = In[GI];
-      break;
-    case 2:
-      A._m10 = In[GI];
-      break;
-    case 3:
-      A._m11 = In[GI];
-      break;
-  }
+    //--------------------------------------------------
+    // 1. Named element getters (_mXY)
+    //--------------------------------------------------
+    uint s = 0;
+    OutScalar[s++] = m._m00;
+    OutScalar[s++] = m._m01;
+    OutScalar[s++] = m._m02;
+    OutScalar[s++] = m._m03;
 
-  switch(GI) {
-    case 0:
-      Out[GI] = A._m00;
-      break;
-    case 1:
-      Out[GI] = A._m01;
-      break;
-    case 2:
-      Out[GI] = A._m10;
-      break;
-    case 3:
-      Out[GI] = A._m11;
-      break;
-  }
+    OutScalar[s++] = m._m10;
+    OutScalar[s++] = m._m11;
+    OutScalar[s++] = m._m12;
+    OutScalar[s++] = m._m13;
+
+    OutScalar[s++] = m._m20;
+    OutScalar[s++] = m._m21;
+    OutScalar[s++] = m._m22;
+    OutScalar[s++] = m._m23;
+
+    //--------------------------------------------------
+    // 2. float4 row swizzles
+    //--------------------------------------------------
+
+    OutVec4[0] = m._m00_m01_m02_m03;
+    OutVec4[1] = m._m10_m11_m12_m13;
+    OutVec4[2] = m._m20_m21_m22_m23;
+
+    OutVec4[3].wxyz = m._m00_m11_m22_m23;
+    OutVec4[4].gbra = m._m03_m12_m21_m03;
+
+    //--------------------------------------------------
+    // 3. float3 swizzles
+    //--------------------------------------------------
+
+    OutVec3[0] = m._m00_m01_m02;
+    OutVec3[1] = m._m10_m11_m12;
+    OutVec3[2] = m._m20_m21_m22;
+
+    //--------------------------------------------------
+    // 4. float2 swizzles
+    //--------------------------------------------------
+
+    OutVec2[0] = m._m00_m01;
+    OutVec2[1] = m._m02_m03;
+
+    OutVec2[2] = m._m10_m11;
+    OutVec2[3] = m._m12_m13;
+
+    OutVec2[4] = m._m20_m21;
+    OutVec2[5] = m._m22_m23;
+
+
 }
 
 //--- pipeline.yaml
-
 ---
 Shaders:
   - Stage: Compute
@@ -46,19 +75,80 @@ Shaders:
     DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
-    Format: Int32
-    Data: [ 1, 2, 3, 4]
-  - Name: Out
-    Format: Int32
-    FillSize: 16
-  - Name: ExpectedOut
-    Format: Int32
-    Data: [ 1, 2, 3, 4 ]
+    Format: Float32
+    Data: [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0 ]
+
+  #--------------------------------------------------
+  # Scalar output (12 floats)
+  #--------------------------------------------------
+  - Name: OutScalar
+    Format: Float32
+    FillSize: 48
+
+  - Name: ExpectedOutScalar
+    Format: Float32
+    Data: [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0 ]
+
+  #--------------------------------------------------
+  # float2 outputs
+  #--------------------------------------------------
+  - Name: OutVec2
+    Format: Float32
+    Channels: 2
+    FillSize: 48
+  - Name: ExpectedOutVec2
+    Format: Float32
+    Channels: 2
+    Data: [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0 ]
+
+  #--------------------------------------------------
+  # float3 outputs
+  #--------------------------------------------------
+  - Name: OutVec3
+    Format: Float32
+    Channels: 3
+    FillSize: 36
+  - Name: ExpectedOutVec3
+    Format: Float32
+    Channels: 3
+    Data: [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0 ]
+
+  #--------------------------------------------------
+  # float4 outputs
+  #--------------------------------------------------
+  - Name: OutVec4
+    Format: Float32
+    Channels: 4
+    FillSize: 80
+  - Name: ExpectedOutVec4
+    Format: Float32
+    Channels: 4
+    Data: [ 1.0, 2.0, 3.0, 4.0, 
+            5.0, 6.0, 7.0, 8.0, 
+            9.0, 10.0, 11.0, 12.0, 
+            6.0, 11.0, 12.0, 1.0, 
+            10.0, 4.0, 7.0, 4.0]
 Results:
-  - Result: Out
-    Rule: BufferExact
-    Actual: Out
-    Expected: ExpectedOut
+  - Result: CheckScalar
+    Rule: BufferFloatULP
+    ULPT: 0
+    Actual: OutScalar
+    Expected: ExpectedOutScalar
+  - Result: CheckVec2
+    Rule: BufferFloatULP
+    ULPT: 0
+    Actual: OutVec2
+    Expected: ExpectedOutVec2
+  - Result: CheckVec3
+    Rule: BufferFloatULP
+    ULPT: 0
+    Actual: OutVec3
+    Expected: ExpectedOutVec3
+  - Result: CheckVec4
+    Rule: BufferFloatULP
+    ULPT: 0
+    Actual: OutVec4
+    Expected: ExpectedOutVec4
 DescriptorSets:
   - Resources:
     - Name: In
@@ -68,17 +158,37 @@ DescriptorSets:
         Space: 0
       VulkanBinding:
         Binding: 0
-    - Name: Out
+    - Name: OutScalar
       Kind: RWBuffer
       DirectXBinding:
         Register: 1
         Space: 0
       VulkanBinding:
         Binding: 1
+    - Name: OutVec2
+      Kind: RWBuffer
+      DirectXBinding:
+        Register: 2
+        Space: 0
+      VulkanBinding:
+        Binding: 2
+    - Name: OutVec3
+      Kind: RWBuffer
+      DirectXBinding:
+        Register: 3
+        Space: 0
+      VulkanBinding:
+        Binding: 3
+    - Name: OutVec4
+      Kind: RWBuffer
+      DirectXBinding:
+        Register: 4
+        Space: 0
+      VulkanBinding:
+        Binding: 4
 ...
 #--- end
 
-# UNSUPPORTED: Clang
 # RUN: split-file %s %t
-# RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -T cs_6_0 -fvk-use-dx-layout -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Basic/Matrix/matrix_m-based_getter.test
+++ b/test/Basic/Matrix/matrix_m-based_getter.test
@@ -2,7 +2,6 @@
 RWBuffer<float>  In;
 RWBuffer<float>  OutScalar;
 RWBuffer<float2> OutVec2;
-RWBuffer<float3> OutVec3;
 RWBuffer<float4> OutVec4;
 
 [numthreads(1,1,1)]
@@ -40,17 +39,6 @@ void main() {
     OutVec4[1] = m._m10_m11_m12_m13;
     OutVec4[2] = m._m20_m21_m22_m23;
 
-    OutVec4[3].wxyz = m._m00_m11_m22_m23;
-    OutVec4[4].gbra = m._m03_m12_m21_m03;
-
-    //--------------------------------------------------
-    // 3. float3 swizzles
-    //--------------------------------------------------
-
-    OutVec3[0] = m._m00_m01_m02;
-    OutVec3[1] = m._m10_m11_m12;
-    OutVec3[2] = m._m20_m21_m22;
-
     //--------------------------------------------------
     // 4. float2 swizzles
     //--------------------------------------------------
@@ -63,8 +51,6 @@ void main() {
 
     OutVec2[4] = m._m20_m21;
     OutVec2[5] = m._m22_m23;
-
-
 }
 
 //--- pipeline.yaml
@@ -100,34 +86,19 @@ Buffers:
     Format: Float32
     Channels: 2
     Data: [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0 ]
-
-  #--------------------------------------------------
-  # float3 outputs
-  #--------------------------------------------------
-  - Name: OutVec3
-    Format: Float32
-    Channels: 3
-    FillSize: 36
-  - Name: ExpectedOutVec3
-    Format: Float32
-    Channels: 3
-    Data: [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0 ]
-
   #--------------------------------------------------
   # float4 outputs
   #--------------------------------------------------
   - Name: OutVec4
     Format: Float32
     Channels: 4
-    FillSize: 80
+    FillSize: 48
   - Name: ExpectedOutVec4
     Format: Float32
     Channels: 4
     Data: [ 1.0, 2.0, 3.0, 4.0, 
             5.0, 6.0, 7.0, 8.0, 
-            9.0, 10.0, 11.0, 12.0, 
-            6.0, 11.0, 12.0, 1.0, 
-            10.0, 4.0, 7.0, 4.0]
+            9.0, 10.0, 11.0, 12.0]
 Results:
   - Result: CheckScalar
     Rule: BufferFloatULP
@@ -139,11 +110,6 @@ Results:
     ULPT: 0
     Actual: OutVec2
     Expected: ExpectedOutVec2
-  - Result: CheckVec3
-    Rule: BufferFloatULP
-    ULPT: 0
-    Actual: OutVec3
-    Expected: ExpectedOutVec3
   - Result: CheckVec4
     Rule: BufferFloatULP
     ULPT: 0
@@ -172,20 +138,13 @@ DescriptorSets:
         Space: 0
       VulkanBinding:
         Binding: 2
-    - Name: OutVec3
+    - Name: OutVec4
       Kind: RWBuffer
       DirectXBinding:
         Register: 3
         Space: 0
       VulkanBinding:
         Binding: 3
-    - Name: OutVec4
-      Kind: RWBuffer
-      DirectXBinding:
-        Register: 4
-        Space: 0
-      VulkanBinding:
-        Binding: 4
 ...
 #--- end
 

--- a/test/Basic/Matrix/matrix_m-based_setter.test
+++ b/test/Basic/Matrix/matrix_m-based_setter.test
@@ -1,0 +1,217 @@
+#--- source.hlsl
+RWBuffer<float>  In;
+RWStructuredBuffer<float3x4> OutScalar;
+RWStructuredBuffer<float3x4> OutVec2;
+RWStructuredBuffer<float3x4> OutVec3;
+RWStructuredBuffer<float3x4> OutVec4;
+
+[numthreads(1,1,1)]
+void main() {
+
+  //--------------------------------------------------
+  // Start with an uninitialized matrix
+  //--------------------------------------------------
+  float3x4 m_init_scalar;
+  float3x4 m_init_vec4;
+  float3x4 m_init_vec3;
+  float3x4 m_init_vec2;
+
+  //--------------------------------------------------
+  // 1. Scalar setters (_m accessors, zero-based)
+  //--------------------------------------------------
+  uint i = 0;
+
+  m_init_scalar._m00 = In[i++];
+  m_init_scalar._m01 = In[i++];
+  m_init_scalar._m02 = In[i++];
+  m_init_scalar._m03 = In[i++];
+
+  m_init_scalar._m10 = In[i++];
+  m_init_scalar._m11 = In[i++];
+  m_init_scalar._m12 = In[i++];
+  m_init_scalar._m13 = In[i++];
+
+  m_init_scalar._m20 = In[i++];
+  m_init_scalar._m21 = In[i++];
+  m_init_scalar._m22 = In[i++];
+  m_init_scalar._m23 = In[i++];
+
+  //--------------------------------------------------
+  // 2. float4 row setters
+  //--------------------------------------------------
+
+  m_init_vec4._m00_m01_m02_m03 =
+      float4(m_init_scalar._m00,
+             m_init_scalar._m01,
+             m_init_scalar._m02,
+             m_init_scalar._m03);
+
+  m_init_vec4._m10_m11_m12_m13 =
+      float4(m_init_scalar._m10,
+             m_init_scalar._m11,
+             m_init_scalar._m12,
+             m_init_scalar._m13);
+
+  m_init_vec4._m20_m21_m22_m23 =
+      float4(m_init_scalar._m20,
+             m_init_scalar._m21,
+             m_init_scalar._m22,
+             m_init_scalar._m23);
+
+  //--------------------------------------------------
+  // 3. float3 setters
+  //--------------------------------------------------
+
+  m_init_vec3._m00_m01_m02 =
+      float3(m_init_scalar._m00,
+             m_init_scalar._m01,
+             m_init_scalar._m02);
+
+  m_init_vec3._m10_m11_m12 =
+      float3(m_init_scalar._m10,
+             m_init_scalar._m11,
+             m_init_scalar._m12);
+
+  m_init_vec3._m20_m21_m22 =
+      float3(m_init_scalar._m20,
+             m_init_scalar._m21,
+             m_init_scalar._m22);
+
+  m_init_vec3._m03_m13_m23 =
+      float3(m_init_scalar._m03,
+             m_init_scalar._m13,
+             m_init_scalar._m23);
+
+  //--------------------------------------------------
+  // 4. float2 setters
+  //--------------------------------------------------
+
+  m_init_vec2._m00_m01 =
+      float2(m_init_scalar._m00, m_init_scalar._m01);
+
+  m_init_vec2._m02_m03 =
+      float2(m_init_scalar._m02, m_init_scalar._m03);
+
+  m_init_vec2._m10_m11 =
+      float2(m_init_scalar._m10, m_init_scalar._m11);
+
+  m_init_vec2._m12_m13 =
+      float2(m_init_scalar._m12, m_init_scalar._m13);
+
+  m_init_vec2._m20_m21 =
+      float2(m_init_scalar._m20, m_init_scalar._m21);
+
+  m_init_vec2._m22_m23 =
+      float2(m_init_scalar._m22, m_init_scalar._m23);
+
+  //--------------------------------------------------
+  // Read back results (verification)
+  //--------------------------------------------------
+  OutScalar[0] = m_init_scalar;
+  OutVec2[0]   = m_init_vec2;
+  OutVec3[0]   = m_init_vec3;
+  OutVec4[0]   = m_init_vec4;
+}
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+    DispatchSize: [1, 1, 1]
+Buffers:
+  - Name: In
+    Format: Float32
+    Data: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+  - Name: OutScalar
+    Format: Float32
+    Stride: 48
+    FillSize: 48
+  - Name: ExpectedOutScalar
+    Format: Float32
+    Stride: 48
+    Data: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+  - Name: OutVec2
+    Format: Float32
+    Stride: 48
+    FillSize: 48
+  - Name: ExpectedOutVec2
+    Format: Float32
+    Stride: 48
+    Data: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+  - Name: OutVec3
+    Format: Float32
+    Stride: 48
+    FillSize: 48
+  - Name: ExpectedOutVec3
+    Format: Float32
+    Stride: 48
+    Data: [1, 2, 3, 0, 5, 6, 7, 0, 9, 10, 11, 0]
+  - Name: OutVec4
+    Format: Float32
+    Stride: 48
+    FillSize: 48
+  - Name: ExpectedOutVec4
+    Format: Float32
+    Stride: 48
+    Data: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+Results:
+  - Result: OutScalar
+    Rule: BufferExact
+    Actual: OutScalar
+    Expected: ExpectedOutScalar
+  - Result: OutVec2
+    Rule: BufferExact
+    Actual: OutVec2
+    Expected: ExpectedOutVec2
+  - Result: OutVec3
+    Rule: BufferExact
+    Actual: OutVec3
+    Expected: ExpectedOutVec3
+  - Result: OutVec4
+    Rule: BufferExact
+    Actual: OutVec4
+    Expected: ExpectedOutVec4
+DescriptorSets:
+  - Resources:
+    - Name: In
+      Kind: RWBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: OutScalar
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+    - Name: OutVec2
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 2
+        Space: 0
+      VulkanBinding:
+        Binding: 2
+    - Name: OutVec3
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 3
+        Space: 0
+      VulkanBinding:
+        Binding: 3
+    - Name: OutVec4
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 4
+        Space: 0
+      VulkanBinding:
+        Binding: 4
+...
+#--- end
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_0 -fvk-use-dx-layout -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Basic/Matrix/matrix_m-based_setter.test
+++ b/test/Basic/Matrix/matrix_m-based_setter.test
@@ -81,6 +81,7 @@ void main() {
       float3(m_init_scalar._m03,
              m_init_scalar._m13,
              m_init_scalar._m23);
+  
 
   //--------------------------------------------------
   // 4. float2 setters
@@ -130,7 +131,7 @@ Buffers:
   - Name: ExpectedOutScalar
     Format: Float32
     Stride: 48
-    Data: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+    Data: [ 1, 5, 9, 2, 6, 10, 3, 7, 11, 4, 8, 12 ]
   - Name: OutVec2
     Format: Float32
     Stride: 48
@@ -138,7 +139,7 @@ Buffers:
   - Name: ExpectedOutVec2
     Format: Float32
     Stride: 48
-    Data: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+    Data: [ 1, 5, 9, 2, 6, 10, 3, 7, 11, 4, 8, 12 ]
   - Name: OutVec3
     Format: Float32
     Stride: 48
@@ -146,7 +147,7 @@ Buffers:
   - Name: ExpectedOutVec3
     Format: Float32
     Stride: 48
-    Data: [1, 2, 3, 0, 5, 6, 7, 0, 9, 10, 11, 0]
+    Data: [ 1, 5, 9, 2, 6, 10, 3, 7, 11, 4, 8, 12 ]
   - Name: OutVec4
     Format: Float32
     Stride: 48
@@ -154,7 +155,7 @@ Buffers:
   - Name: ExpectedOutVec4
     Format: Float32
     Stride: 48
-    Data: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+    Data: [ 1, 5, 9, 2, 6, 10, 3, 7, 11, 4, 8, 12 ]
 Results:
   - Result: OutScalar
     Rule: BufferExact

--- a/test/Basic/Matrix/matrix_m-based_swizzle_getter.test
+++ b/test/Basic/Matrix/matrix_m-based_swizzle_getter.test
@@ -1,7 +1,5 @@
 #--- source.hlsl
-
 RWBuffer<float>  In;
-RWBuffer<float>  OutScalar;
 RWBuffer<float2> OutVec2;
 RWBuffer<float4> OutVec4;
 
@@ -14,46 +12,33 @@ void main() {
   );
 
   //--------------------------------------------------
-  // 1. Named element getters (one-based)
-  //--------------------------------------------------
-  uint s = 0;
-  OutScalar[s++] = m._11;
-  OutScalar[s++] = m._12;
-  OutScalar[s++] = m._13;
-  OutScalar[s++] = m._14;
-
-  OutScalar[s++] = m._21;
-  OutScalar[s++] = m._22;
-  OutScalar[s++] = m._23;
-  OutScalar[s++] = m._24;
-
-  OutScalar[s++] = m._31;
-  OutScalar[s++] = m._32;
-  OutScalar[s++] = m._33;
-  OutScalar[s++] = m._34;
-
-  //--------------------------------------------------
-  // 2. float4 row swizzles
+  // 1. float4 row swizzles assignments
   //--------------------------------------------------
 
-  OutVec4[0] = m._11_12_13_14;
-  OutVec4[1] = m._21_22_23_24;
-  OutVec4[2] = m._31_32_33_34;
+  // Row 0
+  OutVec4[0].wxzy = m._m00_m01_m02_m03;
+
+  // Row 1 (reverse order write)
+  OutVec4[1].wzyx = m._m10_m11_m12_m13;
+
+  // Row 2 (rotated write)
+  OutVec4[2].yzwx = m._m20_m21_m22_m23;
 
   //--------------------------------------------------
-  // 4. float2 swizzles
+  // 2. float2 swizzles assignments
   //--------------------------------------------------
 
-  OutVec2[0] = m._11_12;
-  OutVec2[1] = m._13_14;
+  OutVec2[0].xy = m._m00_m01;
+  OutVec2[1].yx = m._m02_m03;
 
-  OutVec2[2] = m._21_22;
-  OutVec2[3] = m._23_24;
+  // Second row
+  OutVec2[2].yx = m._m10_m11;
+  OutVec2[3].xy = m._m12_m13;
 
-  OutVec2[4] = m._31_32;
-  OutVec2[5] = m._33_34;
+  // Third row
+  OutVec2[4].rg = m._m20_m21;
+  OutVec2[5].gr = m._m22_m23;
 }
-
 //--- pipeline.yaml
 ---
 Shaders:
@@ -64,18 +49,6 @@ Buffers:
   - Name: In
     Format: Float32
     Data: [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0 ]
-
-  #--------------------------------------------------
-  # Scalar output (12 floats)
-  #--------------------------------------------------
-  - Name: OutScalar
-    Format: Float32
-    FillSize: 48
-
-  - Name: ExpectedOutScalar
-    Format: Float32
-    Data: [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0 ]
-
   #--------------------------------------------------
   # float2 outputs
   #--------------------------------------------------
@@ -86,7 +59,7 @@ Buffers:
   - Name: ExpectedOutVec2
     Format: Float32
     Channels: 2
-    Data: [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0 ]
+    Data: [ 1, 2, 4, 3, 6, 5, 7, 8, 9, 10, 12, 11 ]
   #--------------------------------------------------
   # float4 outputs
   #--------------------------------------------------
@@ -97,13 +70,8 @@ Buffers:
   - Name: ExpectedOutVec4
     Format: Float32
     Channels: 4
-    Data: [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0 ]
+    Data: [ 2, 4, 3, 1, 8, 7, 6, 5, 12, 9, 10, 11 ]
 Results:
-  - Result: CheckScalar
-    Rule: BufferFloatULP
-    ULPT: 0
-    Actual: OutScalar
-    Expected: ExpectedOutScalar
   - Result: CheckVec2
     Rule: BufferFloatULP
     ULPT: 0
@@ -123,29 +91,25 @@ DescriptorSets:
         Space: 0
       VulkanBinding:
         Binding: 0
-    - Name: OutScalar
+    - Name: OutVec2
       Kind: RWBuffer
       DirectXBinding:
         Register: 1
         Space: 0
       VulkanBinding:
         Binding: 1
-    - Name: OutVec2
+    - Name: OutVec4
       Kind: RWBuffer
       DirectXBinding:
         Register: 2
         Space: 0
       VulkanBinding:
         Binding: 2
-    - Name: OutVec4
-      Kind: RWBuffer
-      DirectXBinding:
-        Register: 3
-        Space: 0
-      VulkanBinding:
-        Binding: 3
 ...
 #--- end
+
+# BUG Vulkan  https://github.com/llvm/llvm-project/issues/180258
+# XFAIL: Vulkan && Clang
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -fvk-use-dx-layout -Fo %t.o %t/source.hlsl

--- a/test/Basic/Matrix/matrix_one-based_getter.test
+++ b/test/Basic/Matrix/matrix_one-based_getter.test
@@ -1,46 +1,69 @@
 #--- source.hlsl
 
-RWBuffer<int> In : register(u0);
-RWBuffer<int> Out : register(u1);
+RWBuffer<float>  In;
+RWBuffer<float>  OutScalar;
+RWBuffer<float2> OutVec2;
+RWBuffer<float3> OutVec3;
+RWBuffer<float4> OutVec4;
 
-[numthreads(4,1,1)]
-void main(uint GI : SV_GroupIndex) {
-  int2x2 A;
-  switch(GI) {
-    case 0:
-      A._11 = In[GI];
-      break;
-    case 1:
-      A._12 = In[GI];
-      break;
-    case 2:
-      A._21 = In[GI];
-      break;
-    case 3:
-      A._22 = In[GI];
-      break;
+[numthreads(1,1,1)]
+void main() {
+  float3x4 m = float3x4(
+    In[0],  In[1],  In[2],  In[3],
+    In[4],  In[5],  In[6],  In[7],
+    In[8],  In[9],  In[10], In[11]
+  );
 
-  }
+  //--------------------------------------------------
+  // 1. Named element getters (one-based)
+  //--------------------------------------------------
+  uint s = 0;
+  OutScalar[s++] = m._11;
+  OutScalar[s++] = m._12;
+  OutScalar[s++] = m._13;
+  OutScalar[s++] = m._14;
 
-  switch(GI) {
-    case 0:
-      Out[GI] = A._11;
-      break;
-    case 1:
-      Out[GI] = A._12;
-      break;
-    case 2:
-      Out[GI] = A._21;
-      break;
-    case 3:
-      Out[GI] = A._22;
-      break;
+  OutScalar[s++] = m._21;
+  OutScalar[s++] = m._22;
+  OutScalar[s++] = m._23;
+  OutScalar[s++] = m._24;
 
-  }
+  OutScalar[s++] = m._31;
+  OutScalar[s++] = m._32;
+  OutScalar[s++] = m._33;
+  OutScalar[s++] = m._34;
+
+  //--------------------------------------------------
+  // 2. float4 row swizzles
+  //--------------------------------------------------
+
+  OutVec4[0] = m._11_12_13_14;
+  OutVec4[1] = m._21_22_23_24;
+  OutVec4[2] = m._31_32_33_34;
+
+  //--------------------------------------------------
+  // 3. float3 swizzles
+  //--------------------------------------------------
+
+  OutVec3[0] = m._11_12_13;
+  OutVec3[1] = m._21_22_23;
+  OutVec3[2] = m._31_32_33;
+
+  //--------------------------------------------------
+  // 4. float2 swizzles
+  //--------------------------------------------------
+
+  OutVec2[0] = m._11_12;
+  OutVec2[1] = m._13_14;
+
+  OutVec2[2] = m._21_22;
+  OutVec2[3] = m._23_24;
+
+  OutVec2[4] = m._31_32;
+  OutVec2[5] = m._33_34;
 }
 
 //--- pipeline.yaml
-
 ---
 Shaders:
   - Stage: Compute
@@ -48,19 +71,76 @@ Shaders:
     DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
-    Format: Int32
-    Data: [ 1, 2, 3, 4]
-  - Name: Out
-    Format: Int32
-    FillSize: 16
-  - Name: ExpectedOut
-    Format: Int32
-    Data: [ 1, 2, 3, 4 ]
+    Format: Float32
+    Data: [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0 ]
+
+  #--------------------------------------------------
+  # Scalar output (12 floats)
+  #--------------------------------------------------
+  - Name: OutScalar
+    Format: Float32
+    FillSize: 48
+
+  - Name: ExpectedOutScalar
+    Format: Float32
+    Data: [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0 ]
+
+  #--------------------------------------------------
+  # float2 outputs
+  #--------------------------------------------------
+  - Name: OutVec2
+    Format: Float32
+    Channels: 2
+    FillSize: 48
+  - Name: ExpectedOutVec2
+    Format: Float32
+    Channels: 2
+    Data: [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0 ]
+
+  #--------------------------------------------------
+  # float3 outputs
+  #--------------------------------------------------
+  - Name: OutVec3
+    Format: Float32
+    Channels: 3
+    FillSize: 36
+  - Name: ExpectedOutVec3
+    Format: Float32
+    Channels: 3
+    Data: [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0 ]
+
+  #--------------------------------------------------
+  # float4 outputs
+  #--------------------------------------------------
+  - Name: OutVec4
+    Format: Float32
+    Channels: 4
+    FillSize: 48
+  - Name: ExpectedOutVec4
+    Format: Float32
+    Channels: 4
+    Data: [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0 ]
 Results:
-  - Result: Out
-    Rule: BufferExact
-    Actual: Out
-    Expected: ExpectedOut
+  - Result: CheckScalar
+    Rule: BufferFloatULP
+    ULPT: 0
+    Actual: OutScalar
+    Expected: ExpectedOutScalar
+  - Result: CheckVec2
+    Rule: BufferFloatULP
+    ULPT: 0
+    Actual: OutVec2
+    Expected: ExpectedOutVec2
+  - Result: CheckVec3
+    Rule: BufferFloatULP
+    ULPT: 0
+    Actual: OutVec3
+    Expected: ExpectedOutVec3
+  - Result: CheckVec4
+    Rule: BufferFloatULP
+    ULPT: 0
+    Actual: OutVec4
+    Expected: ExpectedOutVec4
 DescriptorSets:
   - Resources:
     - Name: In
@@ -70,17 +150,37 @@ DescriptorSets:
         Space: 0
       VulkanBinding:
         Binding: 0
-    - Name: Out
+    - Name: OutScalar
       Kind: RWBuffer
       DirectXBinding:
         Register: 1
         Space: 0
       VulkanBinding:
         Binding: 1
+    - Name: OutVec2
+      Kind: RWBuffer
+      DirectXBinding:
+        Register: 2
+        Space: 0
+      VulkanBinding:
+        Binding: 2
+    - Name: OutVec3
+      Kind: RWBuffer
+      DirectXBinding:
+        Register: 3
+        Space: 0
+      VulkanBinding:
+        Binding: 3
+    - Name: OutVec4
+      Kind: RWBuffer
+      DirectXBinding:
+        Register: 4
+        Space: 0
+      VulkanBinding:
+        Binding: 4
 ...
 #--- end
 
-# UNSUPPORTED: Clang
 # RUN: split-file %s %t
-# RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -T cs_6_0 -fvk-use-dx-layout -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Basic/Matrix/matrix_one-based_setter.test
+++ b/test/Basic/Matrix/matrix_one-based_setter.test
@@ -92,7 +92,7 @@ Buffers:
   - Name: ExpectedOutScalar
     Format: Float32
     Stride: 48
-    Data: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+    Data: [ 1, 5, 9, 2, 6, 10, 3, 7, 11, 4, 8, 12 ]
   - Name: OutVec2
     Format: Float32
     Stride: 48
@@ -100,7 +100,7 @@ Buffers:
   - Name: ExpectedOutVec2
     Format: Float32
     Stride: 48
-    Data: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+    Data: [ 1, 5, 9, 2, 6, 10, 3, 7, 11, 4, 8, 12 ]
   - Name: OutVec3
     Format: Float32
     Stride: 48
@@ -108,7 +108,7 @@ Buffers:
   - Name: ExpectedOutVec3
     Format: Float32
     Stride: 48
-    Data: [1, 2, 3, 0, 5, 6, 7, 0, 9, 10, 11, 0]
+    Data: [ 1, 5, 9, 2, 6, 10, 3, 7, 11, 4, 8, 12 ]
   - Name: OutVec4
     Format: Float32
     Stride: 48
@@ -116,7 +116,7 @@ Buffers:
   - Name: ExpectedOutVec4
     Format: Float32
     Stride: 48
-    Data: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+    Data: [ 1, 5, 9, 2, 6, 10, 3, 7, 11, 4, 8, 12 ]
 Results:
   - Result: OutScalar
     Rule: BufferExact

--- a/test/Basic/Matrix/matrix_one-based_setter.test
+++ b/test/Basic/Matrix/matrix_one-based_setter.test
@@ -1,0 +1,179 @@
+#--- source.hlsl
+RWBuffer<float>  In;
+RWStructuredBuffer<float3x4> OutScalar;
+RWStructuredBuffer<float3x4> OutVec2;
+RWStructuredBuffer<float3x4> OutVec3;
+RWStructuredBuffer<float3x4> OutVec4;
+
+[numthreads(1,1,1)]
+void main() {
+
+  //--------------------------------------------------
+  // Start with an uninitialized matrix
+  //--------------------------------------------------
+  float3x4 m_init_scalar;
+  float3x4 m_init_vec4;
+  float3x4 m_init_vec3;
+  float3x4 m_init_vec2;
+
+  //--------------------------------------------------
+  // 1. Scalar setters (one-based accessors)
+  //--------------------------------------------------
+  uint i = 0;
+
+  m_init_scalar._11 = In[i++];
+  m_init_scalar._12 = In[i++];
+  m_init_scalar._13 = In[i++];
+  m_init_scalar._14 = In[i++];
+
+  m_init_scalar._21 = In[i++];
+  m_init_scalar._22 = In[i++];
+  m_init_scalar._23 = In[i++];
+  m_init_scalar._24 = In[i++];
+
+  m_init_scalar._31 = In[i++];
+  m_init_scalar._32 = In[i++];
+  m_init_scalar._33 = In[i++];
+  m_init_scalar._34 = In[i++];
+
+  //--------------------------------------------------
+  // 2. float4 row setters
+  //--------------------------------------------------
+
+  m_init_vec4._11_12_13_14 = float4(m_init_scalar._11, m_init_scalar._12, m_init_scalar._13, m_init_scalar._14);
+  m_init_vec4._21_22_23_24 = float4(m_init_scalar._21, m_init_scalar._22, m_init_scalar._23, m_init_scalar._24);
+  m_init_vec4._31_32_33_34 = float4(m_init_scalar._31, m_init_scalar._32, m_init_scalar._33, m_init_scalar._34);
+
+  //--------------------------------------------------
+  // 3. float3 setters
+  //--------------------------------------------------
+
+  m_init_vec3._11_12_13 = float3(m_init_scalar._11, m_init_scalar._12, m_init_scalar._13);
+  m_init_vec3._21_22_23 = float3(m_init_scalar._21, m_init_scalar._22, m_init_scalar._23);
+  m_init_vec3._31_32_33 = float3(m_init_scalar._31, m_init_scalar._32, m_init_scalar._33);
+  m_init_vec3._14_24_34 = float3(m_init_scalar._14, m_init_scalar._24, m_init_scalar._34);
+
+  //--------------------------------------------------
+  // 4. float2 setters
+  //--------------------------------------------------
+
+  m_init_vec2._11_12 = float2(m_init_scalar._11, m_init_scalar._12);
+  m_init_vec2._13_14 = float2(m_init_scalar._13, m_init_scalar._14);
+
+  m_init_vec2._21_22 = float2(m_init_scalar._21, m_init_scalar._22);
+  m_init_vec2._23_24 = float2(m_init_scalar._23, m_init_scalar._24);
+
+  m_init_vec2._31_32 = float2(m_init_scalar._31, m_init_scalar._32);
+  m_init_vec2._33_34 = float2(m_init_scalar._33, m_init_scalar._34);
+
+  //--------------------------------------------------
+  // Read back results (verification)
+  //--------------------------------------------------
+  OutScalar[0] = m_init_scalar;
+  OutVec2[0] =  m_init_vec2;
+  OutVec3[0] =  m_init_vec3;
+  OutVec4[0] =  m_init_vec4;
+}
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+    DispatchSize: [1, 1, 1]
+Buffers:
+  - Name: In
+    Format: Float32
+    Data: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+  - Name: OutScalar
+    Format: Float32
+    Stride: 48
+    FillSize: 48
+  - Name: ExpectedOutScalar
+    Format: Float32
+    Stride: 48
+    Data: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+  - Name: OutVec2
+    Format: Float32
+    Stride: 48
+    FillSize: 48
+  - Name: ExpectedOutVec2
+    Format: Float32
+    Stride: 48
+    Data: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+  - Name: OutVec3
+    Format: Float32
+    Stride: 48
+    FillSize: 48
+  - Name: ExpectedOutVec3
+    Format: Float32
+    Stride: 48
+    Data: [1, 2, 3, 0, 5, 6, 7, 0, 9, 10, 11, 0]
+  - Name: OutVec4
+    Format: Float32
+    Stride: 48
+    FillSize: 48
+  - Name: ExpectedOutVec4
+    Format: Float32
+    Stride: 48
+    Data: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+Results:
+  - Result: OutScalar
+    Rule: BufferExact
+    Actual: OutScalar
+    Expected: ExpectedOutScalar
+  - Result: OutVec2
+    Rule: BufferExact
+    Actual: OutVec2
+    Expected: ExpectedOutVec2
+  - Result: OutVec3
+    Rule: BufferExact
+    Actual: OutVec3
+    Expected: ExpectedOutVec3
+  - Result: OutVec4
+    Rule: BufferExact
+    Actual: OutVec4
+    Expected: ExpectedOutVec4
+DescriptorSets:
+  - Resources:
+    - Name: In
+      Kind: RWBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: OutScalar
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+    - Name: OutVec2
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 2
+        Space: 0
+      VulkanBinding:
+        Binding: 2
+    - Name: OutVec3
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 3
+        Space: 0
+      VulkanBinding:
+        Binding: 3
+    - Name: OutVec4
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 4
+        Space: 0
+      VulkanBinding:
+        Binding: 4
+...
+#--- end
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_0 -fvk-use-dx-layout -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Basic/Matrix/matrix_one-based_swizzle_getter.test
+++ b/test/Basic/Matrix/matrix_one-based_swizzle_getter.test
@@ -1,7 +1,5 @@
 #--- source.hlsl
-
 RWBuffer<float>  In;
-RWBuffer<float>  OutScalar;
 RWBuffer<float2> OutVec2;
 RWBuffer<float4> OutVec4;
 
@@ -14,46 +12,25 @@ void main() {
   );
 
   //--------------------------------------------------
-  // 1. Named element getters (one-based)
+  // 1. float4 row swizzles assignments
   //--------------------------------------------------
-  uint s = 0;
-  OutScalar[s++] = m._11;
-  OutScalar[s++] = m._12;
-  OutScalar[s++] = m._13;
-  OutScalar[s++] = m._14;
-
-  OutScalar[s++] = m._21;
-  OutScalar[s++] = m._22;
-  OutScalar[s++] = m._23;
-  OutScalar[s++] = m._24;
-
-  OutScalar[s++] = m._31;
-  OutScalar[s++] = m._32;
-  OutScalar[s++] = m._33;
-  OutScalar[s++] = m._34;
+  OutVec4[0].wyzx = m._11_14_13_12;
+  OutVec4[1].zwyx = m._22_21_23_24;
+  OutVec4[2].yzwx = m._31_32_33_34;
 
   //--------------------------------------------------
-  // 2. float4 row swizzles
+  // 2. float2 swizzles assignments
   //--------------------------------------------------
 
-  OutVec4[0] = m._11_12_13_14;
-  OutVec4[1] = m._21_22_23_24;
-  OutVec4[2] = m._31_32_33_34;
+  OutVec2[0].xy = m._11_12;
+  OutVec2[1].yx = m._13_14;
 
-  //--------------------------------------------------
-  // 4. float2 swizzles
-  //--------------------------------------------------
+  OutVec2[2].yx = m._21_22;
+  OutVec2[3].xy = m._23_24;
 
-  OutVec2[0] = m._11_12;
-  OutVec2[1] = m._13_14;
-
-  OutVec2[2] = m._21_22;
-  OutVec2[3] = m._23_24;
-
-  OutVec2[4] = m._31_32;
-  OutVec2[5] = m._33_34;
+  OutVec2[4].rg = m._31_32;
+  OutVec2[5].gr = m._33_34;
 }
-
 //--- pipeline.yaml
 ---
 Shaders:
@@ -64,18 +41,6 @@ Buffers:
   - Name: In
     Format: Float32
     Data: [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0 ]
-
-  #--------------------------------------------------
-  # Scalar output (12 floats)
-  #--------------------------------------------------
-  - Name: OutScalar
-    Format: Float32
-    FillSize: 48
-
-  - Name: ExpectedOutScalar
-    Format: Float32
-    Data: [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0 ]
-
   #--------------------------------------------------
   # float2 outputs
   #--------------------------------------------------
@@ -86,7 +51,7 @@ Buffers:
   - Name: ExpectedOutVec2
     Format: Float32
     Channels: 2
-    Data: [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0 ]
+    Data: [ 1, 2, 4, 3, 6, 5, 7, 8, 9, 10, 12, 11 ]
   #--------------------------------------------------
   # float4 outputs
   #--------------------------------------------------
@@ -97,13 +62,8 @@ Buffers:
   - Name: ExpectedOutVec4
     Format: Float32
     Channels: 4
-    Data: [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0 ]
+    Data: [ 2, 4, 3, 1, 8, 7, 6, 5, 12, 9, 10, 11 ]
 Results:
-  - Result: CheckScalar
-    Rule: BufferFloatULP
-    ULPT: 0
-    Actual: OutScalar
-    Expected: ExpectedOutScalar
   - Result: CheckVec2
     Rule: BufferFloatULP
     ULPT: 0
@@ -123,29 +83,25 @@ DescriptorSets:
         Space: 0
       VulkanBinding:
         Binding: 0
-    - Name: OutScalar
+    - Name: OutVec2
       Kind: RWBuffer
       DirectXBinding:
         Register: 1
         Space: 0
       VulkanBinding:
         Binding: 1
-    - Name: OutVec2
+    - Name: OutVec4
       Kind: RWBuffer
       DirectXBinding:
         Register: 2
         Space: 0
       VulkanBinding:
         Binding: 2
-    - Name: OutVec4
-      Kind: RWBuffer
-      DirectXBinding:
-        Register: 3
-        Space: 0
-      VulkanBinding:
-        Binding: 3
 ...
 #--- end
+
+# BUG Vulkan  https://github.com/llvm/llvm-project/issues/180258
+# XFAIL: Vulkan && Clang
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -fvk-use-dx-layout -Fo %t.o %t/source.hlsl

--- a/test/Basic/Matrix/matrix_swizzle_one_based.test
+++ b/test/Basic/Matrix/matrix_swizzle_one_based.test
@@ -1,0 +1,119 @@
+#--- source.hlsl
+
+RWBuffer<int> In : register(u0);
+RWBuffer<int> RowOut : register(u1);
+RWBuffer<int> ColOut : register(u2);
+
+[numthreads(1,1,1)]
+void main() {
+  for(int I = 0; I < 4; I++) {
+    int4x4 A;
+    int4x4 B;
+    switch(I) {
+      case 0:
+        A._11_12_13_14 = In[I].xxxx;
+        B._11_21_31_41 = In[I].xxxx;
+        break;
+      case 1:
+        A._21_22_23_24 = In[I].xxxx;
+        B._12_22_32_42 = In[I].xxxx;
+        break;
+      case 2:
+        A._31_32_33_34 = In[I].xxxx;
+        B._13_23_33_43 = In[I].xxxx;
+        break;
+      case 3:
+        A._41_42_43_44 = In[I].xxxx;
+        B._14_24_34_44 = In[I].xxxx;
+        break;
+
+    }
+    int4 vec1;
+    int4 vec2;
+    switch(I) {
+      case 0:
+        vec1 = A._11_12_13_14;
+        vec2 = B._11_21_31_41;
+        break;
+      case 1:
+        vec1 = A._21_22_23_24;
+        vec2 = B._12_22_32_42;
+        break;
+      case 2:
+        vec1 = A._31_32_33_34;
+        vec2 = B._13_23_33_43;
+        break;
+      case 3:
+        vec1 = A._41_42_43_44;
+        vec2 = B._14_24_34_44;
+        break;
+    }
+    for(int VI = 0; VI < 4; VI++) {
+      RowOut[I*4+VI] = vec1[VI];
+      ColOut[VI*4+I] = vec2[VI];
+    }
+  }
+}
+
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+    DispatchSize: [1, 1, 1]
+Buffers:
+  - Name: In
+    Format: Int32
+    Data: [ 1, 2, 3, 4]
+  - Name: RowOut
+    Format: Int32
+    FillSize: 64
+  - Name: ColOut
+    Format: Int32
+    FillSize: 64
+  - Name: ExpectedRowOut
+    Format: Int32
+    Data: [ 1,1,1,1, 2,2,2,2, 3,3,3,3, 4,4,4,4 ]
+  - Name: ExpectedColOut
+    Format: Int32
+    Data: [ 1,2,3,4, 1,2,3,4, 1,2,3,4, 1,2,3,4 ]
+Results:
+  - Result: RowOut
+    Rule: BufferExact
+    Actual: RowOut
+    Expected: ExpectedRowOut
+  - Result: ColOut
+    Rule: BufferExact
+    Actual: ColOut
+    Expected: ExpectedColOut
+DescriptorSets:
+  - Resources:
+    - Name: In
+      Kind: RWBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: RowOut
+      Kind: RWBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+    - Name: ColOut
+      Kind: RWBuffer
+      DirectXBinding:
+        Register: 2
+        Space: 0
+      VulkanBinding:
+        Binding: 2
+...
+#--- end
+
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Basic/Matrix/matrix_swizzle_zero_based.test
+++ b/test/Basic/Matrix/matrix_swizzle_zero_based.test
@@ -1,0 +1,119 @@
+#--- source.hlsl
+
+RWBuffer<int> In : register(u0);
+RWBuffer<int> RowOut : register(u1);
+RWBuffer<int> ColOut : register(u2);
+
+[numthreads(1,1,1)]
+void main() {
+  for(int I = 0; I < 4; I++) {
+    int4x4 A;
+    int4x4 B;
+    switch(I) {
+      case 0:
+        A._m00_m01_m02_m03 = In[I].xxxx;
+        B._m00_m10_m20_m30 = In[I].xxxx;
+        break;
+      case 1:
+        A._m10_m11_m12_m13 = In[I].xxxx;
+        B._m01_m11_m21_m31 = In[I].xxxx;
+        break;
+      case 2:
+        A._m20_m21_m22_m23 = In[I].xxxx;
+        B._m02_m12_m22_m32 = In[I].xxxx;
+        break;
+      case 3:
+        A._m30_m31_m32_m33 = In[I].xxxx;
+        B._m03_m13_m23_m33 = In[I].xxxx;
+        break;
+
+    }
+    int4 vec1;
+    int4 vec2;
+    switch(I) {
+      case 0:
+        vec1 = A._m00_m01_m02_m03;
+        vec2 = B._m00_m10_m20_m30;
+        break;
+      case 1:
+        vec1 = A._m10_m11_m12_m13;
+        vec2 = B._m01_m11_m21_m31;
+        break;
+      case 2:
+        vec1 = A._m20_m21_m22_m23;
+        vec2 = B._m02_m12_m22_m32;
+        break;
+      case 3:
+        vec1 = A._m30_m31_m32_m33;
+        vec2 = B._m03_m13_m23_m33;
+        break;
+    }
+    for(int VI = 0; VI < 4; VI++) {
+      RowOut[I*4+VI] = vec1[VI];
+      ColOut[VI*4+I] = vec2[VI];
+    }
+  }
+}
+
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+    DispatchSize: [1, 1, 1]
+Buffers:
+  - Name: In
+    Format: Int32
+    Data: [ 1, 2, 3, 4]
+  - Name: RowOut
+    Format: Int32
+    FillSize: 64
+  - Name: ColOut
+    Format: Int32
+    FillSize: 64
+  - Name: ExpectedRowOut
+    Format: Int32
+    Data: [ 1,1,1,1, 2,2,2,2, 3,3,3,3, 4,4,4,4 ]
+  - Name: ExpectedColOut
+    Format: Int32
+    Data: [ 1,2,3,4, 1,2,3,4, 1,2,3,4, 1,2,3,4 ]
+Results:
+  - Result: RowOut
+    Rule: BufferExact
+    Actual: RowOut
+    Expected: ExpectedRowOut
+  - Result: ColOut
+    Rule: BufferExact
+    Actual: ColOut
+    Expected: ExpectedColOut
+DescriptorSets:
+  - Resources:
+    - Name: In
+      Kind: RWBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: RowOut
+      Kind: RWBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+    - Name: ColOut
+      Kind: RWBuffer
+      DirectXBinding:
+        Register: 2
+        Space: 0
+      VulkanBinding:
+        Binding: 2
+...
+#--- end
+
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
Existing matrix swizzle tests are  too minimal and are blocked by issues with SV_GroupIndex on vulkan. These new tests are more methodical to  distinguish getter versus setter uses.