### PR TITLE
Address post-merge review comments on CommandBuffer (#1033)

### DIFF
--- a/include/API/Buffer.h
+++ b/include/API/Buffer.h
@@ -22,7 +22,7 @@ struct BufferCreateDesc {
 
 class Buffer {
 public:
-  virtual ~Buffer() = default;
+  virtual ~Buffer();
 
   Buffer(const Buffer &) = delete;
   Buffer &operator=(const Buffer &) = delete;

--- a/include/API/CommandBuffer.h
+++ b/include/API/CommandBuffer.h
@@ -6,6 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 //
+// Defines the CommandBuffer base class for recording and submitting GPU work.
+// Each backend (DirectX, Vulkan, Metal) provides a concrete subclass that
+// wraps the native command recording objects. LLVM-style RTTI is provided for
+// downcasting to the backend-specific type.
 //
 //===----------------------------------------------------------------------===//
 

--- a/include/API/CommandBuffer.h
+++ b/include/API/CommandBuffer.h
@@ -23,7 +23,7 @@ class CommandBuffer {
 
 public:
   explicit CommandBuffer(GPUAPI API) : API(API) {}
-  virtual ~CommandBuffer() = default;
+  virtual ~CommandBuffer();
   CommandBuffer(const CommandBuffer &) = delete;
   CommandBuffer &operator=(const CommandBuffer &) = delete;
 

--- a/include/API/CommandBuffer.h
+++ b/include/API/CommandBuffer.h
@@ -18,29 +18,18 @@
 
 #include "API/API.h"
 
-#include <cassert>
-
 namespace offloadtest {
 
 class CommandBuffer {
-  GPUAPI API;
+  GPUAPI Kind;
 
 public:
-  explicit CommandBuffer(GPUAPI API) : API(API) {}
+  explicit CommandBuffer(GPUAPI Kind) : Kind(Kind) {}
   virtual ~CommandBuffer();
   CommandBuffer(const CommandBuffer &) = delete;
   CommandBuffer &operator=(const CommandBuffer &) = delete;
 
-  GPUAPI getAPI() const { return API; }
-
-  template <typename T> T &as() {
-    assert(API == T::BackendAPI && "CommandBuffer backend mismatch");
-    return static_cast<T &>(*this);
-  }
-  template <typename T> const T &as() const {
-    assert(API == T::BackendAPI && "CommandBuffer backend mismatch");
-    return static_cast<const T &>(*this);
-  }
+  GPUAPI getKind() const { return Kind; }
 };
 
 } // namespace offloadtest

--- a/include/API/Device.h
+++ b/include/API/Device.h
@@ -42,7 +42,7 @@ struct DeviceConfig {
 
 class Fence {
 public:
-  virtual ~Fence() = default;
+  virtual ~Fence();
 
   Fence(const Fence &) = delete;
   Fence &operator=(const Fence &) = delete;

--- a/include/API/Texture.h
+++ b/include/API/Texture.h
@@ -141,7 +141,7 @@ inline llvm::Error validateTextureCreateDesc(const TextureCreateDesc &Desc) {
 
 class Texture {
 public:
-  virtual ~Texture() = default;
+  virtual ~Texture();
 
   Texture(const Texture &) = delete;
   Texture &operator=(const Texture &) = delete;

--- a/include/Image/Image.h
+++ b/include/Image/Image.h
@@ -30,7 +30,7 @@ namespace offloadtest {
 
 class ImageComparatorBase {
 public:
-  virtual ~ImageComparatorBase() {}
+  virtual ~ImageComparatorBase();
   virtual void processPixel(Color L, Color R) = 0;
   virtual void print(llvm::raw_ostream &OS) {}
   virtual bool result() { return true; }

--- a/include/Image/ImageComparators.h
+++ b/include/Image/ImageComparators.h
@@ -113,7 +113,7 @@ class ImageComparatorDiffImage : public ImageComparatorBase {
   llvm::StringRef OutputFilename;
 
 public:
-  virtual ~ImageComparatorDiffImage() {}
+  ~ImageComparatorDiffImage() override;
   ImageComparatorDiffImage(uint32_t Height, uint32_t Width, llvm::StringRef OF)
       : DiffImg(Height, Width, 4, 3, true), OutputFilename(OF) {
     DiffPtr = reinterpret_cast<float *>(DiffImg.data());

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -414,7 +414,9 @@ public:
 
 class DXCommandBuffer : public offloadtest::CommandBuffer {
 public:
-  static constexpr GPUAPI BackendAPI = GPUAPI::DirectX;
+  static bool classof(const CommandBuffer *CB) {
+    return CB->getKind() == GPUAPI::DirectX;
+  }
 
   ComPtr<ID3D12CommandAllocator> Allocator;
   ComPtr<ID3D12GraphicsCommandList> CmdList;

--- a/lib/API/Device.cpp
+++ b/lib/API/Device.cpp
@@ -21,7 +21,15 @@
 
 using namespace offloadtest;
 
+Buffer::~Buffer() {}
+
+CommandBuffer::~CommandBuffer() {}
+
+Fence::~Fence() {}
+
 Queue::~Queue() {}
+
+Texture::~Texture() {}
 
 Device::~Device() {}
 

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -150,7 +150,9 @@ public:
 
 class MTLCommandBuffer : public offloadtest::CommandBuffer {
 public:
-  static constexpr GPUAPI BackendAPI = GPUAPI::Metal;
+  static bool classof(const CommandBuffer *CB) {
+    return CB->getKind() == GPUAPI::Metal;
+  }
 
   MTL::CommandBuffer *CmdBuffer = nullptr;
 

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -480,7 +480,9 @@ public:
 
 class VulkanCommandBuffer : public offloadtest::CommandBuffer {
 public:
-  static constexpr GPUAPI BackendAPI = GPUAPI::Vulkan;
+  static bool classof(const CommandBuffer *CB) {
+    return CB->getKind() == GPUAPI::Vulkan;
+  }
 
   VkDevice Device = VK_NULL_HANDLE;
   // Owned per command buffer so that recording, submission, and lifetime

--- a/lib/Image/Image.cpp
+++ b/lib/Image/Image.cpp
@@ -25,6 +25,8 @@
 
 using namespace offloadtest;
 
+ImageComparatorBase::~ImageComparatorBase() {}
+
 template <typename DstType, typename SrcType>
 static void translatePixelData(Image &Dst, ImageRef Src, bool ForWrite) {
   const uint64_t Pixels = Dst.getHeight() * Dst.getWidth();

--- a/lib/Image/ImageComparators.cpp
+++ b/lib/Image/ImageComparators.cpp
@@ -14,6 +14,8 @@
 using namespace llvm;
 using namespace offloadtest;
 
+ImageComparatorDiffImage::~ImageComparatorDiffImage() {}
+
 void yaml::MappingTraits<CompareCheck>::mapping(IO &I, CompareCheck &C) {
   I.mapRequired("Type", C.Type);
   if (C.Type == CompareCheck::Intervals)


### PR DESCRIPTION
Address post-review comments from @bogner on #1033. These felt significant enough that they weren't worth cramming into an "unrelated" PR but deserve their own clean follow-up in three individual commits.

- Add virtual method anchors for all polymorphic types (`Buffer`, `CommandBuffer`, `Fence`, `ImageComparatorBase`, `ImageComparatorDiffImage`, `Texture`) per LLVM coding standards
- Add file description to header comment
- Switch to LLVM-style RTTI (`classof()`) instead of hand-rolled `as<T>()` + `BackendAPI`, fixing `-Wunused-const-variable`

Adding `-Werror` to the build is left for a separate PR as it requires a warning audit first — the project inherits compile flags from LLVM's CMake infrastructure and backend SDK headers may introduce additional warnings.