### PR TITLE
XFAIL WARP && !AVX512 on `WaveActiveAllEqual.fp64`

### DIFF
--- a/test/WaveOps/WaveActiveAllEqual.fp64.test
+++ b/test/WaveOps/WaveActiveAllEqual.fp64.test
@@ -148,7 +148,7 @@ DescriptorSets:
 #--- end
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/1114
-# XFAIL: WARP && !AVX512
+# XFAIL: WARP && (x64 || x86) && !AVX512
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/944
 # XFAIL: Intel && DirectX

--- a/test/WaveOps/WaveActiveAllEqual.fp64.test
+++ b/test/WaveOps/WaveActiveAllEqual.fp64.test
@@ -148,7 +148,7 @@ DescriptorSets:
 #--- end
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/1114
-# UNSUPPORTED: WARP
+# XFAIL: WARP && !AVX512
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/944
 # XFAIL: Intel && DirectX


### PR DESCRIPTION
It appears that the test simply fails on CPUs lacking AVX-512 support. So the `UNSUPPORTED: WARP` can now be `XFAIL: WARP && !AVX512` with reasonable evidence.

I have updated #1114 and the internal bug report to reflect my findings.