### PR TITLE
Improve validation of shader pipeline type.

### DIFF
--- a/include/Support/Pipeline.h
+++ b/include/Support/Pipeline.h
@@ -16,6 +16,7 @@
 #include "API/Enums.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Error.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/YAMLTraits.h"
 #include <limits>
@@ -26,6 +27,14 @@
 namespace offloadtest {
 
 enum class Stages { Compute, Vertex, Pixel };
+inline constexpr std::array AllStages = {
+    Stages::Compute,
+    Stages::Vertex,
+    Stages::Pixel,
+};
+inline constexpr size_t NumStages = AllStages.size();
+
+enum class ShaderPipelineKind { Compute, TraditionalRaster };
 
 enum class Rule { BufferExact, BufferFloatULP, BufferFloatEpsilon };
 
@@ -396,6 +405,7 @@ struct Shader {
 };
 
 struct Pipeline {
+  ShaderPipelineKind Kind;
   llvm::SmallVector<Shader> Shaders;
   RuntimeSettings Settings;
 
@@ -435,10 +445,11 @@ struct Pipeline {
     return nullptr;
   }
 
-  bool isGraphics() const { return !isCompute(); }
+  llvm::Error validatePipelineKind();
 
-  bool isCompute() const {
-    return Shaders.size() == 1 && Shaders[0].Stage == Stages::Compute;
+  bool isCompute() const { return Kind == ShaderPipelineKind::Compute; }
+  bool isTraditionalRaster() const {
+    return Kind == ShaderPipelineKind::TraditionalRaster;
   }
 };
 } // namespace offloadtest

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -2068,7 +2068,7 @@ public:
         return Err;
       llvm::outs() << "Compute command list created.\n";
 
-    } else {
+    } else if (P.isTraditionalRaster()) {
       // Create render target, depth/stencil, readback and vertex buffer and
       // PSO.
       if (auto Err = createRenderTarget(P, State))
@@ -2127,6 +2127,9 @@ public:
       if (auto Err = createGraphicsCommands(P, State))
         return Err;
       llvm::outs() << "Graphics command list created complete.\n";
+    } else {
+      return llvm::createStringError(
+          "Pipeline was neither Compute nor Traditional Graphics");
     }
 
     auto SubmitResult = executeCommandList(State);

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -2129,7 +2129,7 @@ public:
       llvm::outs() << "Graphics command list created complete.\n";
     } else {
       return llvm::createStringError(
-          "Pipeline was neither Compute nor Traditional Graphics");
+          "Pipeline was neither Compute nor Traditional Raster");
     }
 
     auto SubmitResult = executeCommandList(State);

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -364,7 +364,7 @@ class MTLDevice : public offloadtest::Device {
       }
       IS.ArgBuffer->didModifyRange(NS::Range::Make(0, IS.ArgBuffer->length()));
     }
-    if (P.isGraphics()) {
+    if (P.isTraditionalRaster()) {
       if (!P.Bindings.VertexBufferPtr)
         return llvm::createStringError(
             std::errc::invalid_argument,
@@ -612,7 +612,7 @@ class MTLDevice : public offloadtest::Device {
             MTL::Region(0, 0, Width, Height), 0);
       }
     }
-    if (P.isGraphics()) {
+    if (P.isTraditionalRaster()) {
       CPUBuffer *RTarget = P.Bindings.RTargetBufferPtr;
       const uint64_t Width = RTarget->OutputProps.Width;
       const uint64_t Height = RTarget->OutputProps.Height;

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -2831,7 +2831,7 @@ public:
       llvm::outs() << "Frame buffer created.\n";
     } else {
       return llvm::createStringError(
-          "Pipeline was neither Compute nor Traditional Graphics");
+          "Pipeline was neither Compute nor Traditional Raster");
     }
 
     llvm::outs() << "Memory buffers created.\n";

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -1781,7 +1781,7 @@ public:
       }
     }
 
