### PR TITLE
Move `Queue::submit` function definition out of anonymous namespace.

### DIFF
--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -499,43 +499,6 @@ private:
   DXCommandBuffer() : CommandBuffer(GPUAPI::DirectX) {}
 };
 
-llvm::Error DXQueue::submit(
-    llvm::SmallVectorImpl<std::unique_ptr<offloadtest::CommandBuffer>> &&CBs) {
-  llvm::SmallVector<ID3D12CommandList *> CmdLists;
-  CmdLists.reserve(CBs.size());
-
-  // Wait on the previous submit's fence value before executing this batch,
-  // so that back-to-back submits don't overlap on the GPU. Skip on first
-  // submit since Wait(fence, 0) triggers a D3D12 validation warning.
-  if (FenceCounter > 0)
-    if (auto Err =
-            HR::toError(Queue->Wait(SubmitFence->Fence.Get(), FenceCounter),
-                        "Failed to wait on previous submit."))
-      return Err;
-
-  for (auto &CB : CBs) {
-    auto &DCB = *llvm::cast<DXCommandBuffer>(CB.get());
-    if (auto Err =
-            HR::toError(DCB.CmdList->Close(), "Failed to close command list."))
-      return Err;
-    CmdLists.push_back(DCB.CmdList.Get());
-  }
-
-  Queue->ExecuteCommandLists(CmdLists.size(), CmdLists.data());
-
-  const uint64_t CurrentCounter = ++FenceCounter;
-  if (auto Err =
-          HR::toError(Queue->Signal(SubmitFence->Fence.Get(), CurrentCounter),
-                      "Failed to add signal."))
-    return Err;
-
-  // TODO: Return a Fence+value with keepalive lists instead of blocking here.
-  if (auto Err = SubmitFence->waitForCompletion(CurrentCounter))
-    return Err;
-
-  return llvm::Error::success();
-}
-
 struct DescriptorAllocator {
   ComPtr<ID3D12DescriptorHeap> Heap;
   std::atomic<uint32_t> NextIndex{0};
@@ -2017,6 +1980,43 @@ public:
   }
 };
 } // namespace
+
+llvm::Error DXQueue::submit(
+    llvm::SmallVectorImpl<std::unique_ptr<offloadtest::CommandBuffer>> &&CBs) {
+  llvm::SmallVector<ID3D12CommandList *> CmdLists;
+  CmdLists.reserve(CBs.size());
+
+  // Wait on the previous submit's fence value before executing this batch,
+  // so that back-to-back submits don't overlap on the GPU. Skip on first
+  // submit since Wait(fence, 0) triggers a D3D12 validation warning.
+  if (FenceCounter > 0)
+    if (auto Err =
+            HR::toError(Queue->Wait(SubmitFence->Fence.Get(), FenceCounter),
+                        "Failed to wait on previous submit."))
+      return Err;
+
+  for (auto &CB : CBs) {
+    auto &DCB = *llvm::cast<DXCommandBuffer>(CB.get());
+    if (auto Err =
+            HR::toError(DCB.CmdList->Close(), "Failed to close command list."))
+      return Err;
+    CmdLists.push_back(DCB.CmdList.Get());
+  }
+
+  Queue->ExecuteCommandLists(CmdLists.size(), CmdLists.data());
+
+  const uint64_t CurrentCounter = ++FenceCounter;
+  if (auto Err =
+          HR::toError(Queue->Signal(SubmitFence->Fence.Get(), CurrentCounter),
+                      "Failed to add signal."))
+    return Err;
+
+  // TODO: Return a Fence+value with keepalive lists instead of blocking here.
+  if (auto Err = SubmitFence->waitForCompletion(CurrentCounter))
+    return Err;
+
+  return llvm::Error::success();
+}
 
 llvm::Error offloadtest::initializeDX12Devices(
     const DeviceConfig Config,

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -556,55 +556,6 @@ private:
   VulkanCommandBuffer() : CommandBuffer(GPUAPI::Vulkan) {}
 };
 
