### PR TITLE
Address post-merge review comments on #1020 and use LLVM-style RTTI

### DIFF
--- a/include/API/Buffer.h
+++ b/include/API/Buffer.h
@@ -24,17 +24,17 @@ struct BufferCreateDesc {
 };
 
 class Buffer {
-  GPUAPI Kind;
+  GPUAPI API;
 
 public:
   virtual ~Buffer();
   Buffer(const Buffer &) = delete;
   Buffer &operator=(const Buffer &) = delete;
 
-  GPUAPI getKind() const { return Kind; }
+  GPUAPI getAPI() const { return API; }
 
 protected:
-  explicit Buffer(GPUAPI Kind) : Kind(Kind) {}
+  explicit Buffer(GPUAPI API) : API(API) {}
 };
 
 } // namespace offloadtest

--- a/include/API/Buffer.h
+++ b/include/API/Buffer.h
@@ -15,6 +15,8 @@
 #include "API/API.h"
 #include "API/Resources.h"
 
+#include "llvm/Support/Casting.h"
+
 namespace offloadtest {
 
 struct BufferCreateDesc {
@@ -25,12 +27,14 @@ class Buffer {
   GPUAPI Kind;
 
 public:
-  explicit Buffer(GPUAPI Kind) : Kind(Kind) {}
   virtual ~Buffer();
   Buffer(const Buffer &) = delete;
   Buffer &operator=(const Buffer &) = delete;
 
   GPUAPI getKind() const { return Kind; }
+
+protected:
+  explicit Buffer(GPUAPI Kind) : Kind(Kind) {}
 };
 
 } // namespace offloadtest

--- a/include/API/Buffer.h
+++ b/include/API/Buffer.h
@@ -34,7 +34,7 @@ public:
   GPUAPI getAPI() const { return API; }
 
 protected:
-  explicit Buffer(GPUAPI API);
+  explicit Buffer(GPUAPI API) : API(API) {}
 };
 
 } // namespace offloadtest

--- a/include/API/Buffer.h
+++ b/include/API/Buffer.h
@@ -34,7 +34,7 @@ public:
   GPUAPI getAPI() const { return API; }
 
 protected:
-  explicit Buffer(GPUAPI API) : API(API) {}
+  explicit Buffer(GPUAPI API);
 };
 
 } // namespace offloadtest

--- a/include/API/Buffer.h
+++ b/include/API/Buffer.h
@@ -12,6 +12,7 @@
 #ifndef OFFLOADTEST_API_BUFFER_H
 #define OFFLOADTEST_API_BUFFER_H
 
+#include "API/API.h"
 #include "API/Resources.h"
 
 namespace offloadtest {
@@ -21,14 +22,15 @@ struct BufferCreateDesc {
 };
 
 class Buffer {
-public:
-  virtual ~Buffer();
+  GPUAPI Kind;
 
+public:
+  explicit Buffer(GPUAPI Kind) : Kind(Kind) {}
+  virtual ~Buffer();
   Buffer(const Buffer &) = delete;
   Buffer &operator=(const Buffer &) = delete;
 
-protected:
-  Buffer() = default;
+  GPUAPI getKind() const { return Kind; }
 };
 
 } // namespace offloadtest

--- a/include/API/Device.h
+++ b/include/API/Device.h
@@ -78,11 +78,11 @@ public:
   virtual llvm::Expected<std::unique_ptr<Fence>>
   createFence(llvm::StringRef Name) = 0;
 
-  virtual llvm::Expected<std::shared_ptr<Buffer>>
+  virtual llvm::Expected<std::unique_ptr<Buffer>>
   createBuffer(std::string Name, BufferCreateDesc &Desc,
                size_t SizeInBytes) = 0;
 
-  virtual llvm::Expected<std::shared_ptr<Texture>>
+  virtual llvm::Expected<std::unique_ptr<Texture>>
   createTexture(std::string Name, TextureCreateDesc &Desc) = 0;
 
   virtual void printExtra(llvm::raw_ostream &OS) {}
@@ -111,11 +111,11 @@ initializeDevices(const DeviceConfig Config);
 // Creates a render target texture using the format and dimensions from a
 // CPUBuffer. Does not upload the buffer's data — only uses its description to
 // configure the texture.
-llvm::Expected<std::shared_ptr<Texture>>
+llvm::Expected<std::unique_ptr<Texture>>
 createRenderTargetFromCPUBuffer(Device &Dev, const CPUBuffer &Buf);
 
 // Creates a depth/stencil texture matching the dimensions of a render target.
-llvm::Expected<std::shared_ptr<Texture>>
+llvm::Expected<std::unique_ptr<Texture>>
 createDefaultDepthStencilTarget(Device &Dev, uint32_t Width, uint32_t Height);
 
 } // namespace offloadtest

--- a/include/API/Texture.h
+++ b/include/API/Texture.h
@@ -152,7 +152,7 @@ public:
   GPUAPI getAPI() const { return API; }
 
 protected:
-  explicit Texture(GPUAPI API);
+  explicit Texture(GPUAPI API) : API(API) {}
 };
 
 } // namespace offloadtest

--- a/include/API/Texture.h
+++ b/include/API/Texture.h
@@ -17,6 +17,7 @@
 
 #include "llvm/ADT/BitmaskEnum.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Casting.h"
 #include "llvm/Support/Error.h"
 
 #include <cstdint>
@@ -144,12 +145,14 @@ class Texture {
   GPUAPI Kind;
 
 public:
-  explicit Texture(GPUAPI Kind) : Kind(Kind) {}
   virtual ~Texture();
   Texture(const Texture &) = delete;
   Texture &operator=(const Texture &) = delete;
 
   GPUAPI getKind() const { return Kind; }
+
+protected:
+  explicit Texture(GPUAPI Kind) : Kind(Kind) {}
 };
 
 } // namespace offloadtest

--- a/include/API/Texture.h
+++ b/include/API/Texture.h
@@ -12,6 +12,7 @@
 #ifndef OFFLOADTEST_API_TEXTURE_H
 #define OFFLOADTEST_API_TEXTURE_H
 
+#include "API/API.h"
 #include "API/Resources.h"
 
 #include "llvm/ADT/BitmaskEnum.h"
@@ -140,14 +141,15 @@ inline llvm::Error validateTextureCreateDesc(const TextureCreateDesc &Desc) {
 }
 
 class Texture {
-public:
-  virtual ~Texture();
+  GPUAPI Kind;
 
+public:
+  explicit Texture(GPUAPI Kind) : Kind(Kind) {}
+  virtual ~Texture();
   Texture(const Texture &) = delete;
   Texture &operator=(const Texture &) = delete;
 
-protected:
-  Texture() = default;
+  GPUAPI getKind() const { return Kind; }
 };
 
 } // namespace offloadtest

--- a/include/API/Texture.h
+++ b/include/API/Texture.h
@@ -152,7 +152,7 @@ public:
   GPUAPI getAPI() const { return API; }
 
 protected:
-  explicit Texture(GPUAPI API) : API(API) {}
+  explicit Texture(GPUAPI API);
 };
 
 } // namespace offloadtest

