### PR TITLE
Remove/update XFAILs on tests related to resources in structs

### DIFF
--- a/test/Feature/ResourcesInStructs/array-of-structs-with-res.test
+++ b/test/Feature/ResourcesInStructs/array-of-structs-with-res.test
@@ -100,7 +100,7 @@ DescriptorSets:
 #--- end
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/351
-# XFAIL: Metal
+# XFAIL: Clang && Metal
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl

--- a/test/Feature/ResourcesInStructs/array-of-structs-with-res.test
+++ b/test/Feature/ResourcesInStructs/array-of-structs-with-res.test
@@ -99,6 +99,10 @@ DescriptorSets:
 ...
 #--- end
 
+# Bug: https://github.com/llvm/offload-test-suite/issues/305
+# Bug: https://github.com/llvm/offload-test-suite/issues/351
+# XFAIL: Metal
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/ResourcesInStructs/array-of-structs-with-res.test
+++ b/test/Feature/ResourcesInStructs/array-of-structs-with-res.test
@@ -99,9 +99,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Unimplemented https://github.com/llvm/wg-hlsl/issues/367
-# XFAIL: Clang
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/ResourcesInStructs/array-of-structs-with-res.test
+++ b/test/Feature/ResourcesInStructs/array-of-structs-with-res.test
@@ -99,7 +99,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug: https://github.com/llvm/offload-test-suite/issues/305
 # Bug: https://github.com/llvm/offload-test-suite/issues/351
 # XFAIL: Metal
 

--- a/test/Feature/ResourcesInStructs/res-array-of-matrix-in-struct.test
+++ b/test/Feature/ResourcesInStructs/res-array-of-matrix-in-struct.test
@@ -72,9 +72,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Unimplemented https://github.com/llvm/wg-hlsl/issues/367
-# XFAIL: Clang
-
 # Unimplemented https://github.com/microsoft/DirectXShaderCompiler/issues/8301
 # XFAIL: Vulkan && DXC
 

--- a/test/Feature/ResourcesInStructs/res-in-struct-mix.test
+++ b/test/Feature/ResourcesInStructs/res-in-struct-mix.test
@@ -118,8 +118,11 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug https://github.com/llvm/offload-test-suite/issues/642
+# Bug https://github.com/llvm/offload-test-suite/issues/351
 # XFAIL: Metal
+
+# DXC + Vulkan does not support global structures containing buffers.
+# UNSUPPORTED: DXC && Vulkan
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl

--- a/test/Feature/ResourcesInStructs/res-in-struct-mix.test
+++ b/test/Feature/ResourcesInStructs/res-in-struct-mix.test
@@ -14,7 +14,6 @@ class G : F {
   E e;
   StructuredBuffer<int> SrvBuf2;
   RWBuffer<int> UavBuf2;
-  uint n;
 };
 
 RWStructuredBuffer<int4> Out : register(u0);
@@ -119,15 +118,8 @@ DescriptorSets:
 ...
 #--- end
 
-# Unimplemented https://github.com/llvm/wg-hlsl/issues/367
-# XFAIL: Clang
-
 # Bug https://github.com/llvm/offload-test-suite/issues/642
 # XFAIL: Metal
-
-# Vulkan does not support global structures with buffers or structures
-# containing both resources and non-resources.
-# UNSUPPORTED: Vulkan
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl

--- a/test/Feature/ResourcesInStructs/res-in-struct-simple-array.test
+++ b/test/Feature/ResourcesInStructs/res-in-struct-simple-array.test
@@ -70,9 +70,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Unimplemented https://github.com/llvm/wg-hlsl/issues/367
-# XFAIL: Clang
-
 # Unimplemented https://github.com/llvm/offload-test-suite/issues/305
 # XFAIL: Metal
 

--- a/test/Feature/ResourcesInStructs/res-in-struct-simple-array.test
+++ b/test/Feature/ResourcesInStructs/res-in-struct-simple-array.test
@@ -70,7 +70,8 @@ DescriptorSets:
 ...
 #--- end
 
-# Unimplemented https://github.com/llvm/offload-test-suite/issues/305
+# Bug: https://github.com/llvm/offload-test-suite/issues/305
+# Bug: https://github.com/llvm/offload-test-suite/issues/351
 # XFAIL: Metal
 
 # RUN: split-file %s %t

--- a/test/Feature/ResourcesInStructs/res-in-struct-simple-one.test
+++ b/test/Feature/ResourcesInStructs/res-in-struct-simple-one.test
@@ -63,9 +63,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Unimplemented https://github.com/llvm/wg-hlsl/issues/367
-# XFAIL: Clang
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/ResourcesInStructs/res-in-struct-simple-one.test
+++ b/test/Feature/ResourcesInStructs/res-in-struct-simple-one.test
@@ -63,6 +63,9 @@ DescriptorSets:
 ...
 #--- end
 
+# Bug: https://github.com/llvm/offload-test-suite/issues/351
+# XFAIL: Metal
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/ResourcesInStructs/res-in-struct-simple-one.test
+++ b/test/Feature/ResourcesInStructs/res-in-struct-simple-one.test
@@ -64,7 +64,7 @@ DescriptorSets:
 #--- end
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/351
-# XFAIL: Metal
+# XFAIL: Clang && Metal
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl

--- a/test/Feature/ResourcesInStructs/res-of-matrix-in-struct.test
+++ b/test/Feature/ResourcesInStructs/res-of-matrix-in-struct.test
@@ -60,14 +60,9 @@ DescriptorSets:
 ...
 #--- end
 
-# Unimplemented https://github.com/llvm/wg-hlsl/issues/367
-# XFAIL: Clang
-
 # Unimplemented https://github.com/microsoft/DirectXShaderCompiler/issues/8302
 # XFAIL: Vulkan && DXC
-
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o
-


### PR DESCRIPTION
These should all be passing since https://github.com/llvm/llvm-project/issues/182989 is completed.