### PR TITLE
[Matrix][Vulkan] disable matrix getter tests

### DIFF
--- a/test/Basic/Matrix/matrix_m-based_getter.test
+++ b/test/Basic/Matrix/matrix_m-based_getter.test
@@ -148,6 +148,9 @@ DescriptorSets:
 ...
 #--- end
 
+# BUG Vulkan https://github.com/llvm/offload-test-suite/issues/1091
+# XFAIL: Vulkan && Clang
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -fvk-use-dx-layout -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Basic/Matrix/matrix_one-based_getter.test
+++ b/test/Basic/Matrix/matrix_one-based_getter.test
@@ -147,6 +147,9 @@ DescriptorSets:
 ...
 #--- end
 
+# BUG Vulkan https://github.com/llvm/offload-test-suite/issues/1091
+# XFAIL: Vulkan && Clang
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -fvk-use-dx-layout -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
For now disable these tests to get vulkan tests back to green. I think we should either rewrite the test not to use `RWBuffer<float2>` or we need to make a change in the spirv backend to add the `StorageImageExtendedFormats` capability.