-    if (P.isGraphics()) {
+    if (P.isTraditionalRaster()) {
       if (auto Err = createRenderTarget(P, IS))
         return Err;
       // TODO: Always created for graphics pipelines. Consider making this
@@ -2499,7 +2499,7 @@ public:
     for (auto &R : IS.Resources)
       copyResourceDataToDevice(IS, R);
 
-    if (P.isGraphics()) {
+    if (P.isTraditionalRaster()) {
       auto &RT = llvm::cast<VulkanTexture>(*IS.RenderTarget);
       auto &DS = llvm::cast<VulkanTexture>(*IS.DepthStencil);
       auto &PipelineState = llvm::cast<VulkanPipelineState>(*IS.Pipeline);
@@ -2552,7 +2552,7 @@ public:
       vkCmdSetScissor(IS.CB->CmdBuffer, 0, 1, &Scissor);
     }
 
-    const VkPipelineBindPoint BindPoint = P.isGraphics()
+    const VkPipelineBindPoint BindPoint = P.isTraditionalRaster()
                                               ? VK_PIPELINE_BIND_POINT_GRAPHICS
                                               : VK_PIPELINE_BIND_POINT_COMPUTE;
     const VulkanPipelineState &VulkanPipeline =
@@ -2642,7 +2642,7 @@ public:
     }
 
     // Copy back the frame buffer data if this was a graphics pipeline.
-    if (P.isGraphics()) {
+    if (P.isTraditionalRaster()) {
       auto &Readback = llvm::cast<VulkanBuffer>(*IS.RTReadback);
 
       VkMappedMemoryRange Range = {};
@@ -2781,7 +2781,7 @@ public:
         return PipelineStateOrErr.takeError();
       State.Pipeline = std::move(*PipelineStateOrErr);
       llvm::outs() << "Compute Pipeline created.\n";
-    } else {
+    } else if (P.isTraditionalRaster()) {
       ShaderContainer VS = {};
       ShaderContainer PS = {};
       for (auto &Shader : P.Shaders) {
@@ -2829,6 +2829,9 @@ public:
       if (auto Err = createFrameBuffer(State))
         return Err;
       llvm::outs() << "Frame buffer created.\n";
+    } else {
+      return llvm::createStringError(
+          "Pipeline was neither Compute nor Traditional Graphics");
     }
 
     llvm::outs() << "Memory buffers created.\n";

--- a/lib/Support/Pipeline.cpp
+++ b/lib/Support/Pipeline.cpp
@@ -40,6 +40,9 @@ namespace yaml {
 void MappingTraits<offloadtest::Pipeline>::mapping(IO &I,
                                                    offloadtest::Pipeline &P) {
   I.mapRequired("Shaders", P.Shaders);
+  if (auto Err = P.validatePipelineKind())
+    I.setError(llvm::toString(std::move(Err)));
+
   // Runtime-specific settings.
   I.mapOptional("RuntimeSettings", P.Settings);
 
@@ -554,3 +557,35 @@ void MappingTraits<offloadtest::SpecializationConstant>::mapping(
 
 } // namespace yaml
 } // namespace llvm
+
+llvm::Error offloadtest::Pipeline::validatePipelineKind() {
+  bool HasShaderType[NumStages] = {};
+  for (const auto &Shader : Shaders) {
+    // This works except for ray tracing shaders. We will have to make an
+    // exception for miss, closest hit, any hit and intersection shaders once we
+    // support those.
+    if (HasShaderType[llvm::to_underlying(Shader.Stage)])
+      return llvm::createStringError(
+          "Pipeline has multiple shaders of the same type.");
+
+    HasShaderType[llvm::to_underlying(Shader.Stage)] = true;
+  }
+
+  if (HasShaderType[llvm::to_underlying(Stages::Compute)]) {
+    if (Shaders.size() > 1)
+      return llvm::createStringError(
+          "Compute Pipeline is only allowed to have Compute Shader.");
+    Kind = ShaderPipelineKind::Compute;
+    return llvm::Error::success();
+  }
+
+  if (HasShaderType[llvm::to_underlying(Stages::Vertex)]) {
+    Kind = ShaderPipelineKind::TraditionalRaster;
+    return llvm::Error::success();
+  }
+
+  // As we add more pipeline types this error message should be updated with
+  // more required shader types.
+  return llvm::createStringError(
+      "The pipeline misses a Compute or Vertex Shader.");
+}


### PR DESCRIPTION
There are some restrictions on what shaders are allowed to go together in a single shader pipeline.
This change defines two kinds: `Compute`, and `TraditionalRaster`. In the future we can add support for other like `MeshShaderRaster`, `RayTracing`, and `WorkGraph`.

By validating once if the provided shaders are a valid pipeline and assigning a pipeline type when we load from the YAML file, we can keep the logic in `executeProgram` simple and won't have to do any more expensive validation there.