### PR TITLE
Rewrite `Buffer` CPU-mapping API to lift vertex buffer creation into the common API layer

### DIFF
--- a/include/API/Buffer.h
+++ b/include/API/Buffer.h
@@ -19,8 +19,14 @@
 
 namespace offloadtest {
 
+enum class BufferUsage {
+  Storage,
+  VertexBuffer,
+};
+
 struct BufferCreateDesc {
   MemoryLocation Location;
+  BufferUsage Usage;
 };
 
 class Buffer {
@@ -28,6 +34,8 @@ class Buffer {
 
 public:
   virtual ~Buffer();
+  virtual size_t getSizeInBytes() const = 0;
+
   Buffer(const Buffer &) = delete;
   Buffer &operator=(const Buffer &) = delete;
 

--- a/include/API/Buffer.h
+++ b/include/API/Buffer.h
@@ -39,7 +39,7 @@ public:
 
   // Maps the buffer's memory for host access. Only valid for CpuToGpu and
   // GpuToCpu buffers; returns an error for GpuOnly. Each successful map() must
-  // be paired with a call to unmap().
+  // be paired with a call to unmap() before the buffer is used on the GPU.
   virtual llvm::Expected<void *> map() = 0;
   virtual llvm::Error unmap() = 0;
 

--- a/include/API/Buffer.h
+++ b/include/API/Buffer.h
@@ -16,6 +16,7 @@
 #include "API/Resources.h"
 
 #include "llvm/Support/Casting.h"
+#include "llvm/Support/Error.h"
 
 namespace offloadtest {
 
@@ -35,6 +36,12 @@ class Buffer {
 public:
   virtual ~Buffer();
   virtual size_t getSizeInBytes() const = 0;
+
+  // Maps the buffer's memory for host access. Only valid for CpuToGpu and
+  // GpuToCpu buffers; returns an error for GpuOnly. Each successful map() must
+  // be paired with a call to unmap().
+  virtual llvm::Expected<void *> map() = 0;
+  virtual llvm::Error unmap() = 0;
 
   Buffer(const Buffer &) = delete;
   Buffer &operator=(const Buffer &) = delete;

--- a/include/API/Device.h
+++ b/include/API/Device.h
@@ -213,6 +213,10 @@ createRenderTargetFromCPUBuffer(Device &Dev, const CPUBuffer &Buf);
 llvm::Expected<std::unique_ptr<Texture>>
 createDefaultDepthStencilTarget(Device &Dev, uint32_t Width, uint32_t Height);
 
+// Creates a vertex buffer and uploads the given CPU-side vertex data into it.
+llvm::Expected<std::unique_ptr<Buffer>>
+createVertexBufferFromCPUBuffer(Device &Dev, const CPUBuffer &Buf);
+
 } // namespace offloadtest
 
 #endif // OFFLOADTEST_API_DEVICE_H

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -345,6 +345,22 @@ public:
 
   size_t getSizeInBytes() const override { return SizeInBytes; }
 
+  llvm::Expected<void *> map() override {
+    if (Desc.Location == MemoryLocation::GpuOnly)
+      return llvm::createStringError(std::errc::invalid_argument,
+                                     "Cannot map a GpuOnly buffer.");
+    void *Ptr = nullptr;
+    if (auto Err =
+            HR::toError(Buffer->Map(0, nullptr, &Ptr), "Failed to map buffer."))
+      return std::move(Err);
+    return Ptr;
+  }
+
+  llvm::Error unmap() override {
+    Buffer->Unmap(0, nullptr);
+    return llvm::Error::success();
+  }
+
   static bool classof(const offloadtest::Buffer *B) {
     return B->getAPI() == GPUAPI::DirectX;
   }
@@ -628,7 +644,7 @@ private:
     std::unique_ptr<offloadtest::Texture> RT;
     std::unique_ptr<offloadtest::Buffer> RTReadback;
     std::unique_ptr<offloadtest::Texture> DS;
-    std::optional<offloadtest::VertexBuffer> VB;
+    std::unique_ptr<offloadtest::Buffer> VB;
 
     llvm::SmallVector<DescriptorTable> DescTables;
     llvm::SmallVector<ResourcePair> RootResources;
@@ -1871,30 +1887,17 @@ public:
       return llvm::createStringError(
           std::errc::invalid_argument,
           "No vertex buffer bound for graphics pipeline.");
-    const CPUBuffer &VB = *P.Bindings.VertexBufferPtr;
-    const uint64_t VBSize = VB.size();
 
-    BufferCreateDesc BufDesc = {};
-    BufDesc.Location = MemoryLocation::CpuToGpu;
-    BufDesc.Usage = BufferUsage::VertexBuffer;
-    auto BufOrErr = createBuffer("VertexBuffer", BufDesc, VBSize);
-    if (!BufOrErr)
-      return BufOrErr.takeError();
-    IS.VB = std::static_pointer_cast<DXBuffer>(*BufOrErr);
+    auto VBOrErr = offloadtest::createVertexBufferFromCPUBuffer(
+        *this, *P.Bindings.VertexBufferPtr);
+    if (!VBOrErr)
+      return VBOrErr.takeError();
+    IS.VB = std::move(*VBOrErr);
 
-    // TODO: Currently uses a single CpuToGpu mapped buffer. For optimal GPU
-    // performance on discrete GPUs, use a staging buffer + copy to a GpuOnly
-    // vertex buffer instead.
-    void *Ptr = nullptr;
-    if (auto Err = HR::toError(IS.VB->Buffer->Map(0, nullptr, &Ptr),
-                               "Failed to map vertex buffer"))
-      return Err;
-    memcpy(Ptr, VB.Data[0].get(), VBSize);
-    IS.VB->Buffer->Unmap(0, nullptr);
-
+    auto &VBBuf = llvm::cast<DXBuffer>(*IS.VB);
     D3D12_VERTEX_BUFFER_VIEW VBView = {};
-    VBView.BufferLocation = IS.VB->Buffer->GetGPUVirtualAddress();
-    VBView.SizeInBytes = static_cast<UINT>(VBSize);
+    VBView.BufferLocation = VBBuf.Buffer->GetGPUVirtualAddress();
+    VBView.SizeInBytes = static_cast<UINT>(IS.VB->getSizeInBytes());
     VBView.StrideInBytes = P.Bindings.getVertexStride();
 
     IS.CB->CmdList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -343,6 +343,8 @@ public:
       : offloadtest::Buffer(GPUAPI::DirectX), Buffer(Buffer), Name(Name),
         Desc(Desc), SizeInBytes(SizeInBytes) {}
 
+  size_t getSizeInBytes() const override { return SizeInBytes; }
+
   static bool classof(const offloadtest::Buffer *B) {
     return B->getAPI() == GPUAPI::DirectX;
   }
@@ -626,7 +628,7 @@ private:
     std::unique_ptr<offloadtest::Texture> RT;
     std::unique_ptr<offloadtest::Buffer> RTReadback;
     std::unique_ptr<offloadtest::Texture> DS;
-    ComPtr<ID3D12Resource> VB;
+    std::optional<offloadtest::VertexBuffer> VB;
 
     llvm::SmallVector<DescriptorTable> DescTables;
     llvm::SmallVector<ResourcePair> RootResources;
@@ -875,9 +877,9 @@ public:
     const D3D12_HEAP_TYPE HeapType = getDXHeapType(Desc.Location);
 
     const D3D12_RESOURCE_FLAGS Flags =
-        HeapType == D3D12_HEAP_TYPE_READBACK
-            ? D3D12_RESOURCE_FLAG_NONE
-            : D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
+        HeapType == D3D12_HEAP_TYPE_DEFAULT
+            ? D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS
+            : D3D12_RESOURCE_FLAG_NONE;
 
     const D3D12_HEAP_PROPERTIES HeapProps = CD3DX12_HEAP_PROPERTIES(HeapType);
     const D3D12_RESOURCE_DESC BufferDesc =
@@ -1844,6 +1846,7 @@ public:
     // back to a tight layout happens in readBack() via GetCopyableFootprints.
     BufferCreateDesc BufDesc = {};
     BufDesc.Location = MemoryLocation::GpuToCpu;
+    BufDesc.Usage = BufferUsage::Storage;
     auto BufOrErr = createBuffer("RTReadback", BufDesc,
                                  getAlignedTextureBufferSize(OutBuf));
     if (!BufOrErr)
@@ -1870,25 +1873,27 @@ public:
           "No vertex buffer bound for graphics pipeline.");
     const CPUBuffer &VB = *P.Bindings.VertexBufferPtr;
     const uint64_t VBSize = VB.size();
-    D3D12_RESOURCE_DESC const Desc = CD3DX12_RESOURCE_DESC::Buffer(VBSize);
-    CD3DX12_HEAP_PROPERTIES HeapProps =
-        CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD);
-    if (auto Err = HR::toError(Device->CreateCommittedResource(
-                                   &HeapProps, D3D12_HEAP_FLAG_NONE, &Desc,
-                                   D3D12_RESOURCE_STATE_GENERIC_READ, nullptr,
-                                   IID_PPV_ARGS(&IS.VB)),
-                               "Failed to create vertex buffer"))
-      return Err;
 
+    BufferCreateDesc BufDesc = {};
+    BufDesc.Location = MemoryLocation::CpuToGpu;
+    BufDesc.Usage = BufferUsage::VertexBuffer;
+    auto BufOrErr = createBuffer("VertexBuffer", BufDesc, VBSize);
+    if (!BufOrErr)
+      return BufOrErr.takeError();
+    IS.VB = std::static_pointer_cast<DXBuffer>(*BufOrErr);
+
+    // TODO: Currently uses a single CpuToGpu mapped buffer. For optimal GPU
+    // performance on discrete GPUs, use a staging buffer + copy to a GpuOnly
+    // vertex buffer instead.
     void *Ptr = nullptr;
-    if (auto Err = HR::toError(IS.VB->Map(0, nullptr, &Ptr),
+    if (auto Err = HR::toError(IS.VB->Buffer->Map(0, nullptr, &Ptr),
                                "Failed to map vertex buffer"))
       return Err;
     memcpy(Ptr, VB.Data[0].get(), VBSize);
-    IS.VB->Unmap(0, nullptr);
+    IS.VB->Buffer->Unmap(0, nullptr);
 
     D3D12_VERTEX_BUFFER_VIEW VBView = {};
-    VBView.BufferLocation = IS.VB->GetGPUVirtualAddress();
+    VBView.BufferLocation = IS.VB->Buffer->GetGPUVirtualAddress();
     VBView.SizeInBytes = static_cast<UINT>(VBSize);
     VBView.StrideInBytes = P.Bindings.getVertexStride();
 
@@ -1902,6 +1907,10 @@ public:
     auto &RT = llvm::cast<DXTexture>(*IS.RT);
     auto &DS = llvm::cast<DXTexture>(*IS.DS);
     auto &RTReadback = llvm::cast<DXBuffer>(*IS.RTReadback);
+
+    if (!IS.VB)
+      return llvm::createStringError(std::errc::invalid_argument,
+                                     "Vertex buffer not initialized.");
 
     const DXPipelineState &DXPipeline =
         llvm::cast<DXPipelineState>(*IS.Pipeline.get());

--- a/lib/API/Device.cpp
+++ b/lib/API/Device.cpp
@@ -87,24 +87,28 @@ offloadtest::createRenderTargetFromCPUBuffer(Device &Dev,
   return Dev.createTexture("RenderTarget", Desc);
 }
 
-llvm::Expected<VertexBuffer>
-offloadtest::createVertexBuffer(Device &Dev, const ParsedVertexBuffer &PVB) {
+llvm::Expected<std::unique_ptr<Buffer>>
+offloadtest::createVertexBufferFromCPUBuffer(Device &Dev,
+                                             const CPUBuffer &Buf) {
   BufferCreateDesc BufDesc = {};
   BufDesc.Location = MemoryLocation::CpuToGpu;
   BufDesc.Usage = BufferUsage::VertexBuffer;
-  auto BufOrErr =
-      Dev.createBuffer("VertexBuffer", BufDesc, PVB.InterleavedSize);
+  auto BufOrErr = Dev.createBuffer("VertexBuffer", BufDesc, Buf.size());
   if (!BufOrErr)
     return BufOrErr.takeError();
+  auto VB = std::move(*BufOrErr);
 
-  VertexBufferDesc VBDesc;
-  for (const auto &S : PVB.Streams)
-    VBDesc.Streams.push_back({S.Name, S.Fmt});
+  // TODO: Currently uses a single CpuToGpu mapped buffer.
+  // On discrete GPUs consider using a staging buffer + copy to a GpuOnly vertex
+  // buffer for optimal GPU read performance.
+  auto PtrOrErr = VB->map();
+  if (!PtrOrErr)
+    return PtrOrErr.takeError();
+  memcpy(*PtrOrErr, Buf.Data[0].get(), Buf.size());
+  if (auto Err = VB->unmap())
+    return std::move(Err);
 
-  // TODO: Generalize VB data copy so that we can deduplicate that from each
-  // backend.
-
-  return VertexBuffer{VBDesc, *BufOrErr};
+  return VB;
 }
 
 llvm::Expected<std::unique_ptr<Texture>>

--- a/lib/API/Device.cpp
+++ b/lib/API/Device.cpp
@@ -87,6 +87,26 @@ offloadtest::createRenderTargetFromCPUBuffer(Device &Dev,
   return Dev.createTexture("RenderTarget", Desc);
 }
 
+llvm::Expected<VertexBuffer>
+offloadtest::createVertexBuffer(Device &Dev, const ParsedVertexBuffer &PVB) {
+  BufferCreateDesc BufDesc = {};
+  BufDesc.Location = MemoryLocation::CpuToGpu;
+  BufDesc.Usage = BufferUsage::VertexBuffer;
+  auto BufOrErr =
+      Dev.createBuffer("VertexBuffer", BufDesc, PVB.InterleavedSize);
+  if (!BufOrErr)
+    return BufOrErr.takeError();
+
+  VertexBufferDesc VBDesc;
+  for (const auto &S : PVB.Streams)
+    VBDesc.Streams.push_back({S.Name, S.Fmt});
+
+  // TODO: Generalize VB data copy so that we can deduplicate that from each
+  // backend.
+
+  return VertexBuffer{VBDesc, *BufOrErr};
+}
+
 llvm::Expected<std::unique_ptr<Texture>>
 offloadtest::createDefaultDepthStencilTarget(Device &Dev, uint32_t Width,
                                              uint32_t Height) {

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -159,6 +159,22 @@ public:
 
   size_t getSizeInBytes() const override { return SizeInBytes; }
 
+  llvm::Expected<void *> map() override {
+    if (Desc.Location == MemoryLocation::GpuOnly)
+      return llvm::createStringError(std::errc::invalid_argument,
+                                     "Cannot map a GpuOnly buffer.");
+    return Buf->contents();
+  }
+
+  llvm::Error unmap() override {
+    // Managed storage (CpuToGpu) requires an explicit didModifyRange to
+    // propagate CPU-side writes to the GPU. Shared storage (GpuToCpu) is
+    // coherent and needs no action.
+    if (Desc.Location == MemoryLocation::CpuToGpu)
+      Buf->didModifyRange(NS::Range::Make(0, SizeInBytes));
+    return llvm::Error::success();
+  }
+
   ~MTLBuffer() override {
     if (Buf)
       Buf->release();
@@ -258,7 +274,7 @@ class MTLDevice : public offloadtest::Device {
 
     NS::AutoreleasePool *Pool = nullptr;
     MTL::Buffer *ArgBuffer;
-    std::shared_ptr<MTLBuffer> VB;
+    std::unique_ptr<offloadtest::Buffer> VB;
     llvm::SmallVector<MTL::Texture *> Textures;
     llvm::SmallVector<MTL::Buffer *> Buffers;
     std::unique_ptr<offloadtest::Texture> FrameBufferTexture;
@@ -353,23 +369,12 @@ class MTLDevice : public offloadtest::Device {
         return llvm::createStringError(
             std::errc::invalid_argument,
             "No vertex buffer specified for graphics pipeline.");
-      const CPUBuffer &VB = *P.Bindings.VertexBufferPtr;
 
-      BufferCreateDesc BufDesc = {};
-      BufDesc.Location = MemoryLocation::CpuToGpu;
-      BufDesc.Usage = BufferUsage::VertexBuffer;
-      auto BufOrErr = createBuffer("VertexBuffer", BufDesc, VB.size());
-      if (!BufOrErr)
-        return BufOrErr.takeError();
-      IS.VB = std::static_pointer_cast<MTLBuffer>(*BufOrErr);
-
-      // TODO: Currently uses a single CpuToGpu mapped buffer. On discrete GPUs
-      // (DX/VK), consider using a staging buffer + copy to a GpuOnly vertex
-      // buffer for optimal GPU read performance. On Apple Silicon this is
-      // unnecessary due to unified memory.
-      const size_t BufSize = IS.VB->getSizeInBytes();
-      memcpy(IS.VB->Buf->contents(), VB.Data[0].get(), BufSize);
-      IS.VB->Buf->didModifyRange(NS::Range::Make(0, BufSize));
+      auto VBOrErr = offloadtest::createVertexBufferFromCPUBuffer(
+          *this, *P.Bindings.VertexBufferPtr);
+      if (!VBOrErr)
+        return VBOrErr.takeError();
+      IS.VB = std::move(*VBOrErr);
     }
     return llvm::Error::success();
   }
@@ -555,7 +560,7 @@ class MTLDevice : public offloadtest::Device {
 
     // Bind vertex buffer at slot 0 to match the vertex descriptor which
     // references buffer index 0.
-    CmdEncoder->setVertexBuffer(IS.VB->Buf, 0, 0);
+    CmdEncoder->setVertexBuffer(llvm::cast<MTLBuffer>(*IS.VB).Buf, 0, 0);
 
     CmdEncoder->drawPrimitives(MTL::PrimitiveTypeTriangle, NS::UInteger(0),
                                P.Bindings.getVertexCount());

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -157,6 +157,8 @@ public:
       : offloadtest::Buffer(GPUAPI::Metal), Buf(Buf), Name(Name), Desc(Desc),
         SizeInBytes(SizeInBytes) {}
 
+  size_t getSizeInBytes() const override { return SizeInBytes; }
+
   ~MTLBuffer() override {
     if (Buf)
       Buf->release();
@@ -256,7 +258,7 @@ class MTLDevice : public offloadtest::Device {
 
     NS::AutoreleasePool *Pool = nullptr;
     MTL::Buffer *ArgBuffer;
-    MTL::Buffer *VertexBuffer;
+    std::shared_ptr<MTLBuffer> VB;
     llvm::SmallVector<MTL::Texture *> Textures;
     llvm::SmallVector<MTL::Buffer *> Buffers;
     std::unique_ptr<offloadtest::Texture> FrameBufferTexture;
@@ -347,12 +349,27 @@ class MTLDevice : public offloadtest::Device {
       IS.ArgBuffer->didModifyRange(NS::Range::Make(0, IS.ArgBuffer->length()));
     }
     if (P.isGraphics()) {
-      // Create and mark the vertex buffer as modified.
-      IS.VertexBuffer = Device->newBuffer(
-          P.Bindings.VertexBufferPtr->Data.back().get(),
-          P.Bindings.VertexBufferPtr->size(), MTL::ResourceStorageModeManaged);
-      IS.VertexBuffer->didModifyRange(
-          NS::Range::Make(0, IS.VertexBuffer->length()));
+      if (!P.Bindings.VertexBufferPtr)
+        return llvm::createStringError(
+            std::errc::invalid_argument,
+            "No vertex buffer specified for graphics pipeline.");
+      const CPUBuffer &VB = *P.Bindings.VertexBufferPtr;
+
+      BufferCreateDesc BufDesc = {};
+      BufDesc.Location = MemoryLocation::CpuToGpu;
+      BufDesc.Usage = BufferUsage::VertexBuffer;
+      auto BufOrErr = createBuffer("VertexBuffer", BufDesc, VB.size());
+      if (!BufOrErr)
+        return BufOrErr.takeError();
+      IS.VB = std::static_pointer_cast<MTLBuffer>(*BufOrErr);
+
+      // TODO: Currently uses a single CpuToGpu mapped buffer. On discrete GPUs
+      // (DX/VK), consider using a staging buffer + copy to a GpuOnly vertex
+      // buffer for optimal GPU read performance. On Apple Silicon this is
+      // unnecessary due to unified memory.
+      const size_t BufSize = IS.VB->getSizeInBytes();
+      memcpy(IS.VB->Buf->contents(), VB.Data[0].get(), BufSize);
+      IS.VB->Buf->didModifyRange(NS::Range::Make(0, BufSize));
     }
     return llvm::Error::success();
   }
@@ -442,6 +459,7 @@ class MTLDevice : public offloadtest::Device {
     // Create a readback buffer for copying render target data to the CPU.
     BufferCreateDesc BufDesc = {};
     BufDesc.Location = MemoryLocation::GpuToCpu;
+    BufDesc.Usage = BufferUsage::Storage;
     auto BufOrErr = createBuffer("RTReadback", BufDesc, OutBuf.size());
     if (!BufOrErr)
       return BufOrErr.takeError();
@@ -537,7 +555,7 @@ class MTLDevice : public offloadtest::Device {
 
     // Bind vertex buffer at slot 0 to match the vertex descriptor which
     // references buffer index 0.
-    CmdEncoder->setVertexBuffer(IS.VertexBuffer, 0, 0);
+    CmdEncoder->setVertexBuffer(IS.VB->Buf, 0, 0);
 
     CmdEncoder->drawPrimitives(MTL::PrimitiveTypeTriangle, NS::UInteger(0),
                                P.Bindings.getVertexCount());

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -404,8 +404,8 @@ public:
     if (vkMapMemory(Dev, Memory, 0, SizeInBytes, 0, &Ptr) != VK_SUCCESS)
       return llvm::createStringError(std::errc::io_error,
                                      "Failed to map buffer.");
-    // HOST_CACHED memory (GpuToCpu) needs explicit invalidation so the CPU
-    // sees the GPU-side writes.
+    // HOST_CACHED memory that is *not* HOST_COHERENT (GpuToCpu) needs explicit
+    // invalidation so the CPU sees the GPU-side writes.
     if (Desc.Location == MemoryLocation::GpuToCpu) {
       VkMappedMemoryRange Range = {};
       Range.sType = VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE;

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -2702,12 +2702,6 @@ public:
       }
     }
 
-    if (IS.VertexBuffer.has_value()) {
-      vkDestroyBuffer(Device, IS.VertexBuffer->Device.Buffer, nullptr);
-      vkFreeMemory(Device, IS.VertexBuffer->Device.Memory, nullptr);
-      vkDestroyBuffer(Device, IS.VertexBuffer->Host.Buffer, nullptr);
-      vkFreeMemory(Device, IS.VertexBuffer->Host.Memory, nullptr);
-    }
     if (IS.FrameBuffer)
       vkDestroyFramebuffer(Device, IS.FrameBuffer, nullptr);
 

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -396,6 +396,32 @@ public:
 
   size_t getSizeInBytes() const override { return SizeInBytes; }
 
+  llvm::Expected<void *> map() override {
+    if (Desc.Location == MemoryLocation::GpuOnly)
+      return llvm::createStringError(std::errc::invalid_argument,
+                                     "Cannot map a GpuOnly buffer.");
+    void *Ptr = nullptr;
+    if (vkMapMemory(Dev, Memory, 0, SizeInBytes, 0, &Ptr) != VK_SUCCESS)
+      return llvm::createStringError(std::errc::io_error,
+                                     "Failed to map buffer.");
+    // HOST_CACHED memory (GpuToCpu) needs explicit invalidation so the CPU
+    // sees the GPU-side writes.
+    if (Desc.Location == MemoryLocation::GpuToCpu) {
+      VkMappedMemoryRange Range = {};
+      Range.sType = VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE;
+      Range.memory = Memory;
+      Range.offset = 0;
+      Range.size = VK_WHOLE_SIZE;
+      vkInvalidateMappedMemoryRanges(Dev, 1, &Range);
+    }
+    return Ptr;
+  }
+
+  llvm::Error unmap() override {
+    vkUnmapMemory(Dev, Memory);
+    return llvm::Error::success();
+  }
+
   ~VulkanBuffer() override {
     vkDestroyBuffer(Dev, Buffer, nullptr);
     vkFreeMemory(Dev, Memory, nullptr);
@@ -690,7 +716,7 @@ private:
     std::unique_ptr<offloadtest::Texture> RenderTarget;
     std::unique_ptr<offloadtest::Buffer> RTReadback;
     std::unique_ptr<offloadtest::Texture> DepthStencil;
-    std::shared_ptr<VulkanBuffer> VB;
+    std::unique_ptr<offloadtest::Buffer> VB;
 
     uint32_t ShaderStageMask = 0;
 
@@ -1767,24 +1793,12 @@ public:
         return llvm::createStringError(
             std::errc::invalid_argument,
             "No Vertex buffer specified for graphics pipeline.");
-      const CPUBuffer &VB = *P.Bindings.VertexBufferPtr;
 
-      BufferCreateDesc BufDesc = {};
-      BufDesc.Location = MemoryLocation::CpuToGpu;
-      BufDesc.Usage = BufferUsage::VertexBuffer;
-      auto BufOrErr = createBuffer("VertexBuffer", BufDesc, VB.size());
-      if (!BufOrErr)
-        return BufOrErr.takeError();
-      IS.VB = std::static_pointer_cast<VulkanBuffer>(*BufOrErr);
-
-      // TODO: Currently uses a single CpuToGpu mapped buffer. For optimal GPU
-      // performance on discrete GPUs, use a staging buffer + copy to a GpuOnly
-      // vertex buffer instead.
-      const size_t BufSize = IS.VB->getSizeInBytes();
-      void *Mapped = nullptr;
-      vkMapMemory(Device, IS.VB->Memory, 0, BufSize, 0, &Mapped);
-      memcpy(Mapped, VB.Data[0].get(), BufSize);
-      vkUnmapMemory(Device, IS.VB->Memory);
+      auto VBOrErr = offloadtest::createVertexBufferFromCPUBuffer(
+          *this, *P.Bindings.VertexBufferPtr);
+      if (!VBOrErr)
+        return VBOrErr.takeError();
+      IS.VB = std::move(*VBOrErr);
     }
 
     return llvm::Error::success();
@@ -2567,7 +2581,7 @@ public:
     } else {
       VkDeviceSize Offsets[1]{0};
       assert(IS.VB);
-      VkBuffer VBHandle = IS.VB->Buffer;
+      VkBuffer VBHandle = llvm::cast<VulkanBuffer>(*IS.VB).Buffer;
       vkCmdBindVertexBuffers(IS.CB->CmdBuffer, 0, 1, &VBHandle, Offsets);
       // instanceCount must be >=1 to draw; previously was 0 which draws nothing
       vkCmdDraw(IS.CB->CmdBuffer, P.Bindings.getVertexCount(), 1, 0, 0);

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -394,6 +394,8 @@ public:
       : offloadtest::Buffer(GPUAPI::Vulkan), Dev(Dev), Buffer(Buffer),
         Memory(Memory), Name(Name), Desc(Desc), SizeInBytes(SizeInBytes) {}
 
+  size_t getSizeInBytes() const override { return SizeInBytes; }
+
   ~VulkanBuffer() override {
     vkDestroyBuffer(Dev, Buffer, nullptr);
     vkFreeMemory(Dev, Memory, nullptr);
@@ -688,7 +690,7 @@ private:
     std::unique_ptr<offloadtest::Texture> RenderTarget;
     std::unique_ptr<offloadtest::Buffer> RTReadback;
     std::unique_ptr<offloadtest::Texture> DepthStencil;
-    std::optional<ResourceRef> VertexBuffer = std::nullopt;
+    std::shared_ptr<VulkanBuffer> VB;
 
     uint32_t ShaderStageMask = 0;
 
@@ -1266,9 +1268,17 @@ public:
     VkBufferCreateInfo BufInfo = {};
     BufInfo.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
     BufInfo.size = SizeInBytes;
-    BufInfo.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT |
-                    VK_BUFFER_USAGE_TRANSFER_SRC_BIT |
-                    VK_BUFFER_USAGE_TRANSFER_DST_BIT;
+    BufInfo.usage =
+        VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT;
+    switch (Desc.Usage) {
+    case BufferUsage::Storage:
+      BufInfo.usage |= VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
+      break;
+    case BufferUsage::VertexBuffer:
+      BufInfo.usage |= VK_BUFFER_USAGE_VERTEX_BUFFER_BIT |
+                       VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
+      break;
+    }
     BufInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
 
     VkBuffer DeviceBuffer;
@@ -1718,6 +1728,7 @@ public:
     // Create a host-visible staging buffer for readback.
     BufferCreateDesc BufDesc = {};
     BufDesc.Location = MemoryLocation::GpuToCpu;
+    BufDesc.Usage = BufferUsage::Storage;
     auto BufOrErr = createBuffer("RTReadback", BufDesc, RTBuf.size());
     if (!BufOrErr)
       return BufOrErr.takeError();
@@ -1756,30 +1767,24 @@ public:
         return llvm::createStringError(
             std::errc::invalid_argument,
             "No Vertex buffer specified for graphics pipeline.");
-      const Resource VertexBuffer = {ResourceKind::StructuredBuffer,
-                                     "VertexBuffer",
-                                     {},
-                                     {},
-                                     P.Bindings.VertexBufferPtr,
-                                     nullptr,
-                                     false,
-                                     std::nullopt,
-                                     false};
-      auto ExVHostBuf = createBuffer(
-          VK_BUFFER_USAGE_TRANSFER_SRC_BIT, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT,
-          VertexBuffer.size(), VertexBuffer.BufferPtr->Data[0].get());
-      if (!ExVHostBuf)
-        return ExVHostBuf.takeError();
-      auto ExDeviceBuf = createBuffer(
-          VK_BUFFER_USAGE_VERTEX_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
-          VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, VertexBuffer.size());
-      if (!ExDeviceBuf)
-        return ExDeviceBuf.takeError();
-      VkBufferCopy Copy = {};
-      Copy.size = VertexBuffer.size();
-      vkCmdCopyBuffer(IS.CB->CmdBuffer, ExVHostBuf->Buffer, ExDeviceBuf->Buffer,
-                      1, &Copy);
-      IS.VertexBuffer = ResourceRef(*ExVHostBuf, *ExDeviceBuf);
+      const CPUBuffer &VB = *P.Bindings.VertexBufferPtr;
+
+      BufferCreateDesc BufDesc = {};
+      BufDesc.Location = MemoryLocation::CpuToGpu;
+      BufDesc.Usage = BufferUsage::VertexBuffer;
+      auto BufOrErr = createBuffer("VertexBuffer", BufDesc, VB.size());
+      if (!BufOrErr)
+        return BufOrErr.takeError();
+      IS.VB = std::static_pointer_cast<VulkanBuffer>(*BufOrErr);
+
+      // TODO: Currently uses a single CpuToGpu mapped buffer. For optimal GPU
+      // performance on discrete GPUs, use a staging buffer + copy to a GpuOnly
+      // vertex buffer instead.
+      const size_t BufSize = IS.VB->getSizeInBytes();
+      void *Mapped = nullptr;
+      vkMapMemory(Device, IS.VB->Memory, 0, BufSize, 0, &Mapped);
+      memcpy(Mapped, VB.Data[0].get(), BufSize);
+      vkUnmapMemory(Device, IS.VB->Memory);
     }
 
     return llvm::Error::success();
@@ -2561,9 +2566,9 @@ public:
                    << DispatchSize[1] << ", " << DispatchSize[2] << " }\n";
     } else {
       VkDeviceSize Offsets[1]{0};
-      assert(IS.VertexBuffer.has_value());
-      vkCmdBindVertexBuffers(IS.CB->CmdBuffer, 0, 1,
-                             &IS.VertexBuffer->Device.Buffer, Offsets);
+      assert(IS.VB);
+      VkBuffer VBHandle = IS.VB->Buffer;
+      vkCmdBindVertexBuffers(IS.CB->CmdBuffer, 0, 1, &VBHandle, Offsets);
       // instanceCount must be >=1 to draw; previously was 0 which draws nothing
       vkCmdDraw(IS.CB->CmdBuffer, P.Bindings.getVertexCount(), 1, 0, 0);
       llvm::outs() << "Drew " << P.Bindings.getVertexCount() << " vertices.\n";


### PR DESCRIPTION
Lift vertex buffer creation into the common API layer and unifies it across the DX, Vulkan, and Metal backends.

### `Buffer` API
- Add pure-virtual `getSizeInBytes()`, `map()`, `unmap()` to `Buffer`. 
- Add `BufferUsage { Storage, VertexBuffer }` on `BufferCreateDesc`.
- Add `createVertexBufferFromCPUBuffer(Device&, const CPUBuffer&)`

### DirectX 
- Tighten the UAV flag logic: only `HEAP_TYPE_DEFAULT` gets `ALLOW_UNORDERED_ACCESS`