--- a/include/API/Texture.h
+++ b/include/API/Texture.h
@@ -142,17 +142,17 @@ inline llvm::Error validateTextureCreateDesc(const TextureCreateDesc &Desc) {
 }
 
 class Texture {
-  GPUAPI Kind;
+  GPUAPI API;
 
 public:
   virtual ~Texture();
   Texture(const Texture &) = delete;
   Texture &operator=(const Texture &) = delete;
 
-  GPUAPI getKind() const { return Kind; }
+  GPUAPI getAPI() const { return API; }
 
 protected:
-  explicit Texture(GPUAPI Kind) : Kind(Kind) {}
+  explicit Texture(GPUAPI API) : API(API) {}
 };
 
 } // namespace offloadtest

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -41,6 +41,7 @@
 
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Object/DXContainer.h"
+#include "llvm/Support/Casting.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/Signals.h"
 
@@ -285,6 +286,10 @@ namespace {
 
 class DXBuffer : public offloadtest::Buffer {
 public:
+  static bool classof(const offloadtest::Buffer *B) {
+    return B->getKind() == GPUAPI::DirectX;
+  }
+
   ComPtr<ID3D12Resource> Buffer;
   std::string Name;
   BufferCreateDesc Desc;
@@ -292,11 +297,16 @@ public:
 
   DXBuffer(ComPtr<ID3D12Resource> Buffer, llvm::StringRef Name,
            BufferCreateDesc Desc, size_t SizeInBytes)
-      : Buffer(Buffer), Name(Name), Desc(Desc), SizeInBytes(SizeInBytes) {}
+      : offloadtest::Buffer(GPUAPI::DirectX), Buffer(Buffer), Name(Name),
+        Desc(Desc), SizeInBytes(SizeInBytes) {}
 };
 
 class DXTexture : public offloadtest::Texture {
 public:
+  static bool classof(const offloadtest::Texture *T) {
+    return T->getKind() == GPUAPI::DirectX;
+  }
+
   ComPtr<ID3D12Resource> Resource;
   // TODO:
   // RTV/DSV own a dedicated single-descriptor heap and are created at
@@ -313,7 +323,8 @@ public:
 
   DXTexture(ComPtr<ID3D12Resource> Resource, llvm::StringRef Name,
             TextureCreateDesc Desc)
-      : Resource(Resource), Name(Name), Desc(Desc) {}
+      : offloadtest::Texture(GPUAPI::DirectX), Resource(Resource), Name(Name),
+        Desc(Desc) {}
 };
 
 class DXFence : public offloadtest::Fence {
@@ -479,9 +490,9 @@ private:
     std::unique_ptr<offloadtest::Fence> CompletionFence;
 
     // Resources for graphics pipelines.
-    std::unique_ptr<DXTexture> RT;
-    std::unique_ptr<DXBuffer> RTReadback;
-    std::unique_ptr<DXTexture> DS;
+    std::unique_ptr<offloadtest::Texture> RT;
+    std::unique_ptr<offloadtest::Buffer> RTReadback;
+    std::unique_ptr<offloadtest::Texture> DS;
     ComPtr<ID3D12Resource> VB;
 
     llvm::SmallVector<DescriptorTable> DescTables;
@@ -1534,13 +1545,15 @@ public:
     // while our image writer expects bottom-left.
     const CPUBuffer &B = *P.Bindings.RTargetBufferPtr;
     void *Mapped = nullptr;
-    if (auto Err = HR::toError(IS.RTReadback->Buffer->Map(0, nullptr, &Mapped),
+    auto &Readback = llvm::cast<DXBuffer>(*IS.RTReadback);
+    if (auto Err = HR::toError(Readback.Buffer->Map(0, nullptr, &Mapped),
                                "Failed to map render target readback"))
       return Err;
 
     // Query the copy footprint to get the actual padded row pitch used by the
     // copy operation.
-    const D3D12_RESOURCE_DESC RTDesc = IS.RT->Resource->GetDesc();
+    auto &RT = llvm::cast<DXTexture>(*IS.RT);
+    const D3D12_RESOURCE_DESC RTDesc = RT.Resource->GetDesc();
     D3D12_PLACED_SUBRESOURCE_FOOTPRINT Placed = {};
     uint32_t NumRows = 0;
     uint64_t RowSizeInBytes = 0;
@@ -1565,7 +1578,7 @@ public:
       memcpy(DstRow, SrcRow, RowBytes);
     }
 
-    IS.RTReadback->Buffer->Unmap(0, nullptr);
+    Readback.Buffer->Unmap(0, nullptr);
     return llvm::Error::success();
   }
 
@@ -1580,7 +1593,7 @@ public:
     if (!TexOrErr)
       return TexOrErr.takeError();
 
-    IS.RT.reset(static_cast<DXTexture *>(TexOrErr->release()));
+    IS.RT = std::move(*TexOrErr);
 
     // Create readback buffer sized for the pixel data (raw bytes).
     BufferCreateDesc BufDesc = {};
@@ -1588,7 +1601,7 @@ public:
     auto BufOrErr = createBuffer("RTReadback", BufDesc, OutBuf.size());
     if (!BufOrErr)
       return BufOrErr.takeError();
-    IS.RTReadback.reset(static_cast<DXBuffer *>(BufOrErr->release()));
+    IS.RTReadback = std::move(*BufOrErr);
 
     return llvm::Error::success();
   }
@@ -1599,7 +1612,7 @@ public:
         P.Bindings.RTargetBufferPtr->OutputProps.Height);
     if (!TexOrErr)
       return TexOrErr.takeError();
-    IS.DS.reset(static_cast<DXTexture *>(TexOrErr->release()));
+    IS.DS = std::move(*TexOrErr);
     return llvm::Error::success();
   }
 
@@ -1682,7 +1695,8 @@ public:
     PSODesc.DepthStencilState.DepthWriteMask = D3D12_DEPTH_WRITE_MASK_ALL;
     PSODesc.DepthStencilState.DepthFunc = D3D12_COMPARISON_FUNC_LESS;
     PSODesc.DepthStencilState.StencilEnable = false;
-    PSODesc.DSVFormat = getDXGIFormat(IS.DS->Desc.Fmt);
+    auto &DS = llvm::cast<DXTexture>(*IS.DS);
+    PSODesc.DSVFormat = getDXGIFormat(DS.Desc.Fmt);
     PSODesc.SampleMask = UINT_MAX;
     PSODesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
     PSODesc.NumRenderTargets = 1;
