### PR TITLE
[arm64][warp] Remove xfail because bug is fixed

### DIFF
--- a/test/Feature/HLSLLib/fma.matrix.test
+++ b/test/Feature/HLSLLib/fma.matrix.test
@@ -133,9 +133,6 @@ DescriptorSets:
         Binding: 3
 #--- end
 
-# Bug https://github.com/llvm/offload-test-suite/issues/1000
-# XFAIL: arm64 && WARP
-
 # REQUIRES: Double
 # RUN: split-file %s %t
 # RUN: %dxc_target -Gis -HV 202x -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/fma.test
+++ b/test/Feature/HLSLLib/fma.test
@@ -93,9 +93,6 @@ DescriptorSets:
         Binding: 3
 #--- end
 
-# Bug https://github.com/microsoft/DirectXShaderCompiler/issues/8330
-# XFAIL: arm64 && WARP
-
 # Bug https://github.com/llvm/offload-test-suite/issues/1026
 # XFAIL: Intel && Vulkan && DXC
 


### PR DESCRIPTION
The new warp landed https://github.com/llvm/offload-test-suite/pull/1111 and issue https://github.com/llvm/offload-test-suite/issues/1000 is resolved.