### PR TITLE
[Metal][DXC] Reduce the scope of the xfail to only clang

### DIFF
--- a/test/Feature/Textures/Texture2D.OperatorIndex.test.yaml
+++ b/test/Feature/Textures/Texture2D.OperatorIndex.test.yaml
@@ -62,7 +62,7 @@ Results:
 #--- end
 
 # Unimplemented: Clang + DX: https://github.com/llvm/llvm-project/issues/101558
-# XFAIL: DirectX || Metal
+# XFAIL: DirectX || Metal && Clang
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl


### PR DESCRIPTION
The Texture2D.OperatorIndex.test.yaml tests are passing on Metal with DXC. This change reduces the scope of the xfail when targeting Metal to just Clang.