### PR TITLE
Add pixel shader `discard` test

### DIFF
--- a/test/Graphics/discard.test
+++ b/test/Graphics/discard.test
@@ -1,0 +1,78 @@
+#--- vertex.hlsl
+struct PSInput {
+  float4 position : SV_POSITION;
+};
+
+PSInput main(float4 position : POSITION) {
+  PSInput result;
+
+  result.position = position;
+
+  return result;
+}
+
+#--- pixel.hlsl
+struct PSInput {
+  float4 position : SV_POSITION;
+};
+
+// Discard the left half of a 4x1 viewport (pixel centers at x = 0.5 and 1.5);
+// keep the right half (pixel centers at x = 2.5 and 3.5). Discarded fragments
+// keep the zero-initialized render target; kept fragments write opaque red.
+float4 main(PSInput input) : SV_TARGET {
+  if (input.position.x < 2.0)
+    discard;
+
+  return float4(1.0, 0.0, 0.0, 1.0);
+}
+
+#--- pipeline.yaml
+---
+Shaders:
+  - Stage: Vertex
+    Entry: main
+  - Stage: Pixel
+    Entry: main
+Buffers:
+  - Name: VertexData
+    Format: Float32
+    Stride: 12
+    Data: [ -1.0, -1.0, 0.0,
+            -1.0,  1.0, 0.0,
+             1.0,  1.0, 0.0,
+             1.0,  1.0, 0.0,
+             1.0, -1.0, 0.0,
+            -1.0, -1.0, 0.0 ]
+  - Name: Output
+    Format: Float32
+    Channels: 4
+    FillSize: 64 # 4x1 @ 16 bytes per pixel
+    OutputProps:
+      Height: 1
+      Width: 4
+      Depth: 1
+Bindings:
+  VertexBuffer: VertexData
+  VertexAttributes:
+    - Format: Float32
+      Channels: 3
+      Offset: 0
+      Name: POSITION
+  RenderTarget: Output
+DescriptorSets: []
+...
+#--- end
+
+# Unimplemented https://github.com/llvm/wg-hlsl/issues/266
+# Clang's HLSL frontend does not yet recognize the `discard` statement.
+# XFAIL: Clang
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T vs_6_0 -Fo %t-vertex.o %t/vertex.hlsl
+# RUN: %dxc_target -T ps_6_0 -Fo %t-pixel.o %t/pixel.hlsl
+# RUN: %offloader %t/pipeline.yaml %t-vertex.o %t-pixel.o | FileCheck %s
+
+# Pixels 0,1 are discarded -> zero-initialized clear (0,0,0,0). 
+# Pixels 2,3 are rendered red (1,0,0,1).
+# CHECK: Name: Output
+# CHECK: Data: [ 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 1, 0, 0, 1 ]


### PR DESCRIPTION
Introduce new test that verifies the `discard` keyword behaves as expected.
The test renders a full screen quad and discards all pixels left half of the render target.
It verifies if the the correct pixels got discarded by using the clear color (black) and geometry color (red).

The test currently fails on clang as it does not yet support the `discard` keyword.