@@ -1699,6 +1713,10 @@ public:
   }
 
   llvm::Error createGraphicsCommands(Pipeline &P, InvocationState &IS) {
+    auto &RT = llvm::cast<DXTexture>(*IS.RT);
+    auto &DS = llvm::cast<DXTexture>(*IS.DS);
+    auto &RTReadback = llvm::cast<DXBuffer>(*IS.RTReadback);
+
     IS.CB->CmdList->SetGraphicsRootSignature(IS.RootSig.Get());
     if (IS.DescHeap) {
       ID3D12DescriptorHeap *const Heaps[] = {IS.DescHeap.Get()};
@@ -1708,17 +1726,17 @@ public:
     }
     IS.CB->CmdList->SetPipelineState(IS.PSO.Get());
 
-    IS.CB->CmdList->OMSetRenderTargets(1, &IS.RT->ViewHandle, false,
-                                       &IS.DS->ViewHandle);
+    IS.CB->CmdList->OMSetRenderTargets(1, &RT.ViewHandle, false,
+                                       &DS.ViewHandle);
 
     const auto *DepthCV =
-        std::get_if<ClearDepthStencil>(&*IS.DS->Desc.OptimizedClearValue);
+        std::get_if<ClearDepthStencil>(&*DS.Desc.OptimizedClearValue);
     if (!DepthCV)
       return llvm::createStringError(
           std::errc::invalid_argument,
           "Depth/stencil clear value must be a ClearDepthStencil.");
     IS.CB->CmdList->ClearDepthStencilView(
-        IS.DS->ViewHandle, D3D12_CLEAR_FLAG_DEPTH | D3D12_CLEAR_FLAG_STENCIL,
+        DS.ViewHandle, D3D12_CLEAR_FLAG_DEPTH | D3D12_CLEAR_FLAG_STENCIL,
         DepthCV->Depth, DepthCV->Stencil, 0, nullptr);
 
     D3D12_VIEWPORT VP = {};
@@ -1740,7 +1758,7 @@ public:
     // Transition the render target to copy source and copy to the readback
     // buffer.
     const D3D12_RESOURCE_BARRIER Barrier = CD3DX12_RESOURCE_BARRIER::Transition(
-        IS.RT->Resource.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET,
+        RT.Resource.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET,
         D3D12_RESOURCE_STATE_COPY_SOURCE);
     IS.CB->CmdList->ResourceBarrier(1, &Barrier);
 
@@ -1750,9 +1768,9 @@ public:
         CD3DX12_SUBRESOURCE_FOOTPRINT(
             getDXFormat(B.Format, B.Channels), B.OutputProps.Width,
             B.OutputProps.Height, 1, B.OutputProps.Width * B.getElementSize())};
-    const CD3DX12_TEXTURE_COPY_LOCATION DstLoc(IS.RTReadback->Buffer.Get(),
+    const CD3DX12_TEXTURE_COPY_LOCATION DstLoc(RTReadback.Buffer.Get(),
                                                Footprint);
-    const CD3DX12_TEXTURE_COPY_LOCATION SrcLoc(IS.RT->Resource.Get(), 0);
+    const CD3DX12_TEXTURE_COPY_LOCATION SrcLoc(RT.Resource.Get(), 0);
 
     IS.CB->CmdList->CopyTextureRegion(&DstLoc, 0, 0, 0, &SrcLoc, nullptr);
 

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -479,9 +479,9 @@ private:
     std::unique_ptr<offloadtest::Fence> CompletionFence;
 
     // Resources for graphics pipelines.
-    std::shared_ptr<DXTexture> RT;
-    std::shared_ptr<DXBuffer> RTReadback;
-    std::shared_ptr<DXTexture> DS;
+    std::unique_ptr<DXTexture> RT;
+    std::unique_ptr<DXBuffer> RTReadback;
+    std::unique_ptr<DXTexture> DS;
     ComPtr<ID3D12Resource> VB;
 
     llvm::SmallVector<DescriptorTable> DescTables;
@@ -508,7 +508,7 @@ public:
     return DXFence::create(Device.Get(), Name);
   }
 
-  llvm::Expected<std::shared_ptr<offloadtest::Buffer>>
+  llvm::Expected<std::unique_ptr<offloadtest::Buffer>>
   createBuffer(std::string Name, BufferCreateDesc &Desc,
                size_t SizeInBytes) override {
     const D3D12_HEAP_TYPE HeapType = getDXHeapType(Desc.Location);
@@ -539,10 +539,10 @@ public:
                         "Failed to create buffer."))
       return Err;
 
-    return std::make_shared<DXBuffer>(DeviceBuffer, Name, Desc, SizeInBytes);
+    return std::make_unique<DXBuffer>(DeviceBuffer, Name, Desc, SizeInBytes);
   }
 
-  llvm::Expected<std::shared_ptr<offloadtest::Texture>>
+  llvm::Expected<std::unique_ptr<offloadtest::Texture>>
   createTexture(std::string Name, TextureCreateDesc &Desc) override {
     if (auto Err = validateTextureCreateDesc(Desc))
       return Err;
@@ -596,7 +596,7 @@ public:
                                "Failed to create texture."))
       return Err;
 
-    auto Tex = std::make_shared<DXTexture>(DeviceTexture, Name, Desc);
+    auto Tex = std::make_unique<DXTexture>(DeviceTexture, Name, Desc);
 
     const bool IsRT = (Desc.Usage & TextureUsage::RenderTarget) != 0;
     const bool IsDS = (Desc.Usage & TextureUsage::DepthStencil) != 0;
@@ -1580,7 +1580,7 @@ public:
     if (!TexOrErr)
       return TexOrErr.takeError();
 
-    IS.RT = std::static_pointer_cast<DXTexture>(*TexOrErr);
+    IS.RT.reset(static_cast<DXTexture *>(TexOrErr->release()));
 
     // Create readback buffer sized for the pixel data (raw bytes).
     BufferCreateDesc BufDesc = {};
@@ -1588,7 +1588,7 @@ public:
     auto BufOrErr = createBuffer("RTReadback", BufDesc, OutBuf.size());
     if (!BufOrErr)
       return BufOrErr.takeError();
-    IS.RTReadback = std::static_pointer_cast<DXBuffer>(*BufOrErr);
+    IS.RTReadback.reset(static_cast<DXBuffer *>(BufOrErr->release()));
 
     return llvm::Error::success();
   }
@@ -1599,7 +1599,7 @@ public:
         P.Bindings.RTargetBufferPtr->OutputProps.Height);
     if (!TexOrErr)
       return TexOrErr.takeError();
-    IS.DS = std::static_pointer_cast<DXTexture>(*TexOrErr);
+    IS.DS.reset(static_cast<DXTexture *>(TexOrErr->release()));
     return llvm::Error::success();
   }
 

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -285,10 +285,6 @@ namespace {
 
 class DXBuffer : public offloadtest::Buffer {
 public:
-  static bool classof(const offloadtest::Buffer *B) {
-    return B->getAPI() == GPUAPI::DirectX;
-  }
-
   ComPtr<ID3D12Resource> Buffer;
   std::string Name;
   BufferCreateDesc Desc;
@@ -298,14 +294,14 @@ public:
            BufferCreateDesc Desc, size_t SizeInBytes)
       : offloadtest::Buffer(GPUAPI::DirectX), Buffer(Buffer), Name(Name),
         Desc(Desc), SizeInBytes(SizeInBytes) {}
+
+  static bool classof(const offloadtest::Buffer *B) {
+    return B->getAPI() == GPUAPI::DirectX;
+  }
 };
 
 class DXTexture : public offloadtest::Texture {
 public:
-  static bool classof(const offloadtest::Texture *T) {
-    return T->getAPI() == GPUAPI::DirectX;
-  }
-
   ComPtr<ID3D12Resource> Resource;
   // TODO:
   // RTV/DSV own a dedicated single-descriptor heap and are created at
@@ -324,6 +320,10 @@ public:
             TextureCreateDesc Desc)
       : offloadtest::Texture(GPUAPI::DirectX), Resource(Resource), Name(Name),
         Desc(Desc) {}
