### PR TITLE
[WSL] Fix D3D12GetInterface infinite recursion by linking libd3d12core.so

### DIFF
--- a/cmake/modules/FindD3D12_WSL.cmake
+++ b/cmake/modules/FindD3D12_WSL.cmake
@@ -5,11 +5,22 @@ endif()
 
 # List of D3D libraries from WSL
 find_library(LIBD3D12 d3d12 HINTS /usr/lib/wsl/lib)
+find_library(LIBD3D12CORE d3d12core HINTS /usr/lib/wsl/lib)
 find_library(LIBDXCORE dxcore HINTS /usr/lib/wsl/lib)
 
 # List of D3D libraries from DirectX-Headers
 find_library(LIBD3DX12-FORMAT-PROPERTIES d3dx12-format-properties)
 find_library(LIBDIRECTX-GUIDS DirectX-Guids)
+
+# libd3d12.so is a shim that loads libd3d12core.so at runtime via dlopen and
+# resolves D3D12GetInterface via dlsym. Due to ELF symbol interposition rules,
+# dlsym may resolve D3D12GetInterface back to libd3d12.so's own export instead
+# of libd3d12core.so's implementation, causing infinite recursion. Explicitly
+# linking libd3d12core.so *before* libd3d12.so ensures it appears first in the
+# global symbol table, so dlsym finds the correct implementation.
+if (LIBD3D12CORE)
+  list(APPEND D3D12_WSL_LIBRARIES ${LIBD3D12CORE})
+endif()
 
 list(APPEND D3D12_WSL_LIBRARIES
      ${LIBD3D12}


### PR DESCRIPTION
In Windows Subsystem for Linux, libd3d12.so is a shim that dlopen's libd3d12core.so and uses dlsym to resolve D3D12GetInterface. Due to ELF symbol interposition, dlsym may resolve back to libd3d12.so's own export, causing infinite recursion and a stack overflow. 

Example:
```
❯ ./api-query
PLEASE submit a bug report to https://github.com/llvm/llvm-project/issues/ and include the crash backtrace and instructions to reproduce the bug.
Stack dump:
0.      Program arguments: ./api-query
  #0 0x00005555556e960b llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) /home/icohedron/hlsl-dev/llvm-project/llvm/lib/Support/Unix/Signals.inc:880:13
  #1 0x00005555556e70f5 llvm::sys::RunSignalHandlers() /home/icohedron/hlsl-dev/llvm-project/llvm/lib/Support/Signals.cpp:109:18
  #2 0x00005555556ea45a SignalHandler(int, siginfo_t*, void*) /home/icohedron/hlsl-dev/llvm-project/llvm/lib/Support/Unix/Signals.inc:448:38
  #3 0x00007ffff7442790 __restore_rt (/nix/store/jms7zxzm7w1whczwny5m3gkgdjghmi2r-glibc-2.42-51/lib/libc.so.6+0x42790)
  #4 0x00007ffff7df4a21 (/usr/lib/wsl/lib/libd3d12.so+0xb7a21)
  #5 0x00007ffff7df6b6a (/usr/lib/wsl/lib/libd3d12.so+0xb9b6a)
  #6 0x00007ffff7df8ac6 D3D12GetInterface (/usr/lib/wsl/lib/libd3d12.so+0xbbac6)
  #7 0x00007ffff7df8adf D3D12GetInterface (/usr/lib/wsl/lib/libd3d12.so+0xbbadf)
...
#254 0x00007ffff7df8adf D3D12GetInterface (/usr/lib/wsl/lib/libd3d12.so+0xbbadf)
#255 0x00007ffff7df8adf D3D12GetInterface (/usr/lib/wsl/lib/libd3d12.so+0xbbadf)
Failed to query D3D info queue
Segmentation fault         (core dumped) ./api-query
```

This PR fixes the issue by explicitly linking libd3d12core.so before libd3d12.so so it appears first in the global symbol table.

Assisted-by: Claude Opus 4.6