### PR TITLE
Return `SubmitResult` from `Queue::submit()` instead of blocking

### DIFF
--- a/include/API/Device.h
+++ b/include/API/Device.h
@@ -54,19 +54,30 @@ protected:
   Fence() = default;
 };
 
+/// Returned by Queue::submit() so that callers can decide when to block.
+struct SubmitResult {
+  Fence *F;
+  uint64_t Value;
+
+  llvm::Error waitForCompletion() const { return F->waitForCompletion(Value); }
+};
+
 class Queue {
 public:
   virtual ~Queue() = 0;
+  Queue(const Queue &) = delete;
+  Queue &operator=(const Queue &) = delete;
+  Queue(Queue &&) = default;
+  Queue &operator=(Queue &&) = default;
 
-  /// Submit command buffers for execution and block until completion.
-  /// Command buffers execute in array order, but dependencies between them
-  /// require appropriate barriers within the command buffers themselves.
-  virtual llvm::Error
-  submit(llvm::SmallVectorImpl<std::unique_ptr<CommandBuffer>> &&CBs) = 0;
+  /// Submit command buffers for GPU execution.  Returns a fence + value that
+  /// the caller can wait on; the call itself does not block.
+  virtual llvm::Expected<SubmitResult>
+  submit(llvm::SmallVector<std::unique_ptr<CommandBuffer>> CBs) = 0;
 
   /// Convenience overload for submitting a single command buffer.
-  llvm::Error submit(std::unique_ptr<CommandBuffer> CB) {
-    llvm::SmallVector<std::unique_ptr<CommandBuffer>, 1> CBs;
+  llvm::Expected<SubmitResult> submit(std::unique_ptr<CommandBuffer> CB) {
+    llvm::SmallVector<std::unique_ptr<CommandBuffer>> CBs;
     CBs.push_back(std::move(CB));
     return submit(std::move(CBs));
   }

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -440,6 +440,16 @@ public:
   ComPtr<ID3D12CommandQueue> Queue;
   std::unique_ptr<DXFence> SubmitFence;
   uint64_t FenceCounter = 0;
+  // Batches of command buffers submitted to the GPU that may still be
+  // in-flight.  The ID3D12CommandAllocator owns the backing memory for
+  // recorded commands, so it must outlive GPU execution.  Each batch
+  // records the fence value it signals so we can non-blockingly query
+  // progress and release completed batches.
+  struct InFlightBatch {
+    uint64_t FenceValue;
+    llvm::SmallVector<std::unique_ptr<offloadtest::CommandBuffer>> CBs;
+  };
+  llvm::SmallVector<InFlightBatch> InFlightBatches;
 
   DXQueue(ComPtr<ID3D12CommandQueue> Queue,
           std::unique_ptr<DXFence> SubmitFence)
@@ -1984,12 +1994,21 @@ public:
 
 llvm::Expected<offloadtest::SubmitResult> DXQueue::submit(
     llvm::SmallVector<std::unique_ptr<offloadtest::CommandBuffer>> CBs) {
+  // Non-blocking: query how far the GPU has progressed and release
+  // command buffers from completed submissions.
+  {
+    const uint64_t Completed = SubmitFence->getFenceValue();
+    llvm::erase_if(InFlightBatches, [Completed](const InFlightBatch &B) {
+      return B.FenceValue <= Completed;
+    });
+  }
+
   llvm::SmallVector<ID3D12CommandList *> CmdLists;
   CmdLists.reserve(CBs.size());
 
-  // Wait on the previous submit's fence value before executing this batch,
-  // so that back-to-back submits don't overlap on the GPU. Skip on first
-  // submit since Wait(fence, 0) triggers a D3D12 validation warning.
+  // GPU-side wait so that back-to-back submits don't overlap on the GPU.
+  // Skip on first submit since Wait(fence, 0) triggers a D3D12 validation
+  // warning.
   if (FenceCounter > 0)
     if (auto Err =
             HR::toError(Queue->Wait(SubmitFence->Fence.Get(), FenceCounter),
@@ -2011,6 +2030,9 @@ llvm::Expected<offloadtest::SubmitResult> DXQueue::submit(
           HR::toError(Queue->Signal(SubmitFence->Fence.Get(), CurrentCounter),
                       "Failed to add signal."))
     return Err;
+
+  // Keep submitted command buffers alive until the GPU is done with them.
+  InFlightBatches.push_back({CurrentCounter, std::move(CBs)});
 
   return offloadtest::SubmitResult{SubmitFence.get(), CurrentCounter};
 }

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -462,8 +462,8 @@ public:
     return DXQueue(CmdQueue, std::move(*FenceOrErr));
   }
 
-  llvm::Error submit(
-      llvm::SmallVectorImpl<std::unique_ptr<offloadtest::CommandBuffer>> &&CBs)
+  llvm::Expected<offloadtest::SubmitResult>
+  submit(llvm::SmallVector<std::unique_ptr<offloadtest::CommandBuffer>> CBs)
       override;
 };
 
@@ -1024,18 +1024,15 @@ public:
         &HeapRangeStartOffset, &RangeTileCount, D3D12_TILE_MAPPING_FLAG_NONE);
 
     // Synchronize after UpdateTileMappings, which is a queue operation (not
-    // recorded into a command list). Use a dedicated fence to avoid
-    // conflicting signal values with the queue's SubmitFence.
-    auto FenceOrErr = DXFence::create(Device.Get(), "TileMappingFence");
-    if (!FenceOrErr)
-      return FenceOrErr.takeError();
-
-    if (auto Err =
-            HR::toError(CommandQueue->Signal((*FenceOrErr)->Fence.Get(), 1),
-                        "Failed to add signal."))
+    // recorded into a command list).
+    const uint64_t CurrentCounter = ++GraphicsQueue.FenceCounter;
+    if (auto Err = HR::toError(
+            CommandQueue->Signal(GraphicsQueue.SubmitFence->Fence.Get(),
+                                 CurrentCounter),
+            "Failed to add signal."))
       return Err;
 
-    return (*FenceOrErr)->waitForCompletion(1);
+    return GraphicsQueue.SubmitFence->waitForCompletion(CurrentCounter);
   }
 
   llvm::Expected<ResourceBundle> createSRV(Resource &R, InvocationState &IS) {
@@ -1474,7 +1471,8 @@ public:
     IS.CB->CmdList->ResourceBarrier(1, &Barrier);
   }
 
