### PR TITLE
Align rasterizer state, readback paths, cull mode, triangle winding order across backends

### DIFF
--- a/include/Support/Pipeline.h
+++ b/include/Support/Pipeline.h
@@ -153,6 +153,19 @@ struct CPUBuffer {
       return Stride;
     return getSingleElementSize() * Channels;
   }
+
+  // The natural per-row byte size of this buffer when interpreted as a 2D
+  // image (no padding).
+  uint32_t getImageRowBytes() const {
+    return OutputProps.Width * getElementSize();
+  }
+
+  // Copy a 2D image readback from a GPU mapping into Data[0]. The host
+  // buffer is tightly packed with top-left origin. SrcRowPitch is the
+  // source's per-row stride in bytes; pass `getImageRowBytes()` when the
+  // source is tightly packed (Vulkan / Metal), or the GPU's reported pitch
+  // when the source has row padding (e.g., D3D12's 256-byte aligned rows).
+  void copyFromTexture(const void *Src, size_t SrcRowPitch);
 };
 
 struct Result {

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -934,7 +934,6 @@ public:
                                      "shader and a pixel shader.");
 
     PSODesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
-    // Match the Vulkan and Metal backends: no culling, CCW = front-facing.
     PSODesc.RasterizerState.CullMode = D3D12_CULL_MODE_NONE;
     PSODesc.RasterizerState.FrontCounterClockwise = TRUE;
     PSODesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -1878,18 +1878,14 @@ public:
     if (!IS.RTReadback)
       return llvm::Error::success();
 
-    // Map readback and copy into host buffer, accounting for row pitch and
-    // flipping vertical orientation. DirectX render target origin is top-left,
-    // while our image writer expects bottom-left.
-    const CPUBuffer &B = *P.Bindings.RTargetBufferPtr;
     void *Mapped = nullptr;
     auto &Readback = llvm::cast<DXBuffer>(*IS.RTReadback);
     if (auto Err = HR::toError(Readback.Buffer->Map(0, nullptr, &Mapped),
                                "Failed to map render target readback"))
       return Err;
 
-    // Query the copy footprint to get the actual padded row pitch used by the
-    // copy operation.
+    // Query the copy footprint to get the actual padded row pitch used by
+    // the copy operation (D3D12 requires 256-byte aligned rows).
     auto &RT = llvm::cast<DXTexture>(*IS.RT);
     const D3D12_RESOURCE_DESC RTDesc = RT.Resource->GetDesc();
     D3D12_PLACED_SUBRESOURCE_FOOTPRINT Placed = {};
@@ -1899,23 +1895,8 @@ public:
     Device->GetCopyableFootprints(&RTDesc, 0u, 1u, 0u, &Placed, &NumRows,
                                   &RowSizeInBytes, &TotalBytes);
 
-    const uint32_t RowPitch = Placed.Footprint.RowPitch;
-    const uint32_t RowBytes =
-        static_cast<uint32_t>(B.getElementSize() * B.OutputProps.Width);
-    const uint32_t Height = static_cast<uint32_t>(B.OutputProps.Height);
-
-    const uint8_t *SrcBase = reinterpret_cast<uint8_t *>(Mapped);
-    uint8_t *DstBase =
-        reinterpret_cast<uint8_t *>(P.Bindings.RTargetBufferPtr->Data[0].get());
-
-    // Copy rows in reverse order.
-    for (uint32_t Y = 0; Y < Height; ++Y) {
-      const uint8_t *SrcRow = SrcBase + static_cast<size_t>(Y) * RowPitch;
-      uint8_t *DstRow =
-          DstBase + static_cast<size_t>(Height - 1 - Y) * RowBytes;
-      memcpy(DstRow, SrcRow, RowBytes);
-    }
-
+    P.Bindings.RTargetBufferPtr->copyFromTexture(Mapped,
+                                                 Placed.Footprint.RowPitch);
     Readback.Buffer->Unmap(0, nullptr);
     return llvm::Error::success();
   }

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -934,6 +934,9 @@ public:
                                      "shader and a pixel shader.");
 
     PSODesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
