### PR TITLE
Remove Clang && DirectX XFAILs from Texture2D.Load, Texture2D.OperatorIndex, and Texture2D.mips.OperatorIndex tests

### DIFF
--- a/test/Feature/Textures/Texture2D.Load.test.yaml
+++ b/test/Feature/Textures/Texture2D.Load.test.yaml
@@ -74,10 +74,6 @@ Results:
 ...
 #--- end
 
-# Unimplemented: Clang + DX: https://github.com/llvm/llvm-project/issues/101558
-# XFAIL: Clang && !Vulkan
-
-
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl

--- a/test/Feature/Textures/Texture2D.OperatorIndex.test.yaml
+++ b/test/Feature/Textures/Texture2D.OperatorIndex.test.yaml
@@ -61,6 +61,8 @@ Results:
 ...
 #--- end
 
+# Unimplemented: https://github.com/llvm/offload-test-suite/issues/1039
+# XFAIL: DirectX
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl

--- a/test/Feature/Textures/Texture2D.OperatorIndex.test.yaml
+++ b/test/Feature/Textures/Texture2D.OperatorIndex.test.yaml
@@ -61,8 +61,6 @@ Results:
 ...
 #--- end
 
-# Unimplemented: Clang + DX: https://github.com/llvm/llvm-project/issues/101558
-# XFAIL: DirectX || Metal && Clang
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl

--- a/test/Feature/Textures/Texture2D.mips.OperatorIndex.test.yaml
+++ b/test/Feature/Textures/Texture2D.mips.OperatorIndex.test.yaml
@@ -61,9 +61,6 @@ Results:
 ...
 #--- end
 
-# Unimplemented: https://github.com/llvm/llvm-project/issues/101558
-# XFAIL: Clang && DirectX 
-
 # Unimplemented: https://github.com/llvm/offload-test-suite/issues/1039
 # XFAIL: DirectX
 


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/193343 was merged, completing the DirectX backend implementations of the texture load method (https://github.com/llvm/llvm-project/issues/192546) and the texture [] operator (https://github.com/llvm/llvm-project/issues/192558). The `.mips[][]` operator also simply lowers to a texture load, so its implementation is also complete.

Therefore the tests `test/Feature/Textures/Texture2D.Load.test.yaml`, `test/Feature/Textures/Texture2D.OperatorIndex.test.yaml`, and `test/Feature/Textures/Texture2D.mips.OperatorIndex.test.yaml` can now be enabled for Clang && DirectX.

However, only `test/Feature/Textures/Texture2D.Load.test.yaml` is expected to pass, as the other two tests require multiple mip level support and therefore will still XFAIL on DirectX due to https://github.com/llvm/offload-test-suite/issues/1039