-  llvm::Error executeCommandList(InvocationState &IS) {
+  llvm::Expected<offloadtest::SubmitResult>
+  executeCommandList(InvocationState &IS) {
     return GraphicsQueue.submit(std::move(IS.CB));
   }
 
@@ -1969,9 +1967,12 @@ public:
       llvm::outs() << "Graphics command list created complete.\n";
     }
 
-    if (auto Err = executeCommandList(State))
-      return Err;
+    auto SubmitResult = executeCommandList(State);
+    if (!SubmitResult)
+      return SubmitResult.takeError();
     llvm::outs() << "Compute commands executed.\n";
+    if (auto Err = SubmitResult->waitForCompletion())
+      return Err;
     if (auto Err = readBack(P, State))
       return Err;
     llvm::outs() << "Read data back.\n";
@@ -1981,8 +1982,8 @@ public:
 };
 } // namespace
 
-llvm::Error DXQueue::submit(
-    llvm::SmallVectorImpl<std::unique_ptr<offloadtest::CommandBuffer>> &&CBs) {
+llvm::Expected<offloadtest::SubmitResult> DXQueue::submit(
+    llvm::SmallVector<std::unique_ptr<offloadtest::CommandBuffer>> CBs) {
   llvm::SmallVector<ID3D12CommandList *> CmdLists;
   CmdLists.reserve(CBs.size());
 
@@ -2011,11 +2012,7 @@ llvm::Error DXQueue::submit(
                       "Failed to add signal."))
     return Err;
 
-  // TODO: Return a Fence+value with keepalive lists instead of blocking here.
-  if (auto Err = SubmitFence->waitForCompletion(CurrentCounter))
-    return Err;
-
-  return llvm::Error::success();
+  return offloadtest::SubmitResult{SubmitFence.get(), CurrentCounter};
 }
 
 llvm::Error offloadtest::initializeDX12Devices(

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -75,21 +75,6 @@ static MTL::VertexFormat getMTLVertexFormat(DataFormat Format, int Channels) {
 }
 
 namespace {
-class MTLQueue : public offloadtest::Queue {
-public:
-  using Queue::submit;
-
-  MTL::CommandQueue *Queue;
-  MTLQueue(MTL::CommandQueue *Queue) : Queue(Queue) {}
-  ~MTLQueue() override {
-    if (Queue)
-      Queue->release();
-  }
-
-  llvm::Error submit(
-      llvm::SmallVectorImpl<std::unique_ptr<offloadtest::CommandBuffer>> &&CBs)
-      override;
-};
 
 class MTLFence : public offloadtest::Fence {
 public:
@@ -120,6 +105,26 @@ public:
                                      "Timed out waiting on shared event.");
     return llvm::Error::success();
   }
+};
+
+class MTLQueue : public offloadtest::Queue {
+public:
+  using Queue::submit;
+
+  MTL::CommandQueue *Queue;
+  std::unique_ptr<MTLFence> SubmitFence;
+  uint64_t FenceCounter = 0;
+
+  MTLQueue(MTL::CommandQueue *Queue, std::unique_ptr<MTLFence> SubmitFence)
+      : Queue(Queue), SubmitFence(std::move(SubmitFence)) {}
+  ~MTLQueue() override {
+    if (Queue)
+      Queue->release();
+  }
+
+  llvm::Expected<offloadtest::SubmitResult>
+  submit(llvm::SmallVector<std::unique_ptr<offloadtest::CommandBuffer>> CBs)
+      override;
 };
 
 class MTLBuffer : public offloadtest::Buffer {
@@ -187,23 +192,21 @@ private:
   MTLCommandBuffer() : CommandBuffer(GPUAPI::Metal) {}
 };
 
-llvm::Error MTLQueue::submit(
-    llvm::SmallVectorImpl<std::unique_ptr<offloadtest::CommandBuffer>> &&CBs) {
+llvm::Expected<offloadtest::SubmitResult> MTLQueue::submit(
+    llvm::SmallVector<std::unique_ptr<offloadtest::CommandBuffer>> CBs) {
   // Metal serial queues guarantee that command buffers execute in commit order,
   // so no explicit wait on prior work is needed here.
-  for (auto &CB : CBs)
-    llvm::cast<MTLCommandBuffer>(CB.get())->CmdBuffer->commit();
+  const uint64_t SignalValue = ++FenceCounter;
 
-  // TODO: Return a Fence+value with keepalive lists instead of blocking here.
-  for (auto &CB : CBs) {
-    auto &MCB = *llvm::cast<MTLCommandBuffer>(CB.get());
-    MCB.CmdBuffer->waitUntilCompleted();
-
-    NS::Error *Err = MCB.CmdBuffer->error();
-    if (Err)
-      return toError(Err);
+  for (size_t I = 0; I < CBs.size(); ++I) {
+    auto &MCB = *llvm::cast<MTLCommandBuffer>(CBs[I].get());
+    // Signal the submit fence when the last command buffer completes.
+    if (I == CBs.size() - 1)
+      MCB.CmdBuffer->encodeSignalEvent(SubmitFence->Event, SignalValue);
+    MCB.CmdBuffer->commit();
   }
-  return llvm::Error::success();
+
+  return offloadtest::SubmitResult{SubmitFence.get(), SignalValue};
 }
 class MTLDevice : public offloadtest::Device {
   Capabilities Caps;
@@ -677,7 +680,8 @@ class MTLDevice : public offloadtest::Device {
     return llvm::Error::success();
   }
 
-  llvm::Error executeCommands(InvocationState &IS) {
+  llvm::Expected<offloadtest::SubmitResult>
+  executeCommands(InvocationState &IS) {
     return GraphicsQueue.submit(std::move(IS.CB));
   }
 
@@ -732,8 +736,9 @@ class MTLDevice : public offloadtest::Device {
   }
 
 public:
-  MTLDevice(MTL::Device *D, MTL::CommandQueue *Q)
-      : Device(D), GraphicsQueue(MTLQueue(Q)) {
+  MTLDevice(MTL::Device *D, MTL::CommandQueue *Q,
+            std::unique_ptr<MTLFence> SubmitFence)
+      : Device(D), GraphicsQueue(Q, std::move(SubmitFence)) {
     Description = Device->name()->utf8String();
   }
   const Capabilities &getCapabilities() override {
@@ -811,7 +816,11 @@ public:
       llvm::outs() << "Created graphics commands.\n";
     }
 
-    if (auto Err = executeCommands(IS))
+    auto SubmitResult = executeCommands(IS);
+    if (!SubmitResult)
+      return SubmitResult.takeError();
+
+    if (auto Err = SubmitResult->waitForCompletion())
       return Err;
 
     if (auto Err = copyBack(P, IS))
@@ -832,7 +841,12 @@ llvm::Error offloadtest::initializeMetalDevices(
   MTL::Device *MetalDevice = MTL::CreateSystemDefaultDevice();
   MTL::CommandQueue *MetalQueue = MetalDevice->newCommandQueue();
 
-  auto DefaultDev = std::make_unique<MTLDevice>(MetalDevice, MetalQueue);
+  auto SubmitFenceOrErr = MTLFence::create(MetalDevice, "QueueSubmitFence");
+  if (!SubmitFenceOrErr)
+    return SubmitFenceOrErr.takeError();
+
+  auto DefaultDev = std::make_unique<MTLDevice>(MetalDevice, MetalQueue,
+                                                std::move(*SubmitFenceOrErr));
   Devices.push_back(std::move(DefaultDev));
 
   return llvm::Error::success();

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -115,6 +115,15 @@ public:
   std::unique_ptr<MTLFence> SubmitFence;
   uint64_t FenceCounter = 0;
 
+  // Batches of command buffers submitted to the GPU that may still be
+  // in-flight.  Each batch records the fence value it signals so we can
+  // non-blockingly query progress and release completed batches.
+  struct InFlightBatch {
+    uint64_t FenceValue;
+    llvm::SmallVector<std::unique_ptr<offloadtest::CommandBuffer>> CBs;
+  };
+  llvm::SmallVector<InFlightBatch> InFlightBatches;
+
   MTLQueue(MTL::CommandQueue *Queue, std::unique_ptr<MTLFence> SubmitFence)
       : Queue(Queue), SubmitFence(std::move(SubmitFence)) {}
   ~MTLQueue() override {
@@ -194,6 +203,15 @@ private:
 
 llvm::Expected<offloadtest::SubmitResult> MTLQueue::submit(
     llvm::SmallVector<std::unique_ptr<offloadtest::CommandBuffer>> CBs) {
+  // Non-blocking: query how far the GPU has progressed and release
+  // command buffers from completed submissions.
+  {
+    const uint64_t Completed = SubmitFence->getFenceValue();
+    llvm::erase_if(InFlightBatches, [Completed](const InFlightBatch &B) {
+      return B.FenceValue <= Completed;
+    });
+  }
+
   // Metal serial queues guarantee that command buffers execute in commit order,
   // so no explicit wait on prior work is needed here.
   const uint64_t SignalValue = ++FenceCounter;
@@ -205,6 +223,9 @@ llvm::Expected<offloadtest::SubmitResult> MTLQueue::submit(
       MCB.CmdBuffer->encodeSignalEvent(SubmitFence->Event, SignalValue);
     MCB.CmdBuffer->commit();
   }
+
+  // Keep submitted command buffers alive until the GPU is done with them.
+  InFlightBatches.push_back({SignalValue, std::move(CBs)});
 
   return offloadtest::SubmitResult{SubmitFence.get(), SignalValue};
 }

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -497,8 +497,8 @@ public:
       : Queue(Q), QueueFamilyIdx(QueueFamilyIdx), Device(Device),
         SubmitFence(std::move(SubmitFence)) {}
 
-  llvm::Error submit(
-      llvm::SmallVectorImpl<std::unique_ptr<offloadtest::CommandBuffer>> &&CBs)
+  llvm::Expected<offloadtest::SubmitResult>
+  submit(llvm::SmallVector<std::unique_ptr<offloadtest::CommandBuffer>> CBs)
       override;
 };
 
@@ -1343,7 +1343,8 @@ public:
     return llvm::Error::success();
   }
 
-  llvm::Error executeCommandBuffer(InvocationState &IS) {
+  llvm::Expected<offloadtest::SubmitResult>
+  executeCommandBuffer(InvocationState &IS) {
     return GraphicsQueue.submit(std::move(IS.CB));
   }
 
@@ -2464,7 +2465,11 @@ public:
   }
 
   void cleanup(InvocationState &IS) {
-    vkQueueWaitIdle(GraphicsQueue.Queue);
+    // Wait for all in-flight submissions to complete before destroying
+    // resources. On the happy path the caller already waited, but this
+    // handles early-return error paths.
+    llvm::consumeError(GraphicsQueue.SubmitFence->waitForCompletion(
+        GraphicsQueue.FenceCounter));
     for (auto &V : IS.BufferViews)
       vkDestroyBufferView(Device, V, nullptr);
 
@@ -2558,8 +2563,11 @@ public:
       llvm::outs() << "Frame buffer created.\n";
     }
     llvm::outs() << "Memory buffers created.\n";
-    if (auto Err = executeCommandBuffer(State))
-      return Err;
+    // No explicit wait: the next submit's GPU-side timeline semaphore
+    // dependency ensures the copy completes before the dispatch runs.
+    auto CopyResult = executeCommandBuffer(State);
+    if (!CopyResult)
+      return CopyResult.takeError();
     llvm::outs() << "Executed copy command buffer.\n";
     auto DispatchCBOrErr =
         VulkanCommandBuffer::create(Device, GraphicsQueue.QueueFamilyIdx);
@@ -2579,9 +2587,12 @@ public:
     if (auto Err = createCommands(P, State))
       return Err;
     llvm::outs() << "Commands created.\n";
-    if (auto Err = executeCommandBuffer(State))
-      return Err;
+    auto DispatchResult = executeCommandBuffer(State);
+    if (!DispatchResult)
+      return DispatchResult.takeError();
     llvm::outs() << "Executed compute command buffer.\n";
+    if (auto Err = DispatchResult->waitForCompletion())
+      return Err;
     if (auto Err = readBackData(P, State))
       return Err;
     llvm::outs() << "Compute pipeline created.\n";
@@ -2591,8 +2602,8 @@ public:
 };
 } // namespace
 
-llvm::Error VulkanQueue::submit(
-    llvm::SmallVectorImpl<std::unique_ptr<offloadtest::CommandBuffer>> &&CBs) {
+llvm::Expected<offloadtest::SubmitResult> VulkanQueue::submit(
+    llvm::SmallVector<std::unique_ptr<offloadtest::CommandBuffer>> CBs) {
   llvm::SmallVector<VkCommandBuffer> CmdBuffers;
   CmdBuffers.reserve(CBs.size());
 
@@ -2634,11 +2645,7 @@ llvm::Error VulkanQueue::submit(
                       "Failed to submit to queue."))
     return Err;
 
-  // TODO: Return a Fence+value with keepalive lists instead of blocking here.
-  if (auto Err = SubmitFence->waitForCompletion(SignalValue))
-    return Err;
-
-  return llvm::Error::success();
+  return offloadtest::SubmitResult{SubmitFence.get(), SignalValue};
 }
 
 llvm::Error offloadtest::initializeVulkanDevices(

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -491,6 +491,16 @@ public:
   VkDevice Device = VK_NULL_HANDLE;
   std::unique_ptr<VulkanFence> SubmitFence;
   uint64_t FenceCounter = 0;
+  // Batches of command buffers submitted to the GPU that may still be
+  // in-flight.  VulkanCommandBuffer's destructor destroys the VkCommandPool,
+  // which would invalidate any still-pending command buffers.  Each batch
+  // records the fence value it signals so we can non-blockingly query
+  // progress and release completed batches.
+  struct InFlightBatch {
+    uint64_t FenceValue;
+    llvm::SmallVector<std::unique_ptr<offloadtest::CommandBuffer>> CBs;
+  };
+  llvm::SmallVector<InFlightBatch> InFlightBatches;
 
   VulkanQueue(VkQueue Q, uint32_t QueueFamilyIdx, VkDevice Device,
               std::unique_ptr<VulkanFence> SubmitFence)
@@ -801,6 +811,9 @@ public:
   ~VulkanDevice() override {
     if (Device != VK_NULL_HANDLE) {
       vkDeviceWaitIdle(Device);
+      // Release in-flight command buffers before destroying the device,
+      // since their destructors call vkDestroyCommandPool on the VkDevice.
+      GraphicsQueue.InFlightBatches.clear();
       // Destroy the queue's fence before the device, since the fence
       // references the VkDevice for vkDestroySemaphore.
       GraphicsQueue.SubmitFence.reset();
@@ -2604,12 +2617,20 @@ public:
 
 llvm::Expected<offloadtest::SubmitResult> VulkanQueue::submit(
     llvm::SmallVector<std::unique_ptr<offloadtest::CommandBuffer>> CBs) {
+  // Non-blocking: query how far the GPU has progressed and release
+  // command buffers from completed submissions.
+  {
+    const uint64_t Completed = SubmitFence->getFenceValue();
+    llvm::erase_if(InFlightBatches, [Completed](const InFlightBatch &B) {
+      return B.FenceValue <= Completed;
+    });
+  }
+
   llvm::SmallVector<VkCommandBuffer> CmdBuffers;
   CmdBuffers.reserve(CBs.size());
 
-  // Wait on the previous submit's fence value before executing this batch,
-  // so that back-to-back submits don't overlap on the GPU. Waiting for a
-  // value that is already signaled (including 0 on first submit) is a no-op.
+  // GPU-side wait so that back-to-back submits don't overlap on the GPU.
+  // Waiting for a value that is already signaled (including 0) is a no-op.
   const uint64_t WaitValue = FenceCounter;
   const uint64_t SignalValue = ++FenceCounter;
   const VkPipelineStageFlags WaitStage = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
@@ -2644,6 +2665,9 @@ llvm::Expected<offloadtest::SubmitResult> VulkanQueue::submit(
           VK::toError(vkQueueSubmit(Queue, 1, &SubmitInfo, VK_NULL_HANDLE),
                       "Failed to submit to queue."))
     return Err;
+
+  // Keep submitted command buffers alive until the GPU is done with them.
+  InFlightBatches.push_back({SignalValue, std::move(CBs)});
 
   return offloadtest::SubmitResult{SubmitFence.get(), SignalValue};
 }


### PR DESCRIPTION
Change `Queue::submit()` to return `Expected<SubmitResult>` (a fence + signal value pair) instead of blocking until completion. Each backend (Vulkan, DirectX, Metal) now returns its queue fence and counter value, and callers explicitly wait via `SubmitResult::waitForCompletion()` before reading back results.

This allows command buffers submitted between the first and last submit to remain in-flight on the GPU without host-side synchronization.

- Vulkan: `cleanup()` waits on the queue fence for error-path safety
- DirectX: tile mapping sync reuses the queue's `SubmitFence`
- Metal: `MTLQueue` gains a `SharedEvent` fence; the last command buffer in each batch encodes a signal on it

🤖 Generated with [Claude Code](https://claude.com/claude-code)