### PR TITLE
Add IntelCPU feature flag, XFAIL WARP && IntelCPU in WaveActiveAllEqual.fp64

### DIFF
--- a/test/WaveOps/WaveActiveAllEqual.fp64.test
+++ b/test/WaveOps/WaveActiveAllEqual.fp64.test
@@ -150,6 +150,9 @@ DescriptorSets:
 # Bug: https://github.com/llvm/offload-test-suite/issues/944
 # XFAIL: Intel && DirectX
 
+# Bug: https://github.com/llvm/offload-test-suite/issues/1114
+# XFAIL: WARP && IntelCPU
+
 # Bug: https://github.com/llvm/offload-test-suite/issues/981
 # XFAIL: Clang
 

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -77,6 +77,31 @@ def setWaveSizeFeaturesDirectX(config, device):
         MinSizeInt *= 2
 
 
+def hostHasIntelCPU():
+    # Check if the host machine has an Intel CPU.
+    system = platform.system()
+    if system == "Windows":
+        return "intel" in platform.processor().lower()
+    elif system == "Linux":
+        try:
+            with open("/proc/cpuinfo", "r") as f:
+                for line in f:
+                    if line.startswith("vendor_id"):
+                        return "GenuineIntel" in line
+        except (IOError, OSError):
+            return False
+        return False
+    elif system == "Darwin":
+        try:
+            output = subprocess.check_output(
+                ["sysctl", "-n", "machdep.cpu.vendor"]
+            ).decode("UTF-8").strip()
+            return output == "GenuineIntel"
+        except (subprocess.CalledProcessError, OSError):
+            return False
+    return False
+
+
 def hostSupportsAVX512():
     # Check if the host CPU supports AVX-512 instructions.
     system = platform.system()
@@ -131,6 +156,9 @@ def setDeviceFeatures(config, device, compiler):
     if appleSilicon:
         gen = appleSilicon.group(1)
         config.available_features.add(f"AppleM{gen}")
+
+    if hostHasIntelCPU():
+        config.available_features.add("IntelCPU")
 
     if hostSupportsAVX512():
         config.available_features.add("AVX512")

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -93,9 +93,11 @@ def hostHasIntelCPU():
         return False
     elif system == "Darwin":
         try:
-            output = subprocess.check_output(
-                ["sysctl", "-n", "machdep.cpu.vendor"]
-            ).decode("UTF-8").strip()
+            output = (
+                subprocess.check_output(["sysctl", "-n", "machdep.cpu.vendor"])
+                .decode("UTF-8")
+                .strip()
+            )
             return output == "GenuineIntel"
         except (subprocess.CalledProcessError, OSError):
             return False


### PR DESCRIPTION
This PR adds a new `IntelCPU` feature flag, and uses it to add an XFAIL for WARP && IntelCPU in the WaveActiveAllEqual.fp64 test (https://github.com/llvm/offload-test-suite/issues/1114)

Assisted-by: Claude Opus 4.6