+
+  static bool classof(const offloadtest::Texture *T) {
+    return T->getAPI() == GPUAPI::DirectX;
+  }
 };
 
 class DXFence : public offloadtest::Fence {
@@ -424,10 +424,6 @@ public:
 
 class DXCommandBuffer : public offloadtest::CommandBuffer {
 public:
-  static bool classof(const CommandBuffer *CB) {
-    return CB->getKind() == GPUAPI::DirectX;
-  }
-
   ComPtr<ID3D12CommandAllocator> Allocator;
   ComPtr<ID3D12GraphicsCommandList> CmdList;
 
@@ -449,6 +445,10 @@ public:
   }
 
   ~DXCommandBuffer() override = default;
+
+  static bool classof(const CommandBuffer *CB) {
+    return CB->getKind() == GPUAPI::DirectX;
+  }
 
 private:
   DXCommandBuffer() : CommandBuffer(GPUAPI::DirectX) {}

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -41,7 +41,6 @@
 
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Object/DXContainer.h"
-#include "llvm/Support/Casting.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/Signals.h"
 

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -286,7 +286,7 @@ namespace {
 class DXBuffer : public offloadtest::Buffer {
 public:
   static bool classof(const offloadtest::Buffer *B) {
-    return B->getKind() == GPUAPI::DirectX;
+    return B->getAPI() == GPUAPI::DirectX;
   }
 
   ComPtr<ID3D12Resource> Buffer;
@@ -303,7 +303,7 @@ public:
 class DXTexture : public offloadtest::Texture {
 public:
   static bool classof(const offloadtest::Texture *T) {
-    return T->getKind() == GPUAPI::DirectX;
+    return T->getAPI() == GPUAPI::DirectX;
   }
 
   ComPtr<ID3D12Resource> Resource;

--- a/lib/API/Device.cpp
+++ b/lib/API/Device.cpp
@@ -21,8 +21,6 @@
 
 using namespace offloadtest;
 
-Buffer::Buffer(GPUAPI API) : API(API) {}
-
 Buffer::~Buffer() {}
 
 CommandBuffer::~CommandBuffer() {}
@@ -30,8 +28,6 @@ CommandBuffer::~CommandBuffer() {}
 Fence::~Fence() {}
 
 Queue::~Queue() {}
-
-Texture::Texture(GPUAPI API) : API(API) {}
 
 Texture::~Texture() {}
 

--- a/lib/API/Device.cpp
+++ b/lib/API/Device.cpp
@@ -65,7 +65,7 @@ offloadtest::initializeDevices(const DeviceConfig Config) {
   return Devices;
 }
 
-llvm::Expected<std::shared_ptr<Texture>>
+llvm::Expected<std::unique_ptr<Texture>>
 offloadtest::createRenderTargetFromCPUBuffer(Device &Dev,
                                              const CPUBuffer &Buf) {
   auto TexFmtOrErr = toFormat(Buf.Format, Buf.Channels);
@@ -87,7 +87,7 @@ offloadtest::createRenderTargetFromCPUBuffer(Device &Dev,
   return Dev.createTexture("RenderTarget", Desc);
 }
 
-llvm::Expected<std::shared_ptr<Texture>>
+llvm::Expected<std::unique_ptr<Texture>>
 offloadtest::createDefaultDepthStencilTarget(Device &Dev, uint32_t Width,
                                              uint32_t Height) {
   TextureCreateDesc Desc = {};

--- a/lib/API/Device.cpp
+++ b/lib/API/Device.cpp
@@ -21,6 +21,8 @@
 
 using namespace offloadtest;
 
+Buffer::Buffer(GPUAPI API) : API(API) {}
+
 Buffer::~Buffer() {}
 
 CommandBuffer::~CommandBuffer() {}
@@ -28,6 +30,8 @@ CommandBuffer::~CommandBuffer() {}
 Fence::~Fence() {}
 
 Queue::~Queue() {}
+
+Texture::Texture(GPUAPI API) : API(API) {}
 
 Texture::~Texture() {}
 

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -14,6 +14,7 @@
 #include "Support/Pipeline.h"
 
 #include "llvm/ADT/ScopeExit.h"
+#include "llvm/Support/Casting.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/JSON.h"
@@ -118,6 +119,10 @@ public:
 
 class MTLBuffer : public offloadtest::Buffer {
 public:
+  static bool classof(const offloadtest::Buffer *B) {
+    return B->getKind() == GPUAPI::Metal;
+  }
+
   MTL::Buffer *Buf;
   std::string Name;
   BufferCreateDesc Desc;
@@ -125,7 +130,8 @@ public:
 
   MTLBuffer(MTL::Buffer *Buf, llvm::StringRef Name, BufferCreateDesc Desc,
             size_t SizeInBytes)
-      : Buf(Buf), Name(Name), Desc(Desc), SizeInBytes(SizeInBytes) {}
+      : offloadtest::Buffer(GPUAPI::Metal), Buf(Buf), Name(Name), Desc(Desc),
+        SizeInBytes(SizeInBytes) {}
 
   ~MTLBuffer() override {
     if (Buf)
@@ -135,12 +141,16 @@ public:
 
 class MTLTexture : public offloadtest::Texture {
 public:
+  static bool classof(const offloadtest::Texture *T) {
+    return T->getKind() == GPUAPI::Metal;
+  }
+
   MTL::Texture *Tex;
   std::string Name;
   TextureCreateDesc Desc;
 
   MTLTexture(MTL::Texture *Tex, llvm::StringRef Name, TextureCreateDesc Desc)
-      : Tex(Tex), Name(Name), Desc(Desc) {}
+      : offloadtest::Texture(GPUAPI::Metal), Tex(Tex), Name(Name), Desc(Desc) {}
 
   ~MTLTexture() override {
     if (Tex)
@@ -200,9 +210,9 @@ class MTLDevice : public offloadtest::Device {
     MTL::VertexDescriptor *VertexDescriptor;
     llvm::SmallVector<MTL::Texture *> Textures;
     llvm::SmallVector<MTL::Buffer *> Buffers;
-    std::unique_ptr<MTLTexture> FrameBufferTexture;
-    std::unique_ptr<MTLBuffer> FrameBufferReadback;
-    std::unique_ptr<MTLTexture> DepthStencil;
+    std::unique_ptr<offloadtest::Texture> FrameBufferTexture;
+    std::unique_ptr<offloadtest::Buffer> FrameBufferReadback;
+    std::unique_ptr<offloadtest::Texture> DepthStencil;
     std::unique_ptr<MTLCommandBuffer> CB;
     std::unique_ptr<offloadtest::Fence> CompletionFence;
   };
@@ -527,7 +537,7 @@ class MTLDevice : public offloadtest::Device {
     if (!TexOrErr)
       return TexOrErr.takeError();
 
-    IS.FrameBufferTexture.reset(static_cast<MTLTexture *>(TexOrErr->release()));
+    IS.FrameBufferTexture = std::move(*TexOrErr);
 
     // Create a readback buffer for copying render target data to the CPU.
     BufferCreateDesc BufDesc = {};
@@ -535,7 +545,7 @@ class MTLDevice : public offloadtest::Device {
     auto BufOrErr = createBuffer("RTReadback", BufDesc, OutBuf.size());
     if (!BufOrErr)
       return BufOrErr.takeError();
-    IS.FrameBufferReadback.reset(static_cast<MTLBuffer *>(BufOrErr->release()));
+    IS.FrameBufferReadback = std::move(*BufOrErr);
 
     return llvm::Error::success();
   }
@@ -546,7 +556,7 @@ class MTLDevice : public offloadtest::Device {
         P.Bindings.RTargetBufferPtr->OutputProps.Height);
     if (!TexOrErr)
       return TexOrErr.takeError();
-    IS.DepthStencil.reset(static_cast<MTLTexture *>(TexOrErr->release()));
+    IS.DepthStencil = std::move(*TexOrErr);
     return llvm::Error::success();
   }
 
@@ -558,18 +568,22 @@ class MTLDevice : public offloadtest::Device {
     if (auto Err = createDepthStencil(P, IS))
       return Err;
 
+    auto &FBTex = llvm::cast<MTLTexture>(*IS.FrameBufferTexture);
+    auto &DS = llvm::cast<MTLTexture>(*IS.DepthStencil);
+    auto &FBReadback = llvm::cast<MTLBuffer>(*IS.FrameBufferReadback);
+
     MTL::RenderPassDescriptor *Desc =
         MTL::RenderPassDescriptor::alloc()->init();
 
-    const uint64_t Width = IS.FrameBufferTexture->Desc.Width;
-    const uint64_t Height = IS.FrameBufferTexture->Desc.Height;
+    const uint64_t Width = FBTex.Desc.Width;
+    const uint64_t Height = FBTex.Desc.Height;
 
     // Color attachment.
     auto *CADesc = MTL::RenderPassColorAttachmentDescriptor::alloc()->init();
-    CADesc->setTexture(IS.FrameBufferTexture->Tex);
+    CADesc->setTexture(FBTex.Tex);
     CADesc->setLoadAction(MTL::LoadActionClear);
-    const auto *ColorCV = std::get_if<ClearColor>(
-        &*IS.FrameBufferTexture->Desc.OptimizedClearValue);
+    const auto *ColorCV =
+        std::get_if<ClearColor>(&*FBTex.Desc.OptimizedClearValue);
     if (!ColorCV)
       return llvm::createStringError(
           std::errc::invalid_argument,
@@ -581,21 +595,21 @@ class MTLDevice : public offloadtest::Device {
     Desc->colorAttachments()->setObject(CADesc, 0);
 
     // Depth/stencil attachment.
-    const auto *DepthCV = std::get_if<ClearDepthStencil>(
-        &*IS.DepthStencil->Desc.OptimizedClearValue);
+    const auto *DepthCV =
+        std::get_if<ClearDepthStencil>(&*DS.Desc.OptimizedClearValue);
     if (!DepthCV)
       return llvm::createStringError(
           std::errc::invalid_argument,
           "Depth/stencil clear value must be a ClearDepthStencil.");
 
     auto *DADesc = Desc->depthAttachment();
-    DADesc->setTexture(IS.DepthStencil->Tex);
+    DADesc->setTexture(DS.Tex);
     DADesc->setLoadAction(MTL::LoadActionClear);
     DADesc->setClearDepth(DepthCV->Depth);
     DADesc->setStoreAction(MTL::StoreActionDontCare);
 
     auto *SADesc = Desc->stencilAttachment();
-    SADesc->setTexture(IS.DepthStencil->Tex);
+    SADesc->setTexture(DS.Tex);
     SADesc->setLoadAction(MTL::LoadActionClear);
     SADesc->setClearStencil(DepthCV->Stencil);
     SADesc->setStoreAction(MTL::StoreActionDontCare);
@@ -631,12 +645,11 @@ class MTLDevice : public offloadtest::Device {
 
     // Blit the render target into the readback buffer for CPU access.
     MTL::BlitCommandEncoder *Blit = IS.CB->CmdBuffer->blitCommandEncoder();
-    const size_t ElemSize =
-        getFormatSizeInBytes(IS.FrameBufferTexture->Desc.Fmt);
+    const size_t ElemSize = getFormatSizeInBytes(FBTex.Desc.Fmt);
     const size_t RowBytes = Width * ElemSize;
-    Blit->copyFromTexture(IS.FrameBufferTexture->Tex, 0, 0,
-                          MTL::Origin(0, 0, 0), MTL::Size(Width, Height, 1),
-                          IS.FrameBufferReadback->Buf, 0, RowBytes, 0);
+    Blit->copyFromTexture(FBTex.Tex, 0, 0, MTL::Origin(0, 0, 0),
+                          MTL::Size(Width, Height, 1), FBReadback.Buf, 0,
+                          RowBytes, 0);
     Blit->endEncoding();
 
     return llvm::Error::success();
@@ -700,8 +713,9 @@ class MTLDevice : public offloadtest::Device {
 
       // Read from the readback buffer. The blit copied the texture data in
       // GPU layout order, so we flip rows here to produce an upright image.
-      const unsigned char *Src = reinterpret_cast<const unsigned char *>(
-          IS.FrameBufferReadback->Buf->contents());
+      auto &FBReadback = llvm::cast<MTLBuffer>(*IS.FrameBufferReadback);
+      const unsigned char *Src =
+          reinterpret_cast<const unsigned char *>(FBReadback.Buf->contents());
       unsigned char *Buf =
           reinterpret_cast<unsigned char *>(RTarget->Data[0].get());
       for (uint64_t R = 0; R < Height; ++R) {

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -118,10 +118,6 @@ public:
 
 class MTLBuffer : public offloadtest::Buffer {
 public:
-  static bool classof(const offloadtest::Buffer *B) {
-    return B->getAPI() == GPUAPI::Metal;
-  }
-
   MTL::Buffer *Buf;
   std::string Name;
   BufferCreateDesc Desc;
@@ -136,14 +132,14 @@ public:
     if (Buf)
       Buf->release();
   }
+
+  static bool classof(const offloadtest::Buffer *B) {
+    return B->getAPI() == GPUAPI::Metal;
+  }
 };
 
 class MTLTexture : public offloadtest::Texture {
 public:
-  static bool classof(const offloadtest::Texture *T) {
-    return T->getAPI() == GPUAPI::Metal;
-  }
-
   MTL::Texture *Tex;
   std::string Name;
   TextureCreateDesc Desc;
@@ -155,14 +151,14 @@ public:
     if (Tex)
       Tex->release();
   }
+
+  static bool classof(const offloadtest::Texture *T) {
+    return T->getAPI() == GPUAPI::Metal;
+  }
 };
 
 class MTLCommandBuffer : public offloadtest::CommandBuffer {
 public:
-  static bool classof(const CommandBuffer *CB) {
-    return CB->getKind() == GPUAPI::Metal;
-  }
-
   MTL::CommandBuffer *CmdBuffer = nullptr;
 
   static llvm::Expected<std::unique_ptr<MTLCommandBuffer>>
@@ -176,6 +172,10 @@ public:
   }
 
   ~MTLCommandBuffer() override = default;
+
+  static bool classof(const CommandBuffer *CB) {
+    return CB->getKind() == GPUAPI::Metal;
+  }
 
 private:
   MTLCommandBuffer() : CommandBuffer(GPUAPI::Metal) {}

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -200,9 +200,9 @@ class MTLDevice : public offloadtest::Device {
     MTL::VertexDescriptor *VertexDescriptor;
     llvm::SmallVector<MTL::Texture *> Textures;
     llvm::SmallVector<MTL::Buffer *> Buffers;
-    std::shared_ptr<MTLTexture> FrameBufferTexture;
-    std::shared_ptr<MTLBuffer> FrameBufferReadback;
-    std::shared_ptr<MTLTexture> DepthStencil;
+    std::unique_ptr<MTLTexture> FrameBufferTexture;
+    std::unique_ptr<MTLBuffer> FrameBufferReadback;
+    std::unique_ptr<MTLTexture> DepthStencil;
     std::unique_ptr<MTLCommandBuffer> CB;
     std::unique_ptr<offloadtest::Fence> CompletionFence;
   };
@@ -527,7 +527,7 @@ class MTLDevice : public offloadtest::Device {
     if (!TexOrErr)
       return TexOrErr.takeError();
 
-    IS.FrameBufferTexture = std::static_pointer_cast<MTLTexture>(*TexOrErr);
+    IS.FrameBufferTexture.reset(static_cast<MTLTexture *>(TexOrErr->release()));
 
     // Create a readback buffer for copying render target data to the CPU.
     BufferCreateDesc BufDesc = {};
@@ -535,7 +535,7 @@ class MTLDevice : public offloadtest::Device {
     auto BufOrErr = createBuffer("RTReadback", BufDesc, OutBuf.size());
     if (!BufOrErr)
       return BufOrErr.takeError();
-    IS.FrameBufferReadback = std::static_pointer_cast<MTLBuffer>(*BufOrErr);
+    IS.FrameBufferReadback.reset(static_cast<MTLBuffer *>(BufOrErr->release()));
 
     return llvm::Error::success();
   }
@@ -546,7 +546,7 @@ class MTLDevice : public offloadtest::Device {
         P.Bindings.RTargetBufferPtr->OutputProps.Height);
     if (!TexOrErr)
       return TexOrErr.takeError();
-    IS.DepthStencil = std::static_pointer_cast<MTLTexture>(*TexOrErr);
+    IS.DepthStencil.reset(static_cast<MTLTexture *>(TexOrErr->release()));
     return llvm::Error::success();
   }
 
@@ -733,7 +733,7 @@ public:
     return MTLFence::create(Device, Name);
   }
 
-  llvm::Expected<std::shared_ptr<offloadtest::Buffer>>
+  llvm::Expected<std::unique_ptr<offloadtest::Buffer>>
   createBuffer(std::string Name, BufferCreateDesc &Desc,
                size_t SizeInBytes) override {
     MTL::Buffer *Buf = Device->newBuffer(
@@ -741,10 +741,10 @@ public:
     if (!Buf)
       return llvm::createStringError(std::errc::not_enough_memory,
                                      "Failed to create Metal buffer.");
-    return std::make_shared<MTLBuffer>(Buf, Name, Desc, SizeInBytes);
+    return std::make_unique<MTLBuffer>(Buf, Name, Desc, SizeInBytes);
   }
 
-  llvm::Expected<std::shared_ptr<offloadtest::Texture>>
+  llvm::Expected<std::unique_ptr<offloadtest::Texture>>
   createTexture(std::string Name, TextureCreateDesc &Desc) override {
     if (auto Err = validateTextureCreateDesc(Desc))
       return Err;
@@ -760,7 +760,7 @@ public:
     if (!Tex)
       return llvm::createStringError(std::errc::not_enough_memory,
                                      "Failed to create Metal texture.");
-    return std::make_shared<MTLTexture>(Tex, Name, Desc);
+    return std::make_unique<MTLTexture>(Tex, Name, Desc);
   }
 
   llvm::Expected<std::unique_ptr<offloadtest::CommandBuffer>>

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -119,7 +119,7 @@ public:
 class MTLBuffer : public offloadtest::Buffer {
 public:
   static bool classof(const offloadtest::Buffer *B) {
-    return B->getKind() == GPUAPI::Metal;
+    return B->getAPI() == GPUAPI::Metal;
   }
 
   MTL::Buffer *Buf;
@@ -141,7 +141,7 @@ public:
 class MTLTexture : public offloadtest::Texture {
 public:
   static bool classof(const offloadtest::Texture *T) {
-    return T->getKind() == GPUAPI::Metal;
+    return T->getAPI() == GPUAPI::Metal;
   }
 
   MTL::Texture *Tex;

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -15,7 +15,6 @@
 
 #include "llvm/ADT/ScopeExit.h"
 #include "llvm/ADT/SmallString.h"
-#include "llvm/Support/Casting.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/JSON.h"
 #include "llvm/Support/raw_ostream.h"

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -14,8 +14,8 @@
 #include "Support/Pipeline.h"
 
 #include "llvm/ADT/ScopeExit.h"
-#include "llvm/Support/Casting.h"
 #include "llvm/ADT/SmallString.h"
+#include "llvm/Support/Casting.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/JSON.h"
 #include "llvm/Support/raw_ostream.h"

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -374,10 +374,6 @@ namespace {
 
 class VulkanBuffer : public offloadtest::Buffer {
 public:
-  static bool classof(const offloadtest::Buffer *B) {
-    return B->getAPI() == GPUAPI::Vulkan;
-  }
-
   VkDevice Dev; // Needed for clean-up
   VkBuffer Buffer;
   VkDeviceMemory Memory;
@@ -394,14 +390,14 @@ public:
     vkDestroyBuffer(Dev, Buffer, nullptr);
     vkFreeMemory(Dev, Memory, nullptr);
   }
+
+  static bool classof(const offloadtest::Buffer *B) {
+    return B->getAPI() == GPUAPI::Vulkan;
+  }
 };
 
 class VulkanTexture : public offloadtest::Texture {
 public:
-  static bool classof(const offloadtest::Texture *T) {
-    return T->getAPI() == GPUAPI::Vulkan;
-  }
-
   VkDevice Dev;
   VkImage Image;
   VkDeviceMemory Memory;
@@ -424,6 +420,10 @@ public:
       vkDestroyImageView(Dev, View, nullptr);
     vkDestroyImage(Dev, Image, nullptr);
     vkFreeMemory(Dev, Memory, nullptr);
+  }
+
+  static bool classof(const offloadtest::Texture *T) {
+    return T->getAPI() == GPUAPI::Vulkan;
   }
 };
 
@@ -489,10 +489,6 @@ public:
 
 class VulkanCommandBuffer : public offloadtest::CommandBuffer {
 public:
-  static bool classof(const CommandBuffer *CB) {
-    return CB->getKind() == GPUAPI::Vulkan;
-  }
-
   VkDevice Device = VK_NULL_HANDLE;
   // Owned per command buffer so that recording, submission, and lifetime
   // management of each command buffer are independently safe without external
@@ -533,6 +529,10 @@ public:
   ~VulkanCommandBuffer() override {
     if (CmdPool != VK_NULL_HANDLE)
       vkDestroyCommandPool(Device, CmdPool, nullptr);
+  }
+
+  static bool classof(const CommandBuffer *CB) {
+    return CB->getKind() == GPUAPI::Vulkan;
   }
 
 private:

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -375,7 +375,7 @@ namespace {
 class VulkanBuffer : public offloadtest::Buffer {
 public:
   static bool classof(const offloadtest::Buffer *B) {
-    return B->getKind() == GPUAPI::Vulkan;
+    return B->getAPI() == GPUAPI::Vulkan;
   }
 
   VkDevice Dev; // Needed for clean-up
@@ -399,7 +399,7 @@ public:
 class VulkanTexture : public offloadtest::Texture {
 public:
   static bool classof(const offloadtest::Texture *T) {
-    return T->getKind() == GPUAPI::Vulkan;
+    return T->getAPI() == GPUAPI::Vulkan;
   }
 
   VkDevice Dev;

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -14,6 +14,7 @@
 #include "VKResources.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/ScopeExit.h"
+#include "llvm/Support/Casting.h"
 #include "llvm/Support/Error.h"
 
 #include <algorithm>
@@ -374,6 +375,10 @@ namespace {
 
 class VulkanBuffer : public offloadtest::Buffer {
 public:
+  static bool classof(const offloadtest::Buffer *B) {
+    return B->getKind() == GPUAPI::Vulkan;
+  }
+
   VkDevice Dev; // Needed for clean-up
   VkBuffer Buffer;
   VkDeviceMemory Memory;
@@ -383,8 +388,8 @@ public:
 
   VulkanBuffer(VkDevice Dev, VkBuffer Buffer, VkDeviceMemory Memory,
                llvm::StringRef Name, BufferCreateDesc Desc, size_t SizeInBytes)
-      : Dev(Dev), Buffer(Buffer), Memory(Memory), Name(Name), Desc(Desc),
-        SizeInBytes(SizeInBytes) {}
+      : offloadtest::Buffer(GPUAPI::Vulkan), Dev(Dev), Buffer(Buffer),
+        Memory(Memory), Name(Name), Desc(Desc), SizeInBytes(SizeInBytes) {}
 
   ~VulkanBuffer() override {
     vkDestroyBuffer(Dev, Buffer, nullptr);
@@ -394,6 +399,10 @@ public:
 
 class VulkanTexture : public offloadtest::Texture {
 public:
+  static bool classof(const offloadtest::Texture *T) {
+    return T->getKind() == GPUAPI::Vulkan;
+  }
+
   VkDevice Dev;
   VkImage Image;
   VkDeviceMemory Memory;
@@ -408,7 +417,8 @@ public:
 
   VulkanTexture(VkDevice Dev, VkImage Image, VkDeviceMemory Memory,
                 llvm::StringRef Name, TextureCreateDesc Desc)
-      : Dev(Dev), Image(Image), Memory(Memory), Name(Name), Desc(Desc) {}
+      : offloadtest::Texture(GPUAPI::Vulkan), Dev(Dev), Image(Image),
+        Memory(Memory), Name(Name), Desc(Desc) {}
 
   ~VulkanTexture() override {
     if (View)
@@ -621,9 +631,9 @@ private:
 
     // FrameBuffer associated data for offscreen rendering.
     VkFramebuffer FrameBuffer = VK_NULL_HANDLE;
-    std::unique_ptr<VulkanTexture> RenderTarget;
-    std::unique_ptr<VulkanBuffer> RTReadback;
-    std::unique_ptr<VulkanTexture> DepthStencil;
+    std::unique_ptr<offloadtest::Texture> RenderTarget;
+    std::unique_ptr<offloadtest::Buffer> RTReadback;
+    std::unique_ptr<offloadtest::Texture> DepthStencil;
     std::optional<ResourceRef> VertexBuffer = std::nullopt;
 
     VkRenderPass RenderPass = VK_NULL_HANDLE;
@@ -1227,7 +1237,7 @@ public:
     if (!TexOrErr)
       return TexOrErr.takeError();
 
-    IS.RenderTarget.reset(static_cast<VulkanTexture *>(TexOrErr->release()));
+    IS.RenderTarget = std::move(*TexOrErr);
 
     // Create a host-visible staging buffer for readback.
     BufferCreateDesc BufDesc = {};
@@ -1235,7 +1245,7 @@ public:
     auto BufOrErr = createBuffer("RTReadback", BufDesc, RTBuf.size());
     if (!BufOrErr)
       return BufOrErr.takeError();
-    IS.RTReadback.reset(static_cast<VulkanBuffer *>(BufOrErr->release()));
+    IS.RTReadback = std::move(*BufOrErr);
 
     return llvm::Error::success();
   }
@@ -1246,7 +1256,7 @@ public:
         P.Bindings.RTargetBufferPtr->OutputProps.Height);
     if (!TexOrErr)
       return TexOrErr.takeError();
-    IS.DepthStencil.reset(static_cast<VulkanTexture *>(TexOrErr->release()));
+    IS.DepthStencil = std::move(*TexOrErr);
     return llvm::Error::success();
   }
 
@@ -1638,9 +1648,12 @@ public:
   }
 
   llvm::Error createRenderPass(InvocationState &IS) {
+    auto &RT = llvm::cast<VulkanTexture>(*IS.RenderTarget);
+    auto &DS = llvm::cast<VulkanTexture>(*IS.DepthStencil);
+
     std::array<VkAttachmentDescription, 2> Attachments = {};
 
-    Attachments[0].format = getVulkanFormat(IS.RenderTarget->Desc.Fmt);
+    Attachments[0].format = getVulkanFormat(RT.Desc.Fmt);
     Attachments[0].samples = VK_SAMPLE_COUNT_1_BIT;
     Attachments[0].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
     Attachments[0].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
@@ -1649,7 +1662,7 @@ public:
     Attachments[0].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     Attachments[0].finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
-    Attachments[1].format = getVulkanFormat(IS.DepthStencil->Desc.Fmt);
+    Attachments[1].format = getVulkanFormat(DS.Desc.Fmt);
     Attachments[1].samples = VK_SAMPLE_COUNT_1_BIT;
     Attachments[1].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
     Attachments[1].storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
@@ -1720,16 +1733,18 @@ public:
   }
 
   llvm::Error createFrameBuffer(InvocationState &IS) {
-    std::array<VkImageView, 2> Views = {IS.RenderTarget->View,
-                                        IS.DepthStencil->View};
+    auto &RT = llvm::cast<VulkanTexture>(*IS.RenderTarget);
+    auto &DS = llvm::cast<VulkanTexture>(*IS.DepthStencil);
+
+    std::array<VkImageView, 2> Views = {RT.View, DS.View};
 
     VkFramebufferCreateInfo FbufCreateInfo = {};
     FbufCreateInfo.sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
     FbufCreateInfo.renderPass = IS.RenderPass;
     FbufCreateInfo.attachmentCount = Views.size();
     FbufCreateInfo.pAttachments = Views.data();
-    FbufCreateInfo.width = IS.RenderTarget->Desc.Width;
-    FbufCreateInfo.height = IS.RenderTarget->Desc.Height;
+    FbufCreateInfo.width = RT.Desc.Width;
+    FbufCreateInfo.height = RT.Desc.Height;
     FbufCreateInfo.layers = 1;
 
     if (vkCreateFramebuffer(Device, &FbufCreateInfo, nullptr, &IS.FrameBuffer))
@@ -2277,14 +2292,17 @@ public:
       copyResourceDataToDevice(IS, R);
 
     if (P.isGraphics()) {
+      auto &RT = llvm::cast<VulkanTexture>(*IS.RenderTarget);
+      auto &DS = llvm::cast<VulkanTexture>(*IS.DepthStencil);
+
       const auto *ColorCV =
-          std::get_if<ClearColor>(&*IS.RenderTarget->Desc.OptimizedClearValue);
+          std::get_if<ClearColor>(&*RT.Desc.OptimizedClearValue);
       if (!ColorCV)
         return llvm::createStringError(
             std::errc::invalid_argument,
             "Render target clear value must be a ClearColor.");
-      const auto *DepthCV = std::get_if<ClearDepthStencil>(
-          &*IS.DepthStencil->Desc.OptimizedClearValue);
+      const auto *DepthCV =
+          std::get_if<ClearDepthStencil>(&*DS.Desc.OptimizedClearValue);
       if (!DepthCV)
         return llvm::createStringError(
             std::errc::invalid_argument,
@@ -2358,7 +2376,9 @@ public:
       vkCmdDraw(IS.CB->CmdBuffer, P.Bindings.getVertexCount(), 1, 0, 0);
       llvm::outs() << "Drew " << P.Bindings.getVertexCount() << " vertices.\n";
       vkCmdEndRenderPass(IS.CB->CmdBuffer);
-      copyTextureToReadback(IS.CB->CmdBuffer, *IS.RenderTarget, *IS.RTReadback,
+      copyTextureToReadback(IS.CB->CmdBuffer,
+                            llvm::cast<VulkanTexture>(*IS.RenderTarget),
+                            llvm::cast<VulkanBuffer>(*IS.RTReadback),
                             VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
                             VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
                             VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT);
@@ -2412,19 +2432,21 @@ public:
 
     // Copy back the frame buffer data if this was a graphics pipeline.
     if (P.isGraphics()) {
+      auto &Readback = llvm::cast<VulkanBuffer>(*IS.RTReadback);
+
       VkMappedMemoryRange Range = {};
       Range.sType = VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE;
       Range.offset = 0;
       Range.size = VK_WHOLE_SIZE;
-      Range.memory = IS.RTReadback->Memory;
+      Range.memory = Readback.Memory;
 
       void *Mapped = nullptr; // NOLINT(misc-const-correctness)
-      vkMapMemory(Device, IS.RTReadback->Memory, 0, VK_WHOLE_SIZE, 0, &Mapped);
+      vkMapMemory(Device, Readback.Memory, 0, VK_WHOLE_SIZE, 0, &Mapped);
       vkInvalidateMappedMemoryRanges(Device, 1, &Range);
 
       const CPUBuffer &B = *P.Bindings.RTargetBufferPtr;
       memcpy(B.Data[0].get(), Mapped, B.size());
-      vkUnmapMemory(Device, IS.RTReadback->Memory);
+      vkUnmapMemory(Device, Readback.Memory);
     }
     return llvm::Error::success();
   }

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -14,7 +14,6 @@
 #include "VKResources.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/ScopeExit.h"
-#include "llvm/Support/Casting.h"
 #include "llvm/Support/Error.h"
 
 #include <algorithm>

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -621,9 +621,9 @@ private:
 
     // FrameBuffer associated data for offscreen rendering.
     VkFramebuffer FrameBuffer = VK_NULL_HANDLE;
-    std::shared_ptr<VulkanTexture> RenderTarget;
-    std::shared_ptr<VulkanBuffer> RTReadback;
-    std::shared_ptr<VulkanTexture> DepthStencil;
+    std::unique_ptr<VulkanTexture> RenderTarget;
+    std::unique_ptr<VulkanBuffer> RTReadback;
+    std::unique_ptr<VulkanTexture> DepthStencil;
     std::optional<ResourceRef> VertexBuffer = std::nullopt;
 
     VkRenderPass RenderPass = VK_NULL_HANDLE;
@@ -786,7 +786,7 @@ public:
     return VulkanFence::create(Device, Name);
   }
 
-  llvm::Expected<std::shared_ptr<offloadtest::Buffer>>
+  llvm::Expected<std::unique_ptr<offloadtest::Buffer>>
   createBuffer(std::string Name, BufferCreateDesc &Desc,
                size_t SizeInBytes) override {
     VkBufferCreateInfo BufInfo = {};
@@ -822,11 +822,11 @@ public:
       return llvm::createStringError(std::errc::io_error,
                                      "Failed to bind device buffer memory.");
 
-    return std::make_shared<VulkanBuffer>(Device, DeviceBuffer, DeviceMemory,
+    return std::make_unique<VulkanBuffer>(Device, DeviceBuffer, DeviceMemory,
                                           Name, Desc, SizeInBytes);
   }
 
-  llvm::Expected<std::shared_ptr<offloadtest::Texture>>
+  llvm::Expected<std::unique_ptr<offloadtest::Texture>>
   createTexture(std::string Name, TextureCreateDesc &Desc) override {
     if (auto Err = validateTextureCreateDesc(Desc))
       return Err;
@@ -876,7 +876,7 @@ public:
                                      "Failed to bind image memory.");
     }
 
-    auto Tex = std::make_shared<VulkanTexture>(Device, Image, DeviceMemory,
+    auto Tex = std::make_unique<VulkanTexture>(Device, Image, DeviceMemory,
                                                Name, Desc);
 
     const bool IsRT = (Desc.Usage & TextureUsage::RenderTarget) != 0;
@@ -1227,7 +1227,7 @@ public:
     if (!TexOrErr)
       return TexOrErr.takeError();
 
-    IS.RenderTarget = std::static_pointer_cast<VulkanTexture>(*TexOrErr);
+    IS.RenderTarget.reset(static_cast<VulkanTexture *>(TexOrErr->release()));
 
     // Create a host-visible staging buffer for readback.
     BufferCreateDesc BufDesc = {};
@@ -1235,7 +1235,7 @@ public:
     auto BufOrErr = createBuffer("RTReadback", BufDesc, RTBuf.size());
     if (!BufOrErr)
       return BufOrErr.takeError();
-    IS.RTReadback = std::static_pointer_cast<VulkanBuffer>(*BufOrErr);
+    IS.RTReadback.reset(static_cast<VulkanBuffer *>(BufOrErr->release()));
 
     return llvm::Error::success();
   }
@@ -1246,7 +1246,7 @@ public:
         P.Bindings.RTargetBufferPtr->OutputProps.Height);
     if (!TexOrErr)
       return TexOrErr.takeError();
-    IS.DepthStencil = std::static_pointer_cast<VulkanTexture>(*TexOrErr);
+    IS.DepthStencil.reset(static_cast<VulkanTexture *>(TexOrErr->release()));
     return llvm::Error::success();
   }
 


### PR DESCRIPTION
Follow-up on the discussions at: https://github.com/llvm/offload-test-suite/pull/1020#discussion_r3073568722 & https://github.com/llvm/offload-test-suite/pull/1020#discussion_r3063962742

This PR does the following:
- Use `offloadtest::Texture` and `offloadtest::Buffer` types in backends `InvocationState` 
- Switch the usage of `shared_ptr` for those types to `unique_ptr`
- Add LLVM-style RTTI on `Buffer` and `Texture`