### PR TITLE
Update LKG WARP version to 1.0.19

### DIFF
--- a/cmake/modules/Warp.cmake
+++ b/cmake/modules/Warp.cmake
@@ -24,7 +24,7 @@ function(setup_warp version)
   guess_nuget_arch(NUGET_ARCH)
 
   if (version STREQUAL "LKG")
-    set(version "1.0.18")
+    set(version "1.0.19")
     set(version_description "Latest Known Good for ${NUGET_ARCH} (${version})")
   else ()
     set(version_description "Custom (${version})")

--- a/test/WaveOps/QuadReadAcrossY.fp64.test
+++ b/test/WaveOps/QuadReadAcrossY.fp64.test
@@ -128,9 +128,6 @@ DescriptorSets:
 # Bug: https://github.com/llvm/offload-test-suite/issues/986
 # XFAIL: Intel && Vulkan && DXC
 
-# Bug: https://github.com/llvm/offload-test-suite/issues/1013
-# XFAIL: WARP && AVX512
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/WaveOps/WaveActiveBitXor.convergence.test
+++ b/test/WaveOps/WaveActiveBitXor.convergence.test
@@ -164,9 +164,6 @@ DescriptorSets:
 # Bug: https://github.com/llvm/llvm-project/issues/188323
 # XFAIL: Vulkan && Clang
 
-# Bug: https://github.com/llvm/offload-test-suite/issues/1022
-# XFAIL: WARP
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
This PR updates the last-known-good WARP version to 1.0.19 and removes XFAILs from tests that now pass after the update.