### PR TITLE
Remove XFAIL for log10.16.test clang Vulkan scenario

### DIFF
--- a/test/Feature/HLSLLib/log10.16.test
+++ b/test/Feature/HLSLLib/log10.16.test
@@ -61,9 +61,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug https://github.com/llvm/llvm-project/issues/145073
-# XFAIL: Clang && Vulkan
-
 # REQUIRES: Half
 # RUN: split-file %s %t
 # RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl


### PR DESCRIPTION
Fixed in https://github.com/llvm/llvm-project/pull/193730 