### PR TITLE
Add test for resources in structs with local variables/args and `this` access

### DIFF
--- a/test/Feature/ResourcesInStructs/res-in-struct-local-arg.test
+++ b/test/Feature/ResourcesInStructs/res-in-struct-local-arg.test
@@ -77,6 +77,9 @@ DescriptorSets:
 # Unimplemented https://github.com/llvm/wg-hlsl/issues/367
 # XFAIL: Clang
 
+# Unsupported on Metal - requires Vulkan feature robustBufferAccess
+# UNSUPPORTED: Metal
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/ResourcesInStructs/res-in-struct-local-arg.test
+++ b/test/Feature/ResourcesInStructs/res-in-struct-local-arg.test
@@ -1,0 +1,82 @@
+#--- source.hlsl
+
+// This test verifies handling of a simple resource in a struct
+// when used as a local argument.
+
+struct A {
+  RWBuffer<int> Buf;
+};
+
+[[vk::binding(5)]]
+A a1 : register(u5);
+
+A a2; // will bind to register u0
+
+int foo(A LocalA, uint Index) {
+  return LocalA.Buf[Index];
+}
+
+int bar(A LocalA, uint Index) {
+  A TmpA = LocalA;
+  RWBuffer<int> LocalBuf = TmpA.Buf;
+  return LocalBuf[Index];
+}
+
+[numthreads(8, 1, 1)]
+void main(uint3 ID : SV_GroupThreadID) {
+  a2.Buf[ID.x] = foo(a1, ID.x) + bar(a2, ID.x);
+}
+
+//--- pipeline.yaml
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+    DispatchSize: [1, 1, 1]
+Buffers:
+  - Name: BufA1
+    Format: Int32
+    Data:
+      [ 1, 2, 3, 4, 5, 6, 7, 8 ]
+
+  - Name: BufA2
+    Format: Int32
+    Data:
+      [ 10, 20, 30, 40, 50, 60, 70, 80 ]
+
+  - Name: ExpectedBufA2
+    Format: Int32
+    Data:
+      [ 11, 22, 33, 44, 55, 66, 77, 88 ]
+
+Results:
+  - Result: ExpectedResult
+    Rule: BufferExact
+    Actual: BufA2
+    Expected: ExpectedBufA2
+
+DescriptorSets:
+  - Resources:
+    - Name: BufA1
+      Kind: RWBuffer
+      DirectXBinding:
+        Register: 5
+        Space: 0
+      VulkanBinding:
+        Binding: 5
+    - Name: BufA2
+      Kind: RWBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+...
+#--- end
+
+# Unimplemented https://github.com/llvm/wg-hlsl/issues/367
+# XFAIL: Clang
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/ResourcesInStructs/res-in-struct-this-access.test
+++ b/test/Feature/ResourcesInStructs/res-in-struct-this-access.test
@@ -7,7 +7,7 @@ struct A {
   RWBuffer<int> Buf;
 
   int get(uint Index) {
-    return Buf[Index];
+    return this.Buf[Index];
   }
 };
 

--- a/test/Feature/ResourcesInStructs/res-in-struct-this-access.test
+++ b/test/Feature/ResourcesInStructs/res-in-struct-this-access.test
@@ -1,0 +1,76 @@
+#--- source.hlsl
+
+// This test verifies handling of a simple resource in a struct
+// when used as a local argument.
+
+struct A {
+  RWBuffer<int> Buf;
+
+  int get(uint Index) {
+    return Buf[Index];
+  }
+};
+
+[[vk::binding(5)]]
+A a1 : register(u5);
+
+A a2; // will bind to register u0
+
+[numthreads(8, 1, 1)]
+void main(uint3 ID : SV_GroupThreadID) {
+  a2.Buf[ID.x] = a1.get(ID.x) + a2.get(ID.x);
+}
+
+//--- pipeline.yaml
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+    DispatchSize: [1, 1, 1]
+Buffers:
+  - Name: BufA1
+    Format: Int32
+    Data:
+      [ 1, 2, 3, 4, 5, 6, 7, 8 ]
+
+  - Name: BufA2
+    Format: Int32
+    Data:
+      [ 10, 20, 30, 40, 50, 60, 70, 80 ]
+
+  - Name: ExpectedBufA2
+    Format: Int32
+    Data:
+      [ 11, 22, 33, 44, 55, 66, 77, 88 ]
+
+Results:
+  - Result: ExpectedResult
+    Rule: BufferExact
+    Actual: BufA2
+    Expected: ExpectedBufA2
+
+DescriptorSets:
+  - Resources:
+    - Name: BufA1
+      Kind: RWBuffer
+      DirectXBinding:
+        Register: 5
+        Space: 0
+      VulkanBinding:
+        Binding: 5
+    - Name: BufA2
+      Kind: RWBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+...
+#--- end
+
+# Unimplemented https://github.com/llvm/wg-hlsl/issues/367
+# XFAIL: Clang
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
Add tests with resources in structs that are testing:
- structure with a resource as a function argument and local variable
- resource in a struct accessed from a struct method