-llvm::Error VulkanQueue::submit(
-    llvm::SmallVectorImpl<std::unique_ptr<offloadtest::CommandBuffer>> &&CBs) {
-  llvm::SmallVector<VkCommandBuffer> CmdBuffers;
-  CmdBuffers.reserve(CBs.size());
-
-  // Wait on the previous submit's fence value before executing this batch,
-  // so that back-to-back submits don't overlap on the GPU. Waiting for a
-  // value that is already signaled (including 0 on first submit) is a no-op.
-  const uint64_t WaitValue = FenceCounter;
-  const uint64_t SignalValue = ++FenceCounter;
-  const VkPipelineStageFlags WaitStage = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
-
-  for (auto &CB : CBs) {
-    auto &VCB = *llvm::cast<VulkanCommandBuffer>(CB.get());
-    if (auto Err = VK::toError(vkEndCommandBuffer(VCB.CmdBuffer),
-                               "Could not end command buffer."))
-      return Err;
-    CmdBuffers.push_back(VCB.CmdBuffer);
-  }
-
-  VkTimelineSemaphoreSubmitInfo TimelineInfo = {};
-  TimelineInfo.sType = VK_STRUCTURE_TYPE_TIMELINE_SEMAPHORE_SUBMIT_INFO;
-  TimelineInfo.waitSemaphoreValueCount = 1;
-  TimelineInfo.pWaitSemaphoreValues = &WaitValue;
-  TimelineInfo.signalSemaphoreValueCount = 1;
-  TimelineInfo.pSignalSemaphoreValues = &SignalValue;
-
-  VkSubmitInfo SubmitInfo = {};
-  SubmitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
-  SubmitInfo.pNext = &TimelineInfo;
-  SubmitInfo.waitSemaphoreCount = 1;
-  SubmitInfo.pWaitSemaphores = &SubmitFence->Semaphore;
-  SubmitInfo.pWaitDstStageMask = &WaitStage;
-  SubmitInfo.commandBufferCount = CmdBuffers.size();
-  SubmitInfo.pCommandBuffers = CmdBuffers.data();
-  SubmitInfo.signalSemaphoreCount = 1;
-  SubmitInfo.pSignalSemaphores = &SubmitFence->Semaphore;
-
-  if (auto Err =
-          VK::toError(vkQueueSubmit(Queue, 1, &SubmitInfo, VK_NULL_HANDLE),
-                      "Failed to submit to queue."))
-    return Err;
-
-  // TODO: Return a Fence+value with keepalive lists instead of blocking here.
-  if (auto Err = SubmitFence->waitForCompletion(SignalValue))
-    return Err;
-
-  return llvm::Error::success();
-}
 class VulkanDevice : public offloadtest::Device {
 private:
   std::shared_ptr<VulkanInstance> Instance;
@@ -2639,6 +2590,56 @@ public:
   }
 };
 } // namespace
+
+llvm::Error VulkanQueue::submit(
+    llvm::SmallVectorImpl<std::unique_ptr<offloadtest::CommandBuffer>> &&CBs) {
+  llvm::SmallVector<VkCommandBuffer> CmdBuffers;
+  CmdBuffers.reserve(CBs.size());
+
+  // Wait on the previous submit's fence value before executing this batch,
+  // so that back-to-back submits don't overlap on the GPU. Waiting for a
+  // value that is already signaled (including 0 on first submit) is a no-op.
+  const uint64_t WaitValue = FenceCounter;
+  const uint64_t SignalValue = ++FenceCounter;
+  const VkPipelineStageFlags WaitStage = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
+
+  for (auto &CB : CBs) {
+    auto &VCB = *llvm::cast<VulkanCommandBuffer>(CB.get());
+    if (auto Err = VK::toError(vkEndCommandBuffer(VCB.CmdBuffer),
+                               "Could not end command buffer."))
+      return Err;
+    CmdBuffers.push_back(VCB.CmdBuffer);
+  }
+
+  VkTimelineSemaphoreSubmitInfo TimelineInfo = {};
+  TimelineInfo.sType = VK_STRUCTURE_TYPE_TIMELINE_SEMAPHORE_SUBMIT_INFO;
+  TimelineInfo.waitSemaphoreValueCount = 1;
+  TimelineInfo.pWaitSemaphoreValues = &WaitValue;
+  TimelineInfo.signalSemaphoreValueCount = 1;
+  TimelineInfo.pSignalSemaphoreValues = &SignalValue;
+
+  VkSubmitInfo SubmitInfo = {};
+  SubmitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+  SubmitInfo.pNext = &TimelineInfo;
+  SubmitInfo.waitSemaphoreCount = 1;
+  SubmitInfo.pWaitSemaphores = &SubmitFence->Semaphore;
+  SubmitInfo.pWaitDstStageMask = &WaitStage;
+  SubmitInfo.commandBufferCount = CmdBuffers.size();
+  SubmitInfo.pCommandBuffers = CmdBuffers.data();
+  SubmitInfo.signalSemaphoreCount = 1;
+  SubmitInfo.pSignalSemaphores = &SubmitFence->Semaphore;
+
+  if (auto Err =
+          VK::toError(vkQueueSubmit(Queue, 1, &SubmitInfo, VK_NULL_HANDLE),
+                      "Failed to submit to queue."))
+    return Err;
+
+  // TODO: Return a Fence+value with keepalive lists instead of blocking here.
+  if (auto Err = SubmitFence->waitForCompletion(SignalValue))
+    return Err;
+
+  return llvm::Error::success();
+}
 
 llvm::Error offloadtest::initializeVulkanDevices(
     const DeviceConfig Config,


### PR DESCRIPTION
On my local machine I was getting this warning being treated as an error:
```
error: place definition of method 'submit' outside of an anonymous namespace [llvm-prefer-static-over-anonymous-namespace,-warnings-as-errors]
  502 | llvm::Error DXQueue::submit(
      |                      ^
```

This is easily resolved by moving the function definition outside of the anonymous namespace.