### PR TITLE
Enable Matrix accessor tests for Vulkan on Clang

### DIFF
--- a/test/Basic/Matrix/matrix_m-based_getter.test
+++ b/test/Basic/Matrix/matrix_m-based_getter.test
@@ -148,9 +148,6 @@ DescriptorSets:
 ...
 #--- end
 
-# BUG Vulkan https://github.com/llvm/offload-test-suite/issues/1091
-# XFAIL: Vulkan && Clang
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -fvk-use-dx-layout -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Basic/Matrix/matrix_one-based_getter.test
+++ b/test/Basic/Matrix/matrix_one-based_getter.test
@@ -147,9 +147,6 @@ DescriptorSets:
 ...
 #--- end
 
-# BUG Vulkan https://github.com/llvm/offload-test-suite/issues/1091
-# XFAIL: Vulkan && Clang
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -fvk-use-dx-layout -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
this issue was fixed so now turn on tests:
https://github.com/llvm/llvm-project/issues/192486