+    // Match the Vulkan and Metal backends: no culling, CCW = front-facing.
+    PSODesc.RasterizerState.CullMode = D3D12_CULL_MODE_NONE;
+    PSODesc.RasterizerState.FrontCounterClockwise = TRUE;
     PSODesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
     PSODesc.DepthStencilState.DepthEnable = true;
     PSODesc.DepthStencilState.DepthWriteMask = D3D12_DEPTH_WRITE_MASK_ALL;

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -712,6 +712,7 @@ class MTLDevice : public offloadtest::Device {
     CmdEncoder->setViewport(
         MTL::Viewport{0.0, 0.0, (double)Width, (double)Height, 0.0, 1.0});
     CmdEncoder->setCullMode(MTL::CullModeNone);
+    CmdEncoder->setFrontFacingWinding(MTL::WindingCounterClockwise);
 
     // Bind vertex buffer at slot 0 to match the vertex descriptor which
     // references buffer index 0.

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -769,23 +769,9 @@ class MTLDevice : public offloadtest::Device {
       }
     }
     if (P.isTraditionalRaster()) {
-      CPUBuffer *RTarget = P.Bindings.RTargetBufferPtr;
-      const uint64_t Width = RTarget->OutputProps.Width;
-      const uint64_t Height = RTarget->OutputProps.Height;
-      const size_t ElemSize = RTarget->getElementSize();
-      const size_t RowBytes = Width * ElemSize;
-
-      // Read from the readback buffer. The blit copied the texture data in
-      // GPU layout order, so we flip rows here to produce an upright image.
       auto &FBReadback = llvm::cast<MTLBuffer>(*IS.FrameBufferReadback);
-      const unsigned char *Src =
-          reinterpret_cast<const unsigned char *>(FBReadback.Buf->contents());
-      unsigned char *Buf =
-          reinterpret_cast<unsigned char *>(RTarget->Data[0].get());
-      for (uint64_t R = 0; R < Height; ++R) {
-        const uint64_t SrcRow = (Height - 1) - R;
-        memcpy(Buf + R * RowBytes, Src + SrcRow * RowBytes, RowBytes);
-      }
+      auto *RT = P.Bindings.RTargetBufferPtr;
+      RT->copyFromTexture(FBReadback.Buf->contents(), RT->getImageRowBytes());
     }
     return llvm::Error::success();
   }

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -2813,8 +2813,8 @@ public:
       vkMapMemory(Device, Readback.Memory, 0, VK_WHOLE_SIZE, 0, &Mapped);
       vkInvalidateMappedMemoryRanges(Device, 1, &Range);
 
-      const CPUBuffer &B = *P.Bindings.RTargetBufferPtr;
-      memcpy(B.Data[0].get(), Mapped, B.size());
+      auto *RT = P.Bindings.RTargetBufferPtr;
+      RT->copyFromTexture(Mapped, RT->getImageRowBytes());
       vkUnmapMemory(Device, Readback.Memory);
     }
     return llvm::Error::success();

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -2682,13 +2682,17 @@ public:
       vkCmdBeginRenderPass(IS.CB->CmdBuffer, &RenderPassBeginInfo,
                            VK_SUBPASS_CONTENTS_INLINE);
 
+      // Negative viewport height (with Y origin at the bottom) flips clip->
+      // framebuffer Y the same way DX12 and Metal do, so a CCW-in-clip-space
+      // triangle is front-facing on every backend.
       VkViewport Viewport = {};
       Viewport.x = 0.0f;
-      Viewport.y = 0.0f;
+      Viewport.y =
+          static_cast<float>(P.Bindings.RTargetBufferPtr->OutputProps.Height);
       Viewport.width =
           static_cast<float>(P.Bindings.RTargetBufferPtr->OutputProps.Width);
       Viewport.height =
-          static_cast<float>(P.Bindings.RTargetBufferPtr->OutputProps.Height);
+          -static_cast<float>(P.Bindings.RTargetBufferPtr->OutputProps.Height);
       Viewport.minDepth = 0.0f;
       Viewport.maxDepth = 1.0f;
       vkCmdSetViewport(IS.CB->CmdBuffer, 0, 1, &Viewport);

