### PR TITLE
Fix `-Wchanges-meaning` errors from newer GCC

### DIFF
--- a/include/API/FormatConversion.h
+++ b/include/API/FormatConversion.h
@@ -114,12 +114,12 @@ validateTextureDescMatchesCPUBuffer(const TextureCreateDesc &Desc,
   auto ExpectedFmt = toFormat(Buf.Format, Buf.Channels);
   if (!ExpectedFmt)
     return ExpectedFmt.takeError();
-  if (Desc.Format != *ExpectedFmt)
+  if (Desc.Fmt != *ExpectedFmt)
     return llvm::createStringError(
         std::errc::invalid_argument,
         "TextureCreateDesc format '%s' does not match CPUBuffer format "
         "(DataFormat %d, %d channels -> '%s').",
-        getFormatName(Desc.Format).data(), static_cast<int>(Buf.Format),
+        getFormatName(Desc.Fmt).data(), static_cast<int>(Buf.Format),
         Buf.Channels, getFormatName(*ExpectedFmt).data());
   if (Desc.Width != static_cast<uint32_t>(Buf.OutputProps.Width))
     return llvm::createStringError(
@@ -137,7 +137,7 @@ validateTextureDescMatchesCPUBuffer(const TextureCreateDesc &Desc,
         "TextureCreateDesc mip levels %u does not match CPUBuffer mip "
         "levels %d.",
         Desc.MipLevels, Buf.OutputProps.MipLevels);
-  const uint32_t TexelSize = getFormatSizeInBytes(Desc.Format);
+  const uint32_t TexelSize = getFormatSizeInBytes(Desc.Fmt);
   if (Buf.Stride > 0 && static_cast<uint32_t>(Buf.Stride) != TexelSize)
     return llvm::createStringError(
         std::errc::invalid_argument,

--- a/include/API/Texture.h
+++ b/include/API/Texture.h
@@ -65,7 +65,7 @@ using ClearValue = std::variant<ClearColor, ClearDepthStencil>;
 struct TextureCreateDesc {
   MemoryLocation Location;
   TextureUsage Usage;
-  Format Format;
+  Format Fmt;
   uint32_t Width;
   uint32_t Height;
   uint32_t MipLevels;
@@ -77,13 +77,13 @@ struct TextureCreateDesc {
 };
 
 inline llvm::Error validateTextureCreateDesc(const TextureCreateDesc &Desc) {
-  if (!isTextureCompatible(Desc.Format))
+  if (!isTextureCompatible(Desc.Fmt))
     return llvm::createStringError(
         std::errc::invalid_argument,
         "Format '%s' is not compatible with texture creation.",
-        getFormatName(Desc.Format).data());
+        getFormatName(Desc.Fmt).data());
 
-  const bool IsDepth = isDepthFormat(Desc.Format);
+  const bool IsDepth = isDepthFormat(Desc.Fmt);
   const bool IsRT = (Desc.Usage & TextureUsage::RenderTarget) != 0;
   const bool IsDS = (Desc.Usage & TextureUsage::DepthStencil) != 0;
 
@@ -104,12 +104,12 @@ inline llvm::Error validateTextureCreateDesc(const TextureCreateDesc &Desc) {
     return llvm::createStringError(
         std::errc::invalid_argument,
         "Depth format '%s' requires DepthStencil usage.",
-        getFormatName(Desc.Format).data());
+        getFormatName(Desc.Fmt).data());
   if (!IsDepth && IsDS)
     return llvm::createStringError(
         std::errc::invalid_argument,
         "DepthStencil usage requires a depth format, got '%s'.",
-        getFormatName(Desc.Format).data());
+        getFormatName(Desc.Fmt).data());
 
   // Render targets and depth/stencil textures only support a single mip level.
   if ((IsRT || IsDS) && Desc.MipLevels != 1)

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -476,7 +476,7 @@ private:
     ComPtr<ID3D12DescriptorHeap> DescHeap;
     ComPtr<ID3D12PipelineState> PSO;
     std::unique_ptr<DXCommandBuffer> CB;
-    std::unique_ptr<offloadtest::Fence> Fence;
+    std::unique_ptr<offloadtest::Fence> CompletionFence;
 
     // Resources for graphics pipelines.
     std::shared_ptr<DXTexture> RT;
@@ -556,7 +556,7 @@ public:
     TexDesc.Height = Desc.Height;
     TexDesc.DepthOrArraySize = 1;
     TexDesc.MipLevels = static_cast<UINT16>(Desc.MipLevels);
-    TexDesc.Format = getDXGIFormat(Desc.Format);
+    TexDesc.Format = getDXGIFormat(Desc.Fmt);
     TexDesc.SampleDesc.Count = 1;
     TexDesc.Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN;
     TexDesc.Flags = getDXResourceFlags(Desc.Usage);
@@ -1340,14 +1340,14 @@ public:
     // This is a hack but it works since this is all single threaded code.
     static uint64_t FenceCounter = 0;
     const uint64_t CurrentCounter = FenceCounter + 1;
-    auto *F = static_cast<DXFence *>(IS.Fence.get());
+    auto *F = static_cast<DXFence *>(IS.CompletionFence.get());
 
     if (auto Err = HR::toError(
             GraphicsQueue.Queue->Signal(F->Fence.Get(), CurrentCounter),
             "Failed to add signal."))
       return Err;
 
-    if (auto Err = IS.Fence->waitForCompletion(CurrentCounter))
+    if (auto Err = IS.CompletionFence->waitForCompletion(CurrentCounter))
       return Err;
 
     FenceCounter = CurrentCounter;
@@ -1682,7 +1682,7 @@ public:
     PSODesc.DepthStencilState.DepthWriteMask = D3D12_DEPTH_WRITE_MASK_ALL;
     PSODesc.DepthStencilState.DepthFunc = D3D12_COMPARISON_FUNC_LESS;
     PSODesc.DepthStencilState.StencilEnable = false;
-    PSODesc.DSVFormat = getDXGIFormat(IS.DS->Desc.Format);
+    PSODesc.DSVFormat = getDXGIFormat(IS.DS->Desc.Fmt);
     PSODesc.SampleMask = UINT_MAX;
     PSODesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
     PSODesc.NumRenderTargets = 1;
@@ -1840,7 +1840,7 @@ public:
     auto FenceOrErr = createFence("Fence");
     if (!FenceOrErr)
       return FenceOrErr.takeError();
-    State.Fence = std::move(*FenceOrErr);
+    State.CompletionFence = std::move(*FenceOrErr);
 
     if (auto Err = createBuffers(P, State))
       return Err;

--- a/lib/API/Device.cpp
+++ b/lib/API/Device.cpp
@@ -75,7 +75,7 @@ offloadtest::createRenderTargetFromCPUBuffer(Device &Dev,
   TextureCreateDesc Desc = {};
   Desc.Location = MemoryLocation::GpuOnly;
   Desc.Usage = TextureUsage::RenderTarget;
-  Desc.Format = *TexFmtOrErr;
+  Desc.Fmt = *TexFmtOrErr;
   Desc.Width = Buf.OutputProps.Width;
   Desc.Height = Buf.OutputProps.Height;
   Desc.MipLevels = 1;
@@ -93,7 +93,7 @@ offloadtest::createDefaultDepthStencilTarget(Device &Dev, uint32_t Width,
   TextureCreateDesc Desc = {};
   Desc.Location = MemoryLocation::GpuOnly;
   Desc.Usage = TextureUsage::DepthStencil;
-  Desc.Format = Format::D32FloatS8Uint;
+  Desc.Fmt = Format::D32FloatS8Uint;
   Desc.Width = Width;
   Desc.Height = Height;
   Desc.MipLevels = 1;

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -204,7 +204,7 @@ class MTLDevice : public offloadtest::Device {
     std::shared_ptr<MTLBuffer> FrameBufferReadback;
     std::shared_ptr<MTLTexture> DepthStencil;
     std::unique_ptr<MTLCommandBuffer> CB;
-    std::unique_ptr<offloadtest::Fence> Fence;
+    std::unique_ptr<offloadtest::Fence> CompletionFence;
   };
 
   llvm::Error setupVertexShader(InvocationState &IS, const Pipeline &P,
@@ -632,7 +632,7 @@ class MTLDevice : public offloadtest::Device {
     // Blit the render target into the readback buffer for CPU access.
     MTL::BlitCommandEncoder *Blit = IS.CB->CmdBuffer->blitCommandEncoder();
     const size_t ElemSize =
-        getFormatSizeInBytes(IS.FrameBufferTexture->Desc.Format);
+        getFormatSizeInBytes(IS.FrameBufferTexture->Desc.Fmt);
     const size_t RowBytes = Width * ElemSize;
     Blit->copyFromTexture(IS.FrameBufferTexture->Tex, 0, 0,
                           MTL::Origin(0, 0, 0), MTL::Size(Width, Height, 1),
@@ -646,12 +646,12 @@ class MTLDevice : public offloadtest::Device {
     // This is a hack but it works since this is all single threaded code.
     static uint64_t FenceCounter = 0;
     const uint64_t CurrentCounter = FenceCounter + 1;
-    auto *F = static_cast<MTLFence *>(IS.Fence.get());
+    auto *F = static_cast<MTLFence *>(IS.CompletionFence.get());
 
     IS.CB->CmdBuffer->encodeSignalEvent(F->Event, CurrentCounter);
     IS.CB->CmdBuffer->commit();
 
-    if (auto Err = IS.Fence->waitForCompletion(CurrentCounter))
+    if (auto Err = IS.CompletionFence->waitForCompletion(CurrentCounter))
       return Err;
 
     // Check and surface any errors that occurred during execution.
@@ -750,7 +750,7 @@ public:
       return Err;
 
     MTL::TextureDescriptor *TDesc = MTL::TextureDescriptor::texture2DDescriptor(
-        getMetalPixelFormat(Desc.Format), Desc.Width, Desc.Height,
+        getMetalPixelFormat(Desc.Fmt), Desc.Width, Desc.Height,
         Desc.MipLevels > 1);
     TDesc->setMipmapLevelCount(Desc.MipLevels);
     TDesc->setStorageMode(getMetalTextureStorageMode(Desc.Location));
@@ -779,7 +779,7 @@ public:
     auto FenceOrErr = createFence("Fence");
     if (!FenceOrErr)
       return FenceOrErr.takeError();
-    IS.Fence = std::move(*FenceOrErr);
+    IS.CompletionFence = std::move(*FenceOrErr);
 
     if (auto Err = createBuffers(P, IS))
       return Err;

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -617,7 +617,7 @@ private:
     VkPipelineCache PipelineCache = VK_NULL_HANDLE;
     VkPipeline Pipeline = VK_NULL_HANDLE;
 
-    std::unique_ptr<Fence> Fence;
+    std::unique_ptr<offloadtest::Fence> CompletionFence;
 
     // FrameBuffer associated data for offscreen rendering.
     VkFramebuffer FrameBuffer = VK_NULL_HANDLE;
@@ -834,7 +834,7 @@ public:
     VkImageCreateInfo ImageInfo = {};
     ImageInfo.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
     ImageInfo.imageType = VK_IMAGE_TYPE_2D;
-    ImageInfo.format = getVulkanFormat(Desc.Format);
+    ImageInfo.format = getVulkanFormat(Desc.Fmt);
     ImageInfo.extent = {Desc.Width, Desc.Height, 1};
     ImageInfo.mipLevels = Desc.MipLevels;
     ImageInfo.arrayLayers = 1;
@@ -885,7 +885,7 @@ public:
       VkImageViewCreateInfo ViewCi = {};
       ViewCi.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
       ViewCi.viewType = VK_IMAGE_VIEW_TYPE_2D;
-      ViewCi.format = getVulkanFormat(Desc.Format);
+      ViewCi.format = getVulkanFormat(Desc.Fmt);
       ViewCi.subresourceRange.baseMipLevel = 0;
       ViewCi.subresourceRange.levelCount = 1;
       ViewCi.subresourceRange.baseArrayLayer = 0;
@@ -1308,7 +1308,7 @@ public:
       return llvm::createStringError(std::errc::device_or_resource_busy,
                                      "Could not end command buffer.");
 
-    auto *F = static_cast<VulkanFence *>(IS.Fence.get());
+    auto *F = static_cast<VulkanFence *>(IS.CompletionFence.get());
 
     VkTimelineSemaphoreSubmitInfo TimelineSubmitInfo = {};
     TimelineSubmitInfo.sType = VK_STRUCTURE_TYPE_TIMELINE_SEMAPHORE_SUBMIT_INFO;
@@ -1328,7 +1328,7 @@ public:
       return llvm::createStringError(std::errc::device_or_resource_busy,
                                      "Failed to submit to queue.");
 
-    if (auto Err = IS.Fence->waitForCompletion(CurrentCounter))
+    if (auto Err = IS.CompletionFence->waitForCompletion(CurrentCounter))
       return Err;
 
     vkFreeCommandBuffers(Device, IS.CB->CmdPool, 1, &IS.CB->CmdBuffer);
@@ -1640,7 +1640,7 @@ public:
   llvm::Error createRenderPass(InvocationState &IS) {
     std::array<VkAttachmentDescription, 2> Attachments = {};
 
-    Attachments[0].format = getVulkanFormat(IS.RenderTarget->Desc.Format);
+    Attachments[0].format = getVulkanFormat(IS.RenderTarget->Desc.Fmt);
     Attachments[0].samples = VK_SAMPLE_COUNT_1_BIT;
     Attachments[0].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
     Attachments[0].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
@@ -1649,7 +1649,7 @@ public:
     Attachments[0].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     Attachments[0].finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
-    Attachments[1].format = getVulkanFormat(IS.DepthStencil->Desc.Format);
+    Attachments[1].format = getVulkanFormat(IS.DepthStencil->Desc.Fmt);
     Attachments[1].samples = VK_SAMPLE_COUNT_1_BIT;
     Attachments[1].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
     Attachments[1].storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
@@ -2102,7 +2102,7 @@ public:
                              VkImageLayout OldLayout,
                              VkAccessFlags SrcAccessMask,
                              VkPipelineStageFlags SrcStageMask) {
-    const VkImageAspectFlags AspectMask = isDepthFormat(Tex.Desc.Format)
+    const VkImageAspectFlags AspectMask = isDepthFormat(Tex.Desc.Fmt)
                                               ? VK_IMAGE_ASPECT_DEPTH_BIT
                                               : VK_IMAGE_ASPECT_COLOR_BIT;
 
@@ -2512,7 +2512,7 @@ public:
     auto FenceOrErr = createFence("Fence");
     if (!FenceOrErr)
       return FenceOrErr.takeError();
-    State.Fence = std::move(*FenceOrErr);
+    State.CompletionFence = std::move(*FenceOrErr);
     if (auto Err = createShaderModules(P, State))
       return Err;
     llvm::outs() << "Shader module created.\n";


### PR DESCRIPTION
GCC 15 treats `-Wchanges-meaning` as an error, which fires when a struct member declaration shadows its own type name (e.g. `Format Format;` or `std::unique_ptr<Fence> Fence;`). CMake selects GCC as the default compiler on Linux when both GCC and Clang are installed, so the `OffloadTest` library fails to build on distros shipping GCC 15 (e.g. Arch Linux).

The shadowing was introduced by:
- PR #1020 (Introduce a new `Texture` type): `Format Format;` in `TextureCreateDesc`
- PR #1007 (Implement an abstract `Fence` type): `unique_ptr<Fence> Fence;` in `InvocationState` (all backends)

Rename the offending members to break the shadowing:
- `TextureCreateDesc::Format` -> `TextureCreateDesc::Fmt`
- `InvocationState::Fence` -> `InvocationState::CompletionFence` (all backends)