### PR TITLE
Make WaveActiveAllEqual.fp64 unsupported for WARP. Revert IntelCPU feature flag

### DIFF
--- a/test/WaveOps/WaveActiveAllEqual.fp64.test
+++ b/test/WaveOps/WaveActiveAllEqual.fp64.test
@@ -147,6 +147,9 @@ DescriptorSets:
 ...
 #--- end
 
+# Bug: https://github.com/llvm/offload-test-suite/issues/1114
+# UNSUPPORTED: WARP
+
 # Bug: https://github.com/llvm/offload-test-suite/issues/944
 # XFAIL: Intel && DirectX
 

--- a/test/WaveOps/WaveActiveAllEqual.fp64.test
+++ b/test/WaveOps/WaveActiveAllEqual.fp64.test
@@ -150,9 +150,6 @@ DescriptorSets:
 # Bug: https://github.com/llvm/offload-test-suite/issues/944
 # XFAIL: Intel && DirectX
 
-# Bug: https://github.com/llvm/offload-test-suite/issues/1114
-# XFAIL: WARP && IntelCPU
-
 # Bug: https://github.com/llvm/offload-test-suite/issues/981
 # XFAIL: Clang
 

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -77,33 +77,6 @@ def setWaveSizeFeaturesDirectX(config, device):
         MinSizeInt *= 2
 
 
-def hostHasIntelCPU():
-    # Check if the host machine has an Intel CPU.
-    system = platform.system()
-    if system == "Windows":
-        return "intel" in platform.processor().lower()
-    elif system == "Linux":
-        try:
-            with open("/proc/cpuinfo", "r") as f:
-                for line in f:
-                    if line.startswith("vendor_id"):
-                        return "GenuineIntel" in line
-        except (IOError, OSError):
-            return False
-        return False
-    elif system == "Darwin":
-        try:
-            output = (
-                subprocess.check_output(["sysctl", "-n", "machdep.cpu.vendor"])
-                .decode("UTF-8")
-                .strip()
-            )
-            return output == "GenuineIntel"
-        except (subprocess.CalledProcessError, OSError):
-            return False
-    return False
-
-
 def hostSupportsAVX512():
     # Check if the host CPU supports AVX-512 instructions.
     system = platform.system()
@@ -158,9 +131,6 @@ def setDeviceFeatures(config, device, compiler):
     if appleSilicon:
         gen = appleSilicon.group(1)
         config.available_features.add(f"AppleM{gen}")
-
-    if hostHasIntelCPU():
-        config.available_features.add("IntelCPU")
 
     if hostSupportsAVX512():
         config.available_features.add("AVX512")


### PR DESCRIPTION
This PR reverts https://github.com/llvm/offload-test-suite/pull/1116 and instead marks the test `test/WaveOps/WaveActiveAllEqual.fp64.test` as unsupported under WARP due to the exact failure conditions for https://github.com/llvm/offload-test-suite/issues/1114 being unknown under WARP 1.0.19