--- a/lib/Image/Image.cpp
+++ b/lib/Image/Image.cpp
@@ -159,10 +159,10 @@ static llvm::Error writePNGImpl(ImageRef Img, llvm::StringRef OutputPath) {
   png_bytepp Rows =
       (png_bytepp)png_malloc(PNG, Img.getHeight() * sizeof(png_bytep));
   const uint64_t RowSize = Img.getWidth() * Img.getChannels() * Img.getDepth();
-  // Step one row back from the end
-  const uint8_t *Row = reinterpret_cast<const uint8_t *>(Img.data()) +
-                       (RowSize * Img.getHeight()) - RowSize;
-  for (uint32_t I = 0; I < Img.getHeight(); ++I, Row -= RowSize)
+  // The host buffer has top-left origin (matching every backend's readback
+  // and the standard PNG row order), so we walk forward.
+  const uint8_t *Row = reinterpret_cast<const uint8_t *>(Img.data());
+  for (uint32_t I = 0; I < Img.getHeight(); ++I, Row += RowSize)
     Rows[I] = const_cast<png_bytep>(Row);
 
   png_write_image(PNG, Rows);

--- a/lib/Support/Pipeline.cpp
+++ b/lib/Support/Pipeline.cpp
@@ -26,6 +26,21 @@ void PushConstantBlock::getContent(
     memcpy(Output.data() + V.OffsetInBytes, V.Data.data(), V.Data.size());
 }
 
+void CPUBuffer::copyFromTexture(const void *Src, size_t SrcRowPitch) {
+  const uint32_t Height = OutputProps.Height;
+  const uint32_t RowBytes = getImageRowBytes();
+  assert(SrcRowPitch >= RowBytes && "Source row pitch is smaller than image");
+  uint8_t *Dst = reinterpret_cast<uint8_t *>(Data[0].get());
+  if (SrcRowPitch == RowBytes) {
+    memcpy(Dst, Src, static_cast<size_t>(Height) * RowBytes);
+    return;
+  }
+  const uint8_t *S = reinterpret_cast<const uint8_t *>(Src);
+  for (uint32_t Y = 0; Y < Height; ++Y)
+    memcpy(Dst + static_cast<size_t>(Y) * RowBytes,
+           S + static_cast<size_t>(Y) * SrcRowPitch, RowBytes);
+}
+
 uint32_t PushConstantBlock::size() const {
   uint32_t Size = 0;
   for (const PushConstantValue &V : Values)


### PR DESCRIPTION
## Summary

Make the three backends use the same image coordinate system, same culling mode and same `SV_IsFrontFace` polarity.

The framework had the following setup:

1. **Front-face polarity differed.** 
DX/MTL Y-flip clip→framebuffer at the viewport; Vulkan with positive-height viewport doesn't. 
Same HLSL triangle ended up with opposite framebuffer winding on VK vs DX/MTL, so `SV_IsFrontFace` gave opposite answers for the same input. This surfaced while writing a graphics-stage system-values test that needed `SV_IsFrontFace` to agree across backends.

2. **Visual PNG output was aligned by two compensating flips.**
DX and MTL each had a row-reversal on readback documented as "render target origin is top-left, while our image writer expects bottom-left".
The PNG writer reversed rows again on the way out.
VK had neither flip, but VK's no-Y-flip viewport meant its framebuffer was already "upside down" relative to DX/MTL, so its single PNG flip happened to produce a visually identical image. Two-flips-cancel on DX/MTL, no-flip-needed on VK, by accident. 
Adding any new behavior on top of this _(e.g., the negative-height-viewport change in the earlier stage of this PR that kicked off the investigation)_ immediately broke the cancellation and produced visually-flipped outputs.

## PR

Pick HLSL/DX semantics as canonical:
- Clip-space Y up
- Framebuffer Y down
- CCW = front 

Untangled the asymmetry by removing the readback flips on DX/MTL and the PNG writer's row reversal together with the VK viewport flip, so all three places change as one atomic step. After that, every backend produces the same Y-down memory layout end-to-end.

Exposed shared `copyFromTexture` function that all backends can call. 
If https://github.com/llvm/offload-test-suite/pull/1113 goes in main, which introduces `Map`/`Unmap` as functions on the `Buffer` type, the readback path can be generalized further.

## Golden Images
All graphics golden images still work as expected. The resulting Y-order is maintained.
The `Mandelbrot.test` image required updating as it's a compute path. Here's the PR: https://github.com/llvm/offload-golden-images/pull/6



