### PR TITLE
Package cmake files in build artifacts

### DIFF
--- a/.github/workflows/build-and-test-callable.yaml
+++ b/.github/workflows/build-and-test-callable.yaml
@@ -244,7 +244,6 @@ jobs:
               --exclude='*.o' \
               --exclude='*.ilk' \
               --exclude='*.pdb' \
-              --exclude='CMakeFiles' \
               DXC/build/bin llvm-project/build
       - name: Upload build artifacts
         if: inputs.SplitBuild == true


### PR DESCRIPTION
Cmake files need to be included in the build artifacts, since ninja depends on these files when running the tests.
This is to prevent the error: https://github.com/llvm/offload-test-suite/actions/runs/25184022850/job/73838128009#step:13:137
from occurring, which was caused by excluding Cmake files from being included in the artifacts.
Fixes https://github.com/llvm/offload-test-suite/issues/1145