### PR TITLE
Move dispatch dimensions and vertex count to new `DispatchParameters` with defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,8 @@ This framework provides a YAML representation for describing GPU pipelines and b
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
+DispatchParameters:
+  DispatchGroupCount: [2, 1, 1]
 Buffers:
   - Name: Constants
     Format: Int32

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Shaders:
   - Stage: Compute
     Entry: main
 DispatchParameters:
-  DispatchGroupCount: [2, 1, 1]
+  DispatchGroupCount: [2, 1, 1] # Define how many groups to dispatch, if omitted one group is launched.
 Buffers:
   - Name: Constants
     Format: Int32

--- a/include/Support/Pipeline.h
+++ b/include/Support/Pipeline.h
@@ -355,10 +355,6 @@ struct IOBindings {
       Stride += VA.size();
     return Stride;
   }
-
-  uint32_t getVertexCount() const {
-    return VertexBufferPtr->size() / getVertexStride();
-  }
 };
 
 // Describes a contiguous group of bytes in a push constant block.
@@ -400,8 +396,12 @@ struct Shader {
   std::string Entry;
   std::unique_ptr<llvm::MemoryBuffer> Shader;
   std::unique_ptr<llvm::MemoryBuffer> Reflection;
-  int DispatchSize[3];
   llvm::SmallVector<SpecializationConstant> SpecializationConstants;
+};
+
+struct DispatchParametersSet {
+  std::array<uint32_t, 3> DispatchGroupCount = {1, 1, 1};
+  std::optional<uint32_t> VertexCount;
 };
 
 struct Pipeline {
@@ -415,6 +415,17 @@ struct Pipeline {
   llvm::SmallVector<Sampler> Samplers;
   llvm::SmallVector<Result> Results;
   llvm::SmallVector<DescriptorSet> Sets;
+  DispatchParametersSet DispatchParameters;
+
+  uint32_t getVertexCount() const {
+    if (DispatchParameters.VertexCount)
+      return *DispatchParameters.VertexCount;
+
+    assert(Bindings.VertexBufferPtr != nullptr &&
+           "No VertexCount specified and no Vertex Buffer available to imply "
+           "VertexCount from.");
+    return Bindings.VertexBufferPtr->size() / Bindings.getVertexStride();
+  }
 
   uint32_t getDescriptorCount() const {
     uint32_t DescriptorCount = 0;
@@ -465,6 +476,7 @@ LLVM_YAML_IS_SEQUENCE_VECTOR(offloadtest::VertexAttribute)
 LLVM_YAML_IS_SEQUENCE_VECTOR(offloadtest::SpecializationConstant)
 LLVM_YAML_IS_SEQUENCE_VECTOR(offloadtest::PushConstantBlock)
 LLVM_YAML_IS_SEQUENCE_VECTOR(offloadtest::PushConstantValue)
+LLVM_YAML_IS_SEQUENCE_VECTOR(offloadtest::DispatchParametersSet)
 
 namespace llvm {
 namespace yaml {
@@ -511,6 +523,10 @@ template <> struct MappingTraits<offloadtest::PushConstantValue> {
 
 template <> struct MappingTraits<offloadtest::PushConstantBlock> {
   static void mapping(IO &I, offloadtest::PushConstantBlock &B);
+};
+
+template <> struct MappingTraits<offloadtest::DispatchParametersSet> {
+  static void mapping(IO &I, offloadtest::DispatchParametersSet &B);
 };
 
 template <> struct MappingTraits<offloadtest::VertexAttribute> {

--- a/include/Support/Pipeline.h
+++ b/include/Support/Pipeline.h
@@ -457,6 +457,7 @@ struct Pipeline {
   }
 
   llvm::Error validatePipelineKind();
+  llvm::Error validateDispatchParameters();
 
   bool isCompute() const { return Kind == ShaderPipelineKind::Compute; }
   bool isTraditionalRaster() const {

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -1787,10 +1787,10 @@ public:
       if (!EncoderOrErr)
         return EncoderOrErr.takeError();
       auto &Encoder = *EncoderOrErr.get();
-      const llvm::ArrayRef<int> DispatchSize =
-          llvm::ArrayRef<int>(P.Shaders[0].DispatchSize);
-      if (auto Err = Encoder.dispatch(DispatchSize[0], DispatchSize[1],
-                                      DispatchSize[2]))
+      if (auto Err =
+              Encoder.dispatch(P.DispatchParameters.DispatchGroupCount[0],
+                               P.DispatchParameters.DispatchGroupCount[1],
+                               P.DispatchParameters.DispatchGroupCount[2]))
         return Err;
       Encoder.endEncoding();
     }
@@ -2027,7 +2027,7 @@ public:
                                 static_cast<LONG>(VP.Height)};
     IS.CB->CmdList->RSSetScissorRects(1, &Scissor);
 
-    IS.CB->CmdList->DrawInstanced(P.Bindings.getVertexCount(), 1, 0, 0);
+    IS.CB->CmdList->DrawInstanced(P.getVertexCount(), 1, 0, 0);
 
     // Transition the render target to copy source and copy to the readback
     // buffer.

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -594,10 +594,9 @@ class MTLDevice : public offloadtest::Device {
     }
     Encoder.setThreadGroupSize(TGS[0], TGS[1], TGS[2]);
 
-    const llvm::ArrayRef<int> DispatchSize =
-        llvm::ArrayRef<int>(P.Shaders[0].DispatchSize);
-    if (auto Err =
-            Encoder.dispatch(DispatchSize[0], DispatchSize[1], DispatchSize[2]))
+    if (auto Err = Encoder.dispatch(P.DispatchParameters.DispatchGroupCount[0],
+                                    P.DispatchParameters.DispatchGroupCount[1],
+                                    P.DispatchParameters.DispatchGroupCount[2]))
       return Err;
     Encoder.endEncoding();
     return llvm::Error::success();
@@ -718,7 +717,7 @@ class MTLDevice : public offloadtest::Device {
     CmdEncoder->setVertexBuffer(llvm::cast<MTLBuffer>(*IS.VB).Buf, 0, 0);
 
     CmdEncoder->drawPrimitives(MTL::PrimitiveTypeTriangle, NS::UInteger(0),
-                               P.Bindings.getVertexCount());
+                               P.getVertexCount());
 
     CmdEncoder->endEncoding();
 

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -2724,22 +2724,24 @@ public:
       if (!EncoderOrErr)
         return EncoderOrErr.takeError();
       auto &Encoder = *EncoderOrErr.get();
-      const llvm::ArrayRef<int> DispatchSize =
-          llvm::ArrayRef<int>(P.Shaders[0].DispatchSize);
-      if (auto Err = Encoder.dispatch(DispatchSize[0], DispatchSize[1],
-                                      DispatchSize[2]))
+      if (auto Err =
+              Encoder.dispatch(P.DispatchParameters.DispatchGroupCount[0],
+                               P.DispatchParameters.DispatchGroupCount[1],
+                               P.DispatchParameters.DispatchGroupCount[2]))
         return Err;
       Encoder.endEncoding();
-      llvm::outs() << "Dispatched compute shader: { " << DispatchSize[0] << ", "
-                   << DispatchSize[1] << ", " << DispatchSize[2] << " }\n";
+      llvm::outs() << "Dispatched compute shader: { "
+                   << P.DispatchParameters.DispatchGroupCount[0] << ", "
+                   << P.DispatchParameters.DispatchGroupCount[1] << ", "
+                   << P.DispatchParameters.DispatchGroupCount[2] << " }\n";
     } else {
       VkDeviceSize Offsets[1]{0};
       assert(IS.VB);
       VkBuffer VBHandle = llvm::cast<VulkanBuffer>(*IS.VB).Buffer;
       vkCmdBindVertexBuffers(IS.CB->CmdBuffer, 0, 1, &VBHandle, Offsets);
       // instanceCount must be >=1 to draw; previously was 0 which draws nothing
-      vkCmdDraw(IS.CB->CmdBuffer, P.Bindings.getVertexCount(), 1, 0, 0);
-      llvm::outs() << "Drew " << P.Bindings.getVertexCount() << " vertices.\n";
+      vkCmdDraw(IS.CB->CmdBuffer, P.getVertexCount(), 1, 0, 0);
+      llvm::outs() << "Drew " << P.getVertexCount() << " vertices.\n";
       vkCmdEndRenderPass(IS.CB->CmdBuffer);
       copyTextureToReadback(IS.CB->CmdBuffer,
                             llvm::cast<VulkanTexture>(*IS.RenderTarget),

--- a/lib/Support/Pipeline.cpp
+++ b/lib/Support/Pipeline.cpp
@@ -52,6 +52,7 @@ void MappingTraits<offloadtest::Pipeline>::mapping(IO &I,
   I.mapRequired("DescriptorSets", P.Sets);
   I.mapOptional("Bindings", P.Bindings);
   I.mapOptional("PushConstants", P.PushConstants);
+  I.mapOptional("DispatchParameters", P.DispatchParameters);
 
   if (!I.outputting()) {
     for (auto &D : P.Sets) {
@@ -464,6 +465,12 @@ void MappingTraits<offloadtest::PushConstantValue>::mapping(
   }
 }
 
+void MappingTraits<offloadtest::DispatchParametersSet>::mapping(
+    IO &I, offloadtest::DispatchParametersSet &Set) {
+  I.mapOptional("DispatchGroupCount", Set.DispatchGroupCount);
+  I.mapOptional("VertexCount", Set.VertexCount);
+}
+
 void MappingTraits<offloadtest::OutputProperties>::mapping(
     IO &I, offloadtest::OutputProperties &P) {
   I.mapRequired("Height", P.Height);
@@ -516,13 +523,6 @@ void MappingTraits<offloadtest::Shader>::mapping(IO &I,
   I.mapRequired("Stage", S.Stage);
   I.mapRequired("Entry", S.Entry);
   I.mapOptional("SpecializationConstants", S.SpecializationConstants);
-
-  if (S.Stage == Stages::Compute) {
-    // Stage-specific data, not sure if this should be optional
-    // or moved into the Shaders structure.
-    MutableArrayRef<int> MutableDispatchSize(S.DispatchSize);
-    I.mapRequired("DispatchSize", MutableDispatchSize);
-  }
 }
 
 void MappingTraits<offloadtest::Result>::mapping(IO &I,

--- a/lib/Support/Pipeline.cpp
+++ b/lib/Support/Pipeline.cpp
@@ -52,7 +52,10 @@ void MappingTraits<offloadtest::Pipeline>::mapping(IO &I,
   I.mapRequired("DescriptorSets", P.Sets);
   I.mapOptional("Bindings", P.Bindings);
   I.mapOptional("PushConstants", P.PushConstants);
+
   I.mapOptional("DispatchParameters", P.DispatchParameters);
+  if (auto Err = P.validateDispatchParameters())
+    I.setError(llvm::toString(std::move(Err)));
 
   if (!I.outputting()) {
     for (auto &D : P.Sets) {
@@ -588,4 +591,24 @@ llvm::Error offloadtest::Pipeline::validatePipelineKind() {
   // more required shader types.
   return llvm::createStringError(
       "The pipeline misses a Compute or Vertex Shader.");
+}
+
+llvm::Error offloadtest::Pipeline::validateDispatchParameters() {
+  switch (Kind) {
+  case ShaderPipelineKind::Compute:
+    if (DispatchParameters.VertexCount)
+      return llvm::createStringError(
+          "DispatchParameters.VertexCount set on a Compute pipeline. Only "
+          "allowed on a TraditionalRaster pipeline.");
+    break;
+  case ShaderPipelineKind::TraditionalRaster:
+    if (DispatchParameters.DispatchGroupCount !=
+        std::array<uint32_t, 3>{1, 1, 1})
+      return llvm::createStringError(
+          "DispatchParameters.DispatchGroupCount set on a TraditionalRaster "
+          "pipeline. Only allowed on a Compute pipeline.");
+    break;
+  }
+
+  return llvm::Error::success();
 }

--- a/test/Basic/DescriptorSets.test
+++ b/test/Basic/DescriptorSets.test
@@ -14,7 +14,6 @@ void main(uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float32

--- a/test/Basic/Mandelbrot.test
+++ b/test/Basic/Mandelbrot.test
@@ -57,7 +57,8 @@ const static int Dimension = 4096;
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [16384, 1, 1]
+DispatchParameters:
+  DispatchGroupCount: [16384, 1, 1]
 Buffers:
   - Name: Tex
     Format: Float32

--- a/test/Basic/Matrix/matrix_const_single_subscript.i2x3.test
+++ b/test/Basic/Matrix/matrix_const_single_subscript.i2x3.test
@@ -31,7 +31,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Int32

--- a/test/Basic/Matrix/matrix_const_single_subscript.test
+++ b/test/Basic/Matrix/matrix_const_single_subscript.test
@@ -28,7 +28,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Int32

--- a/test/Basic/Matrix/matrix_construct_by_sub_mat.test
+++ b/test/Basic/Matrix/matrix_construct_by_sub_mat.test
@@ -27,7 +27,6 @@ void main(uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Int32

--- a/test/Basic/Matrix/matrix_elementwise_cast.test
+++ b/test/Basic/Matrix/matrix_elementwise_cast.test
@@ -37,7 +37,6 @@ void main(uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float32

--- a/test/Basic/Matrix/matrix_elementwise_vector_cast.test
+++ b/test/Basic/Matrix/matrix_elementwise_vector_cast.test
@@ -21,7 +21,6 @@ void main(uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float32

--- a/test/Basic/Matrix/matrix_groupthread_swizzle_one_based.test
+++ b/test/Basic/Matrix/matrix_groupthread_swizzle_one_based.test
@@ -59,7 +59,6 @@ void main(uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Int32

--- a/test/Basic/Matrix/matrix_groupthread_swizzle_zero_based.test
+++ b/test/Basic/Matrix/matrix_groupthread_swizzle_zero_based.test
@@ -59,7 +59,6 @@ void main(uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Int32

--- a/test/Basic/Matrix/matrix_m-based_getter.test
+++ b/test/Basic/Matrix/matrix_m-based_getter.test
@@ -58,7 +58,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float32

--- a/test/Basic/Matrix/matrix_m-based_setter.test
+++ b/test/Basic/Matrix/matrix_m-based_setter.test
@@ -119,7 +119,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float32

--- a/test/Basic/Matrix/matrix_m-based_swizzle_getter.test
+++ b/test/Basic/Matrix/matrix_m-based_swizzle_getter.test
@@ -44,7 +44,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float32

--- a/test/Basic/Matrix/matrix_one-based_getter.test
+++ b/test/Basic/Matrix/matrix_one-based_getter.test
@@ -59,7 +59,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float32

--- a/test/Basic/Matrix/matrix_one-based_setter.test
+++ b/test/Basic/Matrix/matrix_one-based_setter.test
@@ -80,7 +80,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float32

--- a/test/Basic/Matrix/matrix_one-based_swizzle_getter.test
+++ b/test/Basic/Matrix/matrix_one-based_swizzle_getter.test
@@ -36,7 +36,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float32

--- a/test/Basic/Matrix/matrix_scalar_arithmetic.test
+++ b/test/Basic/Matrix/matrix_scalar_arithmetic.test
@@ -26,7 +26,6 @@ void main(uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Int32

--- a/test/Basic/Matrix/matrix_scalar_constructor.test
+++ b/test/Basic/Matrix/matrix_scalar_constructor.test
@@ -21,7 +21,6 @@ void main(uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Int32

--- a/test/Basic/Matrix/matrix_single_subscript_basic.i2x3.test
+++ b/test/Basic/Matrix/matrix_single_subscript_basic.i2x3.test
@@ -31,7 +31,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Int32

--- a/test/Basic/Matrix/matrix_single_subscript_basic.i3x2.test
+++ b/test/Basic/Matrix/matrix_single_subscript_basic.i3x2.test
@@ -35,7 +35,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Int32

--- a/test/Basic/Matrix/matrix_single_subscript_basic.test
+++ b/test/Basic/Matrix/matrix_single_subscript_basic.test
@@ -37,7 +37,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Int32

--- a/test/Basic/Matrix/matrix_single_subscript_load.test
+++ b/test/Basic/Matrix/matrix_single_subscript_load.test
@@ -29,7 +29,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Int32

--- a/test/Basic/Matrix/matrix_single_subscript_store.test
+++ b/test/Basic/Matrix/matrix_single_subscript_store.test
@@ -30,7 +30,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Int32

--- a/test/Basic/Matrix/matrix_splat_cast.test
+++ b/test/Basic/Matrix/matrix_splat_cast.test
@@ -19,7 +19,6 @@ void main(uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float32

--- a/test/Basic/Matrix/matrix_swizzle_one_based.test
+++ b/test/Basic/Matrix/matrix_swizzle_one_based.test
@@ -61,7 +61,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Int32

--- a/test/Basic/Matrix/matrix_swizzle_zero_based.test
+++ b/test/Basic/Matrix/matrix_swizzle_zero_based.test
@@ -61,7 +61,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Int32

--- a/test/Basic/Matrix/matrix_trunc_cast.test
+++ b/test/Basic/Matrix/matrix_trunc_cast.test
@@ -21,7 +21,6 @@ void main(uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Int32

--- a/test/Basic/TestFloat32Pipeline.test
+++ b/test/Basic/TestFloat32Pipeline.test
@@ -12,7 +12,6 @@ void main(uint3 TID : SV_GroupThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float32

--- a/test/Basic/TestPipeline.test
+++ b/test/Basic/TestPipeline.test
@@ -13,7 +13,6 @@ void CSMain(uint3 TID : SV_GroupThreadID) {
 Shaders:
   - Stage: Compute
     Entry: CSMain
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Int32

--- a/test/Basic/cbuffer.test
+++ b/test/Basic/cbuffer.test
@@ -18,7 +18,6 @@ void main(uint3 TID : SV_GroupThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Int32

--- a/test/Basic/idiv-edges.test
+++ b/test/Basic/idiv-edges.test
@@ -16,7 +16,6 @@ void main(uint3 TID : SV_GroupThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: Buf
     Format: Int32

--- a/test/Basic/simple.test
+++ b/test/Basic/simple.test
@@ -12,7 +12,6 @@ void main(uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float32

--- a/test/Bugs/Adjacent-Partial-Writes.yaml
+++ b/test/Bugs/Adjacent-Partial-Writes.yaml
@@ -18,7 +18,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: InInt
     Format: Int64

--- a/test/Bugs/UAV-Sequental-Consistency.yaml
+++ b/test/Bugs/UAV-Sequental-Consistency.yaml
@@ -18,7 +18,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: X
     Format: Int32

--- a/test/Feature/Attributes/IfBranchAttr.test
+++ b/test/Feature/Attributes/IfBranchAttr.test
@@ -17,7 +17,6 @@ void main(uint3 TID : SV_GroupThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Int32

--- a/test/Feature/Attributes/IfBranchFlatten.test
+++ b/test/Feature/Attributes/IfBranchFlatten.test
@@ -17,7 +17,6 @@ void main(uint3 TID : SV_GroupThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Int32

--- a/test/Feature/Attributes/SwitchBranchAttr.test
+++ b/test/Feature/Attributes/SwitchBranchAttr.test
@@ -25,7 +25,6 @@ void main(uint3 TID : SV_GroupThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Int32

--- a/test/Feature/Attributes/SwitchFlattenAttr.test
+++ b/test/Feature/Attributes/SwitchFlattenAttr.test
@@ -25,7 +25,6 @@ void main(uint3 TID : SV_GroupThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Int32

--- a/test/Feature/ByteAddressBuffer/ByteAddressBuffers-16bit.test
+++ b/test/Feature/ByteAddressBuffer/ByteAddressBuffers-16bit.test
@@ -36,7 +36,8 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [4, 1, 1]
+DispatchParameters:
+  DispatchGroupCount: [4, 1, 1]
 Buffers:
   - Name: In0
     Format: Int16

--- a/test/Feature/ByteAddressBuffer/ByteAddressBuffers-64bit.test
+++ b/test/Feature/ByteAddressBuffer/ByteAddressBuffers-64bit.test
@@ -36,7 +36,8 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [4, 1, 1]
+DispatchParameters:
+  DispatchGroupCount: [4, 1, 1]
 Buffers:
   - Name: In0
     Format: Int64

--- a/test/Feature/ByteAddressBuffer/ByteAddressBuffers.test
+++ b/test/Feature/ByteAddressBuffer/ByteAddressBuffers.test
@@ -89,7 +89,8 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [4, 1, 1]
+DispatchParameters:
+  DispatchGroupCount: [4, 1, 1]
 Buffers:
   - Name: In0
     Format: Int32

--- a/test/Feature/ByteAddressBuffer/GetDimensions.test
+++ b/test/Feature/ByteAddressBuffer/GetDimensions.test
@@ -26,8 +26,9 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [4, 1, 1]
 
+DispatchParameters:
+  DispatchGroupCount: [4, 1, 1]
 Buffers:
   - Name: A
     Format: Int32

--- a/test/Feature/CBuffer/Matrix/MatrixElement/one_based_mat_element.f32.test
+++ b/test/Feature/CBuffer/Matrix/MatrixElement/one_based_mat_element.f32.test
@@ -51,7 +51,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: cbuffer_f1x4
     Format: Float32

--- a/test/Feature/CBuffer/Matrix/MatrixElement/one_based_mat_element_scalar.f32.test
+++ b/test/Feature/CBuffer/Matrix/MatrixElement/one_based_mat_element_scalar.f32.test
@@ -64,7 +64,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: cbuffer_f1x4
     Format: Float32

--- a/test/Feature/CBuffer/Matrix/MatrixElement/zero_based_mat_element.f32.test
+++ b/test/Feature/CBuffer/Matrix/MatrixElement/zero_based_mat_element.f32.test
@@ -51,7 +51,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: cbuffer_f1x4
     Format: Float32

--- a/test/Feature/CBuffer/Matrix/MatrixElement/zero_based_mat_element_scalar.f32.test
+++ b/test/Feature/CBuffer/Matrix/MatrixElement/zero_based_mat_element_scalar.f32.test
@@ -64,7 +64,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: cbuffer_f1x4
     Format: Float32

--- a/test/Feature/CBuffer/Matrix/MatrixSubscript/matrix_subscript.f32.test
+++ b/test/Feature/CBuffer/Matrix/MatrixSubscript/matrix_subscript.f32.test
@@ -64,7 +64,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: cbuffer_f1x4
     Format: Float32

--- a/test/Feature/CBuffer/Matrix/MatrixSubscript/row_major_flag_matrix_subscript.f32.test
+++ b/test/Feature/CBuffer/Matrix/MatrixSubscript/row_major_flag_matrix_subscript.f32.test
@@ -64,7 +64,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: cbuffer_f4x1
     Format: Float32

--- a/test/Feature/CBuffer/Matrix/MatrixSubscript/row_major_matrix_subscript.f32.test
+++ b/test/Feature/CBuffer/Matrix/MatrixSubscript/row_major_matrix_subscript.f32.test
@@ -64,7 +64,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: cbuffer_f4x1
     Format: Float32

--- a/test/Feature/CBuffer/Matrix/SingleSubscript/mat_cbuffer-swizzle.f32.test
+++ b/test/Feature/CBuffer/Matrix/SingleSubscript/mat_cbuffer-swizzle.f32.test
@@ -43,7 +43,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: cbuffer_f1x4
     Format: Float32

--- a/test/Feature/CBuffer/Matrix/SingleSubscript/mat_cbuffer.f32.test
+++ b/test/Feature/CBuffer/Matrix/SingleSubscript/mat_cbuffer.f32.test
@@ -43,7 +43,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: cbuffer_f1x4
     Format: Float32

--- a/test/Feature/CBuffer/Matrix/SingleSubscript/mat_cbuffer_threadgroup.f4x2.test
+++ b/test/Feature/CBuffer/Matrix/SingleSubscript/mat_cbuffer_threadgroup.f4x2.test
@@ -21,7 +21,8 @@ void main(uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [4, 1, 1]
+DispatchParameters:
+  DispatchGroupCount: [4, 1, 1]
 Buffers:
 - Name: cbuffer_f2x4
   Format: Float32

--- a/test/Feature/CBuffer/array-dynamic-index.test
+++ b/test/Feature/CBuffer/array-dynamic-index.test
@@ -16,7 +16,6 @@ void main(uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: Constants
     Format: Hex32

--- a/test/Feature/CBuffer/array-of-structs.test
+++ b/test/Feature/CBuffer/array-of-structs.test
@@ -26,7 +26,6 @@ void main(uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: Constants
     Format: Hex32

--- a/test/Feature/CBuffer/array-vec-index.test
+++ b/test/Feature/CBuffer/array-vec-index.test
@@ -16,7 +16,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: Constants
     Format: UInt32

--- a/test/Feature/CBuffer/arrays-16bit.test
+++ b/test/Feature/CBuffer/arrays-16bit.test
@@ -27,7 +27,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: CBArrays
     Format: Hex16

--- a/test/Feature/CBuffer/arrays-64bit.test
+++ b/test/Feature/CBuffer/arrays-64bit.test
@@ -30,7 +30,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: CBArrays
     Format: Hex64

--- a/test/Feature/CBuffer/arrays.test
+++ b/test/Feature/CBuffer/arrays.test
@@ -30,7 +30,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: CBArrays
     Format: Hex32

--- a/test/Feature/CBuffer/dynamic-struct.test
+++ b/test/Feature/CBuffer/dynamic-struct.test
@@ -25,7 +25,6 @@ void main(uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: Constants
     Format: Hex32

--- a/test/Feature/CBuffer/scalars-16bit.test
+++ b/test/Feature/CBuffer/scalars-16bit.test
@@ -27,7 +27,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: CBScalars
     Format: Hex16

--- a/test/Feature/CBuffer/scalars-64bit.test
+++ b/test/Feature/CBuffer/scalars-64bit.test
@@ -27,7 +27,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: CBScalars
     Format: Hex64

--- a/test/Feature/CBuffer/scalars.test
+++ b/test/Feature/CBuffer/scalars.test
@@ -28,7 +28,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: CBScalars
     Format: Hex32

--- a/test/Feature/CBuffer/structs.test
+++ b/test/Feature/CBuffer/structs.test
@@ -60,7 +60,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: CBVectors
     Format: Hex32

--- a/test/Feature/CBuffer/vectors-16bit.test
+++ b/test/Feature/CBuffer/vectors-16bit.test
@@ -25,7 +25,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: CBVectors
     Format: Hex16

--- a/test/Feature/CBuffer/vectors-64bit.test
+++ b/test/Feature/CBuffer/vectors-64bit.test
@@ -28,7 +28,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: CBVectors
     Format: Hex64

--- a/test/Feature/CBuffer/vectors.test
+++ b/test/Feature/CBuffer/vectors.test
@@ -31,7 +31,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: CBVectors
     Format: Hex32

--- a/test/Feature/Groupshared/GSVector.test
+++ b/test/Feature/Groupshared/GSVector.test
@@ -19,7 +19,6 @@ void main(uint3 ThreadID : SV_GroupThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: Out
     Format: UInt32

--- a/test/Feature/HLSLLib/D3DCOLORtoUBYTE4.test
+++ b/test/Feature/HLSLLib/D3DCOLORtoUBYTE4.test
@@ -13,7 +13,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In0
     Format: Float32

--- a/test/Feature/HLSLLib/PartiallyMappedResources.test
+++ b/test/Feature/HLSLLib/PartiallyMappedResources.test
@@ -62,7 +62,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: X
     Format: Int32

--- a/test/Feature/HLSLLib/abs.32.test
+++ b/test/Feature/HLSLLib/abs.32.test
@@ -35,7 +35,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In1
     Format: Int32

--- a/test/Feature/HLSLLib/abs.fp16.test
+++ b/test/Feature/HLSLLib/abs.fp16.test
@@ -18,7 +18,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In1
     Format: Float16

--- a/test/Feature/HLSLLib/abs.fp64.test
+++ b/test/Feature/HLSLLib/abs.fp64.test
@@ -18,7 +18,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In1
     Format: Float64

--- a/test/Feature/HLSLLib/abs.int16.test
+++ b/test/Feature/HLSLLib/abs.int16.test
@@ -26,7 +26,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In1
     Format: Int16

--- a/test/Feature/HLSLLib/abs.int64.test
+++ b/test/Feature/HLSLLib/abs.int64.test
@@ -26,7 +26,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In1
     Format: Int64

--- a/test/Feature/HLSLLib/acos.16.test
+++ b/test/Feature/HLSLLib/acos.16.test
@@ -19,7 +19,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float16

--- a/test/Feature/HLSLLib/acos.32.test
+++ b/test/Feature/HLSLLib/acos.32.test
@@ -19,7 +19,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float32

--- a/test/Feature/HLSLLib/adduint64.test
+++ b/test/Feature/HLSLLib/adduint64.test
@@ -23,7 +23,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: UInt32

--- a/test/Feature/HLSLLib/all.32.test
+++ b/test/Feature/HLSLLib/all.32.test
@@ -40,7 +40,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In0
     Format: Float32

--- a/test/Feature/HLSLLib/all.bool.test
+++ b/test/Feature/HLSLLib/all.bool.test
@@ -19,7 +19,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Bool

--- a/test/Feature/HLSLLib/all.fp16.test
+++ b/test/Feature/HLSLLib/all.fp16.test
@@ -19,7 +19,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float16

--- a/test/Feature/HLSLLib/all.fp64.test
+++ b/test/Feature/HLSLLib/all.fp64.test
@@ -19,7 +19,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float64

--- a/test/Feature/HLSLLib/all.int16.test
+++ b/test/Feature/HLSLLib/all.int16.test
@@ -30,7 +30,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In0
     Format: Int16

--- a/test/Feature/HLSLLib/all.int64.test
+++ b/test/Feature/HLSLLib/all.int64.test
@@ -30,7 +30,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In0
     Format: Int64

--- a/test/Feature/HLSLLib/and.test
+++ b/test/Feature/HLSLLib/and.test
@@ -18,7 +18,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In1
     Format: Bool

--- a/test/Feature/HLSLLib/any.32.test
+++ b/test/Feature/HLSLLib/any.32.test
@@ -40,7 +40,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In0
     Format: Float32

--- a/test/Feature/HLSLLib/any.bool.test
+++ b/test/Feature/HLSLLib/any.bool.test
@@ -19,7 +19,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Bool

--- a/test/Feature/HLSLLib/any.fp16.test
+++ b/test/Feature/HLSLLib/any.fp16.test
@@ -19,7 +19,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float16

--- a/test/Feature/HLSLLib/any.fp64.test
+++ b/test/Feature/HLSLLib/any.fp64.test
@@ -19,7 +19,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float64

--- a/test/Feature/HLSLLib/any.int16.test
+++ b/test/Feature/HLSLLib/any.int16.test
@@ -30,7 +30,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In0
     Format: Int16

--- a/test/Feature/HLSLLib/any.int64.test
+++ b/test/Feature/HLSLLib/any.int64.test
@@ -30,7 +30,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In0
     Format: Int64

--- a/test/Feature/HLSLLib/asdouble.32.test
+++ b/test/Feature/HLSLLib/asdouble.32.test
@@ -18,7 +18,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: Low
     Format: UInt32

--- a/test/Feature/HLSLLib/asfloat.test
+++ b/test/Feature/HLSLLib/asfloat.test
@@ -31,7 +31,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In0
     Format: Float32

--- a/test/Feature/HLSLLib/asin.16.test
+++ b/test/Feature/HLSLLib/asin.16.test
@@ -20,7 +20,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float16

--- a/test/Feature/HLSLLib/asin.32.test
+++ b/test/Feature/HLSLLib/asin.32.test
@@ -20,7 +20,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float32

--- a/test/Feature/HLSLLib/asint.test
+++ b/test/Feature/HLSLLib/asint.test
@@ -37,7 +37,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In1
     Format: Int32

--- a/test/Feature/HLSLLib/asint16.fp16.test
+++ b/test/Feature/HLSLLib/asint16.fp16.test
@@ -16,7 +16,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In0
     Format: Float16

--- a/test/Feature/HLSLLib/asint16.int16.test
+++ b/test/Feature/HLSLLib/asint16.int16.test
@@ -23,7 +23,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In0
     Format: Int16

--- a/test/Feature/HLSLLib/asuint.32.test
+++ b/test/Feature/HLSLLib/asuint.32.test
@@ -31,7 +31,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In0
     Format: UInt32

--- a/test/Feature/HLSLLib/asuint.64.test
+++ b/test/Feature/HLSLLib/asuint.64.test
@@ -25,7 +25,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In0
     Format: Float64

--- a/test/Feature/HLSLLib/asuint16.fp16.test
+++ b/test/Feature/HLSLLib/asuint16.fp16.test
@@ -16,7 +16,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In0
     Format: Float16

--- a/test/Feature/HLSLLib/asuint16.int16.test
+++ b/test/Feature/HLSLLib/asuint16.int16.test
@@ -23,7 +23,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In0
     Format: UInt16

--- a/test/Feature/HLSLLib/atan.16.test
+++ b/test/Feature/HLSLLib/atan.16.test
@@ -20,7 +20,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float16

--- a/test/Feature/HLSLLib/atan.32.test
+++ b/test/Feature/HLSLLib/atan.32.test
@@ -20,7 +20,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float32

--- a/test/Feature/HLSLLib/atan2.16.test
+++ b/test/Feature/HLSLLib/atan2.16.test
@@ -17,7 +17,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In0
     Format: Float16

--- a/test/Feature/HLSLLib/atan2.32.test
+++ b/test/Feature/HLSLLib/atan2.32.test
@@ -17,7 +17,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In0
     Format: Float32

--- a/test/Feature/HLSLLib/ceil.16.test
+++ b/test/Feature/HLSLLib/ceil.16.test
@@ -21,7 +21,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float16

--- a/test/Feature/HLSLLib/ceil.32.test
+++ b/test/Feature/HLSLLib/ceil.32.test
@@ -21,7 +21,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float32

--- a/test/Feature/HLSLLib/clamp.32.test
+++ b/test/Feature/HLSLLib/clamp.32.test
@@ -36,7 +36,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In0
     Format: Int32

--- a/test/Feature/HLSLLib/clamp.fp16.test
+++ b/test/Feature/HLSLLib/clamp.fp16.test
@@ -19,7 +19,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In0
     Format: Float16

--- a/test/Feature/HLSLLib/clamp.fp64.test
+++ b/test/Feature/HLSLLib/clamp.fp64.test
@@ -18,7 +18,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In0
     Format: Float64

--- a/test/Feature/HLSLLib/clamp.int16.test
+++ b/test/Feature/HLSLLib/clamp.int16.test
@@ -27,7 +27,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In0
     Format: Int16

--- a/test/Feature/HLSLLib/clamp.int64.test
+++ b/test/Feature/HLSLLib/clamp.int64.test
@@ -28,7 +28,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In0
     Format: Int64

--- a/test/Feature/HLSLLib/cos.16.test
+++ b/test/Feature/HLSLLib/cos.16.test
@@ -22,7 +22,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float16

--- a/test/Feature/HLSLLib/cos.32.test
+++ b/test/Feature/HLSLLib/cos.32.test
@@ -20,7 +20,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float32

--- a/test/Feature/HLSLLib/cos.nan-inf-denorm.32.test
+++ b/test/Feature/HLSLLib/cos.nan-inf-denorm.32.test
@@ -18,7 +18,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float32

--- a/test/Feature/HLSLLib/cosh.16.test
+++ b/test/Feature/HLSLLib/cosh.16.test
@@ -20,7 +20,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float16

--- a/test/Feature/HLSLLib/cosh.32.test
+++ b/test/Feature/HLSLLib/cosh.32.test
@@ -20,7 +20,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float32

--- a/test/Feature/HLSLLib/countbits.16.test
+++ b/test/Feature/HLSLLib/countbits.16.test
@@ -31,7 +31,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: InInt
     Format: Int16

--- a/test/Feature/HLSLLib/countbits.32.test
+++ b/test/Feature/HLSLLib/countbits.32.test
@@ -26,7 +26,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: InInt
     Format: Int32

--- a/test/Feature/HLSLLib/countbits.64.test
+++ b/test/Feature/HLSLLib/countbits.64.test
@@ -27,7 +27,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: InInt
     Format: Int64

--- a/test/Feature/HLSLLib/cross.16.test
+++ b/test/Feature/HLSLLib/cross.16.test
@@ -19,7 +19,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: X
     Format: Float16

--- a/test/Feature/HLSLLib/cross.32.test
+++ b/test/Feature/HLSLLib/cross.32.test
@@ -19,7 +19,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: X
     Format: Float32

--- a/test/Feature/HLSLLib/degrees.16.test
+++ b/test/Feature/HLSLLib/degrees.16.test
@@ -20,7 +20,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float16

--- a/test/Feature/HLSLLib/degrees.32.test
+++ b/test/Feature/HLSLLib/degrees.32.test
@@ -20,7 +20,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float32

--- a/test/Feature/HLSLLib/distance.16.test
+++ b/test/Feature/HLSLLib/distance.16.test
@@ -65,7 +65,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: X
     Format: Float16

--- a/test/Feature/HLSLLib/distance.32.test
+++ b/test/Feature/HLSLLib/distance.32.test
@@ -65,7 +65,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: X
     Format: Float32

--- a/test/Feature/HLSLLib/dot.32.test
+++ b/test/Feature/HLSLLib/dot.32.test
@@ -58,7 +58,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: X0
     Format: Float32

--- a/test/Feature/HLSLLib/dot.fp16.test
+++ b/test/Feature/HLSLLib/dot.fp16.test
@@ -25,7 +25,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: X
     Format: Float16

--- a/test/Feature/HLSLLib/dot.fp64.test
+++ b/test/Feature/HLSLLib/dot.fp64.test
@@ -25,7 +25,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: X
     Format: Float64

--- a/test/Feature/HLSLLib/dot.int16.test
+++ b/test/Feature/HLSLLib/dot.int16.test
@@ -42,7 +42,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: X0
     Format: Int16

--- a/test/Feature/HLSLLib/dot.int64.test
+++ b/test/Feature/HLSLLib/dot.int64.test
@@ -42,7 +42,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: X0
     Format: Int64

--- a/test/Feature/HLSLLib/dot2add.test
+++ b/test/Feature/HLSLLib/dot2add.test
@@ -24,7 +24,6 @@ void main(uint3 DTID : SV_DispatchThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: A
     Format: Float16

--- a/test/Feature/HLSLLib/dot4add.test
+++ b/test/Feature/HLSLLib/dot4add.test
@@ -25,7 +25,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: X
     Format: Hex32

--- a/test/Feature/HLSLLib/exp.16.test
+++ b/test/Feature/HLSLLib/exp.16.test
@@ -20,7 +20,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float16

--- a/test/Feature/HLSLLib/exp.32.test
+++ b/test/Feature/HLSLLib/exp.32.test
@@ -20,7 +20,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float32

--- a/test/Feature/HLSLLib/exp2.16.test
+++ b/test/Feature/HLSLLib/exp2.16.test
@@ -20,7 +20,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float16

--- a/test/Feature/HLSLLib/exp2.32.test
+++ b/test/Feature/HLSLLib/exp2.32.test
@@ -20,7 +20,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float32

--- a/test/Feature/HLSLLib/f16tof32.test
+++ b/test/Feature/HLSLLib/f16tof32.test
@@ -45,7 +45,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: UInt32 

--- a/test/Feature/HLSLLib/f32tof16.test
+++ b/test/Feature/HLSLLib/f32tof16.test
@@ -43,7 +43,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float32

--- a/test/Feature/HLSLLib/firstbithigh.16.test
+++ b/test/Feature/HLSLLib/firstbithigh.16.test
@@ -19,7 +19,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In1
     Format: Hex16

--- a/test/Feature/HLSLLib/firstbithigh.32.test
+++ b/test/Feature/HLSLLib/firstbithigh.32.test
@@ -19,7 +19,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In1
     Format: Hex32

--- a/test/Feature/HLSLLib/firstbithigh.64.test
+++ b/test/Feature/HLSLLib/firstbithigh.64.test
@@ -19,7 +19,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In1
     Format: Hex64

--- a/test/Feature/HLSLLib/firstbitlow.16.test
+++ b/test/Feature/HLSLLib/firstbitlow.16.test
@@ -19,7 +19,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In1
     Format: Hex16

--- a/test/Feature/HLSLLib/firstbitlow.32.test
+++ b/test/Feature/HLSLLib/firstbitlow.32.test
@@ -19,7 +19,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In1
     Format: Hex32

--- a/test/Feature/HLSLLib/firstbitlow.64.test
+++ b/test/Feature/HLSLLib/firstbitlow.64.test
@@ -19,7 +19,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In1
     Format: Hex64

--- a/test/Feature/HLSLLib/floor.16.test
+++ b/test/Feature/HLSLLib/floor.16.test
@@ -21,7 +21,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float16

--- a/test/Feature/HLSLLib/floor.32.test
+++ b/test/Feature/HLSLLib/floor.32.test
@@ -21,7 +21,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float32

--- a/test/Feature/HLSLLib/fma.matrix.test
+++ b/test/Feature/HLSLLib/fma.matrix.test
@@ -41,7 +41,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: A
     Format: Float64

--- a/test/Feature/HLSLLib/fma.test
+++ b/test/Feature/HLSLLib/fma.test
@@ -20,7 +20,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: A
     Format: Float64

--- a/test/Feature/HLSLLib/fmod.16.test
+++ b/test/Feature/HLSLLib/fmod.16.test
@@ -17,7 +17,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In0
     Format: Float16

--- a/test/Feature/HLSLLib/fmod.32.test
+++ b/test/Feature/HLSLLib/fmod.32.test
@@ -17,7 +17,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In0
     Format: Float32

--- a/test/Feature/HLSLLib/frac.16.test
+++ b/test/Feature/HLSLLib/frac.16.test
@@ -20,7 +20,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float16

--- a/test/Feature/HLSLLib/frac.32.test
+++ b/test/Feature/HLSLLib/frac.32.test
@@ -20,7 +20,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float32

--- a/test/Feature/HLSLLib/isinf.16.test
+++ b/test/Feature/HLSLLib/isinf.16.test
@@ -17,7 +17,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float16

--- a/test/Feature/HLSLLib/isinf.32.test
+++ b/test/Feature/HLSLLib/isinf.32.test
@@ -17,7 +17,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float32

--- a/test/Feature/HLSLLib/ldexp.16.test
+++ b/test/Feature/HLSLLib/ldexp.16.test
@@ -32,7 +32,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float16

--- a/test/Feature/HLSLLib/ldexp.32.test
+++ b/test/Feature/HLSLLib/ldexp.32.test
@@ -32,7 +32,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float32

--- a/test/Feature/HLSLLib/length.16.test
+++ b/test/Feature/HLSLLib/length.16.test
@@ -19,7 +19,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float16

--- a/test/Feature/HLSLLib/length.32.test
+++ b/test/Feature/HLSLLib/length.32.test
@@ -19,7 +19,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float32

--- a/test/Feature/HLSLLib/lerp.16.test
+++ b/test/Feature/HLSLLib/lerp.16.test
@@ -19,7 +19,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: X
     Format: Float16

--- a/test/Feature/HLSLLib/lerp.32.test
+++ b/test/Feature/HLSLLib/lerp.32.test
@@ -19,7 +19,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: X
     Format: Float32

--- a/test/Feature/HLSLLib/log.16.test
+++ b/test/Feature/HLSLLib/log.16.test
@@ -20,7 +20,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float16

--- a/test/Feature/HLSLLib/log.32.test
+++ b/test/Feature/HLSLLib/log.32.test
@@ -20,7 +20,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float32

--- a/test/Feature/HLSLLib/log10.16.test
+++ b/test/Feature/HLSLLib/log10.16.test
@@ -20,7 +20,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float16

--- a/test/Feature/HLSLLib/log10.32.test
+++ b/test/Feature/HLSLLib/log10.32.test
@@ -20,7 +20,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float32

--- a/test/Feature/HLSLLib/log2.16.test
+++ b/test/Feature/HLSLLib/log2.16.test
@@ -20,7 +20,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float16

--- a/test/Feature/HLSLLib/log2.32.test
+++ b/test/Feature/HLSLLib/log2.32.test
@@ -20,7 +20,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float32

--- a/test/Feature/HLSLLib/mad.32.test
+++ b/test/Feature/HLSLLib/mad.32.test
@@ -40,7 +40,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: M0
     Format: Float32

--- a/test/Feature/HLSLLib/mad.fp16.test
+++ b/test/Feature/HLSLLib/mad.fp16.test
@@ -19,7 +19,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: M
     Format: Float16

--- a/test/Feature/HLSLLib/mad.fp64.test
+++ b/test/Feature/HLSLLib/mad.fp64.test
@@ -19,7 +19,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: M
     Format: Float64

--- a/test/Feature/HLSLLib/mad.int16.test
+++ b/test/Feature/HLSLLib/mad.int16.test
@@ -30,7 +30,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: M0
     Format: Int16

--- a/test/Feature/HLSLLib/mad.int64.test
+++ b/test/Feature/HLSLLib/mad.int64.test
@@ -30,7 +30,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: M0
     Format: Int64

--- a/test/Feature/HLSLLib/max.32.test
+++ b/test/Feature/HLSLLib/max.32.test
@@ -37,7 +37,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: X0
     Format: Float32

--- a/test/Feature/HLSLLib/max.fp16.test
+++ b/test/Feature/HLSLLib/max.fp16.test
@@ -18,7 +18,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: X
     Format: Float16

--- a/test/Feature/HLSLLib/max.fp64.test
+++ b/test/Feature/HLSLLib/max.fp64.test
@@ -18,7 +18,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: X
     Format: Float64

--- a/test/Feature/HLSLLib/max.int16.test
+++ b/test/Feature/HLSLLib/max.int16.test
@@ -28,7 +28,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: X0
     Format: Int16

--- a/test/Feature/HLSLLib/max.int64.test
+++ b/test/Feature/HLSLLib/max.int64.test
@@ -28,7 +28,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: X0
     Format: Int64

--- a/test/Feature/HLSLLib/min.32.test
+++ b/test/Feature/HLSLLib/min.32.test
@@ -39,7 +39,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: X0
     Format: Float32

--- a/test/Feature/HLSLLib/min.fp16.test
+++ b/test/Feature/HLSLLib/min.fp16.test
@@ -18,7 +18,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: X
     Format: Float16

--- a/test/Feature/HLSLLib/min.fp64.test
+++ b/test/Feature/HLSLLib/min.fp64.test
@@ -18,7 +18,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: X
     Format: Float64

--- a/test/Feature/HLSLLib/min.int16.test
+++ b/test/Feature/HLSLLib/min.int16.test
@@ -28,7 +28,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: X0
     Format: Int16

--- a/test/Feature/HLSLLib/min.int64.test
+++ b/test/Feature/HLSLLib/min.int64.test
@@ -28,7 +28,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: X0
     Format: Int64

--- a/test/Feature/HLSLLib/mul.fp16.test
+++ b/test/Feature/HLSLLib/mul.fp16.test
@@ -72,7 +72,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float16

--- a/test/Feature/HLSLLib/mul.fp32.test
+++ b/test/Feature/HLSLLib/mul.fp32.test
@@ -72,7 +72,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float32

--- a/test/Feature/HLSLLib/mul.fp64.test
+++ b/test/Feature/HLSLLib/mul.fp64.test
@@ -72,7 +72,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float64

--- a/test/Feature/HLSLLib/mul.int16.test
+++ b/test/Feature/HLSLLib/mul.int16.test
@@ -72,7 +72,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Int16

--- a/test/Feature/HLSLLib/mul.int32.test
+++ b/test/Feature/HLSLLib/mul.int32.test
@@ -72,7 +72,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Int32

--- a/test/Feature/HLSLLib/mul.int64.test
+++ b/test/Feature/HLSLLib/mul.int64.test
@@ -72,7 +72,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Int64

--- a/test/Feature/HLSLLib/normalize.16.test
+++ b/test/Feature/HLSLLib/normalize.16.test
@@ -17,7 +17,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float16

--- a/test/Feature/HLSLLib/normalize.32.test
+++ b/test/Feature/HLSLLib/normalize.32.test
@@ -17,7 +17,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float32

--- a/test/Feature/HLSLLib/or.test
+++ b/test/Feature/HLSLLib/or.test
@@ -18,7 +18,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In1
     Format: Bool

--- a/test/Feature/HLSLLib/pow.16.test
+++ b/test/Feature/HLSLLib/pow.16.test
@@ -18,7 +18,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: X
     Format: Float16

--- a/test/Feature/HLSLLib/pow.32.test
+++ b/test/Feature/HLSLLib/pow.32.test
@@ -18,7 +18,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: X
     Format: Float32

--- a/test/Feature/HLSLLib/radians.16.test
+++ b/test/Feature/HLSLLib/radians.16.test
@@ -20,7 +20,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float16

--- a/test/Feature/HLSLLib/radians.32.test
+++ b/test/Feature/HLSLLib/radians.32.test
@@ -20,7 +20,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float32

--- a/test/Feature/HLSLLib/rcp.16.test
+++ b/test/Feature/HLSLLib/rcp.16.test
@@ -21,7 +21,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float16

--- a/test/Feature/HLSLLib/rcp.32.test
+++ b/test/Feature/HLSLLib/rcp.32.test
@@ -21,7 +21,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float32

--- a/test/Feature/HLSLLib/rcp.64.test
+++ b/test/Feature/HLSLLib/rcp.64.test
@@ -21,7 +21,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float64

--- a/test/Feature/HLSLLib/reflect.16.test
+++ b/test/Feature/HLSLLib/reflect.16.test
@@ -40,7 +40,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   
   - Name: IncidentRay2D

--- a/test/Feature/HLSLLib/reflect.32.test
+++ b/test/Feature/HLSLLib/reflect.32.test
@@ -40,7 +40,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   
   - Name: IncidentRay2D

--- a/test/Feature/HLSLLib/refract.16.test
+++ b/test/Feature/HLSLLib/refract.16.test
@@ -42,7 +42,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   
   - Name: IncidentRay2D

--- a/test/Feature/HLSLLib/refract.32.test
+++ b/test/Feature/HLSLLib/refract.32.test
@@ -42,7 +42,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   
   - Name: IncidentRay2D

--- a/test/Feature/HLSLLib/reversebits.16.test
+++ b/test/Feature/HLSLLib/reversebits.16.test
@@ -19,7 +19,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: UInt16

--- a/test/Feature/HLSLLib/reversebits.32.test
+++ b/test/Feature/HLSLLib/reversebits.32.test
@@ -19,7 +19,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: UInt32

--- a/test/Feature/HLSLLib/reversebits.64.test
+++ b/test/Feature/HLSLLib/reversebits.64.test
@@ -19,7 +19,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: UInt64

--- a/test/Feature/HLSLLib/round.16.test
+++ b/test/Feature/HLSLLib/round.16.test
@@ -21,7 +21,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float16

--- a/test/Feature/HLSLLib/round.32.test
+++ b/test/Feature/HLSLLib/round.32.test
@@ -21,7 +21,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float32

--- a/test/Feature/HLSLLib/rsqrt.16.test
+++ b/test/Feature/HLSLLib/rsqrt.16.test
@@ -20,7 +20,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float16

--- a/test/Feature/HLSLLib/rsqrt.32.test
+++ b/test/Feature/HLSLLib/rsqrt.32.test
@@ -20,7 +20,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float32

--- a/test/Feature/HLSLLib/saturate.16.test
+++ b/test/Feature/HLSLLib/saturate.16.test
@@ -20,7 +20,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float16

--- a/test/Feature/HLSLLib/saturate.32.test
+++ b/test/Feature/HLSLLib/saturate.32.test
@@ -17,7 +17,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float32

--- a/test/Feature/HLSLLib/select.32.test
+++ b/test/Feature/HLSLLib/select.32.test
@@ -116,7 +116,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: Cond
     Format: Bool

--- a/test/Feature/HLSLLib/select.fp16.test
+++ b/test/Feature/HLSLLib/select.fp16.test
@@ -49,7 +49,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: Cond
     Format: Bool

--- a/test/Feature/HLSLLib/select.fp64.test
+++ b/test/Feature/HLSLLib/select.fp64.test
@@ -49,7 +49,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: Cond
     Format: Bool

--- a/test/Feature/HLSLLib/select.int16.test
+++ b/test/Feature/HLSLLib/select.int16.test
@@ -72,7 +72,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: Cond
     Format: Bool

--- a/test/Feature/HLSLLib/select.int64.test
+++ b/test/Feature/HLSLLib/select.int64.test
@@ -71,7 +71,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: Cond
     Format: Bool

--- a/test/Feature/HLSLLib/select.struct.test
+++ b/test/Feature/HLSLLib/select.struct.test
@@ -22,7 +22,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: Cond
     Format: Bool

--- a/test/Feature/HLSLLib/sign.32.test
+++ b/test/Feature/HLSLLib/sign.32.test
@@ -45,7 +45,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In1
     Format: Int32

--- a/test/Feature/HLSLLib/sign.fp16.test
+++ b/test/Feature/HLSLLib/sign.fp16.test
@@ -28,7 +28,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In1
     Format: Float16

--- a/test/Feature/HLSLLib/sign.fp64.test
+++ b/test/Feature/HLSLLib/sign.fp64.test
@@ -28,7 +28,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In1
     Format: Float64

--- a/test/Feature/HLSLLib/sign.int16.test
+++ b/test/Feature/HLSLLib/sign.int16.test
@@ -26,7 +26,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In1
     Format: Int16

--- a/test/Feature/HLSLLib/sign.int64.test
+++ b/test/Feature/HLSLLib/sign.int64.test
@@ -26,7 +26,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In1
     Format: Int64

--- a/test/Feature/HLSLLib/sin.16.test
+++ b/test/Feature/HLSLLib/sin.16.test
@@ -22,7 +22,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float16

--- a/test/Feature/HLSLLib/sin.32.test
+++ b/test/Feature/HLSLLib/sin.32.test
@@ -20,7 +20,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float32

--- a/test/Feature/HLSLLib/sin.nan-inf-denorm.32.test
+++ b/test/Feature/HLSLLib/sin.nan-inf-denorm.32.test
@@ -18,7 +18,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float32

--- a/test/Feature/HLSLLib/sinh.16.test
+++ b/test/Feature/HLSLLib/sinh.16.test
@@ -20,7 +20,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float16

--- a/test/Feature/HLSLLib/sinh.32.test
+++ b/test/Feature/HLSLLib/sinh.32.test
@@ -20,7 +20,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float32

--- a/test/Feature/HLSLLib/smoothstep.16.test
+++ b/test/Feature/HLSLLib/smoothstep.16.test
@@ -48,7 +48,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   
   - Name: Min2D

--- a/test/Feature/HLSLLib/smoothstep.32.test
+++ b/test/Feature/HLSLLib/smoothstep.32.test
@@ -48,7 +48,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   
   - Name: Min2D

--- a/test/Feature/HLSLLib/sqrt.16.test
+++ b/test/Feature/HLSLLib/sqrt.16.test
@@ -20,7 +20,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float16

--- a/test/Feature/HLSLLib/sqrt.32.test
+++ b/test/Feature/HLSLLib/sqrt.32.test
@@ -20,7 +20,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float32

--- a/test/Feature/HLSLLib/step.16.test
+++ b/test/Feature/HLSLLib/step.16.test
@@ -18,7 +18,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: Y
     Format: Float16

--- a/test/Feature/HLSLLib/step.32.test
+++ b/test/Feature/HLSLLib/step.32.test
@@ -18,7 +18,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: Y
     Format: Float32

--- a/test/Feature/HLSLLib/tanh.16.test
+++ b/test/Feature/HLSLLib/tanh.16.test
@@ -20,7 +20,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float16

--- a/test/Feature/HLSLLib/tanh.32.test
+++ b/test/Feature/HLSLLib/tanh.32.test
@@ -20,7 +20,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float32

--- a/test/Feature/HLSLLib/transpose.bool.test
+++ b/test/Feature/HLSLLib/transpose.bool.test
@@ -64,7 +64,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Int32

--- a/test/Feature/HLSLLib/transpose.fp16.test
+++ b/test/Feature/HLSLLib/transpose.fp16.test
@@ -64,7 +64,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float16

--- a/test/Feature/HLSLLib/transpose.fp32.test
+++ b/test/Feature/HLSLLib/transpose.fp32.test
@@ -64,7 +64,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float32

--- a/test/Feature/HLSLLib/transpose.fp64.test
+++ b/test/Feature/HLSLLib/transpose.fp64.test
@@ -64,7 +64,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float64

--- a/test/Feature/HLSLLib/transpose.int16.test
+++ b/test/Feature/HLSLLib/transpose.int16.test
@@ -64,7 +64,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Int16

--- a/test/Feature/HLSLLib/transpose.int32.test
+++ b/test/Feature/HLSLLib/transpose.int32.test
@@ -64,7 +64,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Int32

--- a/test/Feature/HLSLLib/transpose.int64.test
+++ b/test/Feature/HLSLLib/transpose.int64.test
@@ -64,7 +64,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Int64

--- a/test/Feature/HLSLLib/trunc.16.test
+++ b/test/Feature/HLSLLib/trunc.16.test
@@ -21,7 +21,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float16

--- a/test/Feature/HLSLLib/trunc.32.test
+++ b/test/Feature/HLSLLib/trunc.32.test
@@ -21,7 +21,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float32

--- a/test/Feature/ImplicitBindings/all-implicit.test
+++ b/test/Feature/ImplicitBindings/all-implicit.test
@@ -19,7 +19,8 @@ void main(uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [4, 1, 1]
+DispatchParameters:
+  DispatchGroupCount: [4, 1, 1]
 Buffers:
   - Name: BufA
     Format: Int32

--- a/test/Feature/ImplicitBindings/simple-resources.test
+++ b/test/Feature/ImplicitBindings/simple-resources.test
@@ -19,7 +19,8 @@ void main(uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [4, 1, 1]
+DispatchParameters:
+  DispatchGroupCount: [4, 1, 1]
 Buffers:
   - Name: BufA
     Format: Int32

--- a/test/Feature/MaximalReconvergence/loop_peeling.test
+++ b/test/Feature/MaximalReconvergence/loop_peeling.test
@@ -17,7 +17,6 @@ void main(uint3 TID : SV_GroupThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: Out
     Format: UInt32

--- a/test/Feature/PushConstant/array_of_matrices.test
+++ b/test/Feature/PushConstant/array_of_matrices.test
@@ -26,7 +26,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: output
     Format: Float32

--- a/test/Feature/PushConstant/arrays.test
+++ b/test/Feature/PushConstant/arrays.test
@@ -19,7 +19,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: output
     Format: Int32

--- a/test/Feature/PushConstant/bool.test
+++ b/test/Feature/PushConstant/bool.test
@@ -18,7 +18,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: output
     Format: Int32

--- a/test/Feature/PushConstant/explicit_offset.test
+++ b/test/Feature/PushConstant/explicit_offset.test
@@ -18,7 +18,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: output
     Format: Int32

--- a/test/Feature/PushConstant/matrix.test
+++ b/test/Feature/PushConstant/matrix.test
@@ -19,7 +19,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: output
     Format: Float32

--- a/test/Feature/PushConstant/methods.test
+++ b/test/Feature/PushConstant/methods.test
@@ -23,7 +23,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: output
     Format: Int32

--- a/test/Feature/PushConstant/mixed_types.test
+++ b/test/Feature/PushConstant/mixed_types.test
@@ -28,7 +28,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: output
     Format: Float32

--- a/test/Feature/PushConstant/multiple_values.test
+++ b/test/Feature/PushConstant/multiple_values.test
@@ -18,7 +18,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: output
     Format: Int32

--- a/test/Feature/PushConstant/multiple_values_offset.test
+++ b/test/Feature/PushConstant/multiple_values_offset.test
@@ -20,7 +20,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: output
     Format: Int32

--- a/test/Feature/PushConstant/nested_structs.test
+++ b/test/Feature/PushConstant/nested_structs.test
@@ -28,7 +28,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: output
     Format: Int32

--- a/test/Feature/PushConstant/padding.test
+++ b/test/Feature/PushConstant/padding.test
@@ -20,7 +20,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: output
     Format: Float32

--- a/test/Feature/PushConstant/simple.test
+++ b/test/Feature/PushConstant/simple.test
@@ -16,7 +16,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: output
     Format: Int32

--- a/test/Feature/PushConstant/static_member.test
+++ b/test/Feature/PushConstant/static_member.test
@@ -23,7 +23,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: output
     Format: Int32

--- a/test/Feature/PushConstant/struct_content.test
+++ b/test/Feature/PushConstant/struct_content.test
@@ -24,7 +24,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: output
     Format: Int32

--- a/test/Feature/PushConstant/types.test
+++ b/test/Feature/PushConstant/types.test
@@ -25,7 +25,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: output
     Format: Float32

--- a/test/Feature/PushConstant/types_16bit.test
+++ b/test/Feature/PushConstant/types_16bit.test
@@ -20,7 +20,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: output
     Format: Float32

--- a/test/Feature/PushConstant/types_64bit.test
+++ b/test/Feature/PushConstant/types_64bit.test
@@ -22,7 +22,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: output_d
     Format: Float64

--- a/test/Feature/ResourceArrays/array-global.test
+++ b/test/Feature/ResourceArrays/array-global.test
@@ -36,7 +36,8 @@ void main(uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [4, 2, 1]
+DispatchParameters:
+  DispatchGroupCount: [4, 2, 1]
 Buffers:
   - Name: BufA
     Format: Int32

--- a/test/Feature/ResourceArrays/array-local.test
+++ b/test/Feature/ResourceArrays/array-local.test
@@ -28,7 +28,6 @@ void main(uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: BufA
     Format: Float32

--- a/test/Feature/ResourceArrays/array-local2.test
+++ b/test/Feature/ResourceArrays/array-local2.test
@@ -26,7 +26,6 @@ void main(uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: BufX
     Format: Int32

--- a/test/Feature/ResourceArrays/array-of-constant-buffers.test
+++ b/test/Feature/ResourceArrays/array-of-constant-buffers.test
@@ -22,8 +22,9 @@ void main(uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [4, 2, 1]
 
+DispatchParameters:
+  DispatchGroupCount: [4, 2, 1]
 Buffers:
   - Name: CB
     Format: Int32

--- a/test/Feature/ResourceArrays/multi-dim-array-global.test
+++ b/test/Feature/ResourceArrays/multi-dim-array-global.test
@@ -19,7 +19,6 @@ void main(uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: BufIn
     Format: Int32

--- a/test/Feature/ResourceArrays/multi-dim-array-local.test
+++ b/test/Feature/ResourceArrays/multi-dim-array-local.test
@@ -31,7 +31,6 @@ void main(uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: BufA
     Format: Float32

--- a/test/Feature/ResourceArrays/multi-dim-array-subset-nuri.test
+++ b/test/Feature/ResourceArrays/multi-dim-array-subset-nuri.test
@@ -20,7 +20,6 @@ void main(uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: BufIn
     Format: Float32

--- a/test/Feature/ResourceArrays/multi-dim-array-subset.test
+++ b/test/Feature/ResourceArrays/multi-dim-array-subset.test
@@ -22,7 +22,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: BufIn
     Format: Int32

--- a/test/Feature/ResourceArrays/multi-dim-unbounded-array-nuri.test
+++ b/test/Feature/ResourceArrays/multi-dim-unbounded-array-nuri.test
@@ -17,7 +17,6 @@ void main(uint3 GTI : SV_GroupThreadID, uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: Buf
     Format: Int32

--- a/test/Feature/ResourceArrays/multi-dim-unbounded-array.test
+++ b/test/Feature/ResourceArrays/multi-dim-unbounded-array.test
@@ -18,7 +18,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: Buf
     Format: Int32

--- a/test/Feature/ResourceArrays/overflow-unbounded-array.test
+++ b/test/Feature/ResourceArrays/overflow-unbounded-array.test
@@ -18,7 +18,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: Buf0
     Format: Int32

--- a/test/Feature/ResourceArrays/unbounded-array-nuri.test
+++ b/test/Feature/ResourceArrays/unbounded-array-nuri.test
@@ -17,7 +17,6 @@ void main(uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: Buf
     Format: Int32

--- a/test/Feature/ResourceArrays/unbounded-array.test
+++ b/test/Feature/ResourceArrays/unbounded-array.test
@@ -18,7 +18,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: Buf
     Format: Int32

--- a/test/Feature/ResourcesInStructs/array-of-structs-with-res.test
+++ b/test/Feature/ResourcesInStructs/array-of-structs-with-res.test
@@ -25,7 +25,6 @@ void main(uint3 ID : SV_GroupThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: BufD2
     Format: Int32

--- a/test/Feature/ResourcesInStructs/res-array-of-matrix-in-struct.test
+++ b/test/Feature/ResourcesInStructs/res-array-of-matrix-in-struct.test
@@ -22,7 +22,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: BufB1
     Format: Float32

--- a/test/Feature/ResourcesInStructs/res-in-struct-local-arg.test
+++ b/test/Feature/ResourcesInStructs/res-in-struct-local-arg.test
@@ -32,7 +32,6 @@ void main(uint3 ID : SV_GroupThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: BufA1
     Format: Int32

--- a/test/Feature/ResourcesInStructs/res-in-struct-mix.test
+++ b/test/Feature/ResourcesInStructs/res-in-struct-mix.test
@@ -35,7 +35,6 @@ void main(uint3 ID : SV_GroupThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: Buf_g_F_SrvBuf1
     Format: Int32

--- a/test/Feature/ResourcesInStructs/res-in-struct-simple-array.test
+++ b/test/Feature/ResourcesInStructs/res-in-struct-simple-array.test
@@ -24,7 +24,6 @@ void main(uint3 ID : SV_GroupThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: BufB1
     Format: Int32

--- a/test/Feature/ResourcesInStructs/res-in-struct-simple-one.test
+++ b/test/Feature/ResourcesInStructs/res-in-struct-simple-one.test
@@ -21,7 +21,6 @@ void main(uint3 ID : SV_GroupThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: BufA1
     Format: Int32

--- a/test/Feature/ResourcesInStructs/res-in-struct-this-access.test
+++ b/test/Feature/ResourcesInStructs/res-in-struct-this-access.test
@@ -26,7 +26,6 @@ void main(uint3 ID : SV_GroupThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: BufA1
     Format: Int32

--- a/test/Feature/ResourcesInStructs/res-of-matrix-in-struct.test
+++ b/test/Feature/ResourcesInStructs/res-of-matrix-in-struct.test
@@ -20,7 +20,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: BufA1
     Format: Int32

--- a/test/Feature/RootSignatures/Defaults.test
+++ b/test/Feature/RootSignatures/Defaults.test
@@ -40,7 +40,6 @@ void main(uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 RuntimeSettings:
   DirectX:
     RootParameters:

--- a/test/Feature/RootSignatures/DescriptorTables.test
+++ b/test/Feature/RootSignatures/DescriptorTables.test
@@ -20,7 +20,6 @@ void main(uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float32

--- a/test/Feature/RootSignatures/Flags.test
+++ b/test/Feature/RootSignatures/Flags.test
@@ -45,7 +45,6 @@ void main(uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 RuntimeSettings:
   DirectX:
     RootParameters:

--- a/test/Feature/RootSignatures/ManualDescriptors.test
+++ b/test/Feature/RootSignatures/ManualDescriptors.test
@@ -41,7 +41,6 @@ void main(uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 RuntimeSettings:
   DirectX:
     RootParameters:

--- a/test/Feature/RootSignatures/NumberParameters.test
+++ b/test/Feature/RootSignatures/NumberParameters.test
@@ -45,7 +45,6 @@ void main(uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 RuntimeSettings:
   DirectX:
     RootParameters:

--- a/test/Feature/RootSignatures/ParameterInsensitivity.test
+++ b/test/Feature/RootSignatures/ParameterInsensitivity.test
@@ -41,7 +41,6 @@ void main(uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 RuntimeSettings:
   DirectX:
     RootParameters:

--- a/test/Feature/RootSignatures/RootConstants.test
+++ b/test/Feature/RootSignatures/RootConstants.test
@@ -22,7 +22,6 @@ void main(uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 RuntimeSettings:
   DirectX:
     RootParameters:

--- a/test/Feature/RootSignatures/RootDescriptorAndTables.test
+++ b/test/Feature/RootSignatures/RootDescriptorAndTables.test
@@ -26,7 +26,6 @@ void main(uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 RuntimeSettings:
   DirectX:
     RootParameters:

--- a/test/Feature/RootSignatures/RootDescriptors.test
+++ b/test/Feature/RootSignatures/RootDescriptors.test
@@ -26,7 +26,6 @@ void main(uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 RuntimeSettings:
   DirectX:
     RootParameters:

--- a/test/Feature/RootSignatures/StaticSamplers.test
+++ b/test/Feature/RootSignatures/StaticSamplers.test
@@ -40,7 +40,6 @@ void main(uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float32

--- a/test/Feature/RootSignatures/TwoDescriptorTables.test
+++ b/test/Feature/RootSignatures/TwoDescriptorTables.test
@@ -20,7 +20,6 @@ void main(uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float32

--- a/test/Feature/Semantics/ComputeSystemValues.test
+++ b/test/Feature/Semantics/ComputeSystemValues.test
@@ -21,7 +21,8 @@ void main(uint3 DTID : SV_DispatchThreadID, uint3 GID : SV_GroupID, uint3 GTID :
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [2, 2, 2]
+DispatchParameters:
+  DispatchGroupCount: [2, 2, 2]
 Buffers:
   - Name: OUTPUT
     Format: Int32

--- a/test/Feature/SpecializationConstant/duplicate_spec_id.test
+++ b/test/Feature/SpecializationConstant/duplicate_spec_id.test
@@ -16,7 +16,6 @@ void main(uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
     SpecializationConstants:
       - { ConstantID: 0, Value: 123, Type: Int32 }
 Buffers:

--- a/test/Feature/SpecializationConstant/duplicate_spec_id_in_config.test
+++ b/test/Feature/SpecializationConstant/duplicate_spec_id_in_config.test
@@ -13,7 +13,6 @@ void main(uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
     SpecializationConstants:
       - { ConstantID: 0, Value: 123, Type: Int32 }
       - { ConstantID: 0, Value: 456, Type: Int32 }

--- a/test/Feature/SpecializationConstant/invalid_bool.test
+++ b/test/Feature/SpecializationConstant/invalid_bool.test
@@ -12,7 +12,6 @@ void main(uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
     SpecializationConstants:
       - { ConstantID: 0, Value: "not a number", Type: Bool }
 Buffers:

--- a/test/Feature/SpecializationConstant/invalid_double.test
+++ b/test/Feature/SpecializationConstant/invalid_double.test
@@ -12,7 +12,6 @@ void main(uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
     SpecializationConstants:
       - { ConstantID: 0, Value: "not a number", Type: Float64 }
 Buffers:

--- a/test/Feature/SpecializationConstant/invalid_float.test
+++ b/test/Feature/SpecializationConstant/invalid_float.test
@@ -12,7 +12,6 @@ void main(uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
     SpecializationConstants:
       - { ConstantID: 0, Value: "not a number", Type: Float32 }
 Buffers:

--- a/test/Feature/SpecializationConstant/invalid_int16.test
+++ b/test/Feature/SpecializationConstant/invalid_int16.test
@@ -12,7 +12,6 @@ void main(uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
     SpecializationConstants:
       - { ConstantID: 0, Value: "not a number", Type: Int16 }
 Buffers:

--- a/test/Feature/SpecializationConstant/invalid_int32.test
+++ b/test/Feature/SpecializationConstant/invalid_int32.test
@@ -12,7 +12,6 @@ void main(uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
     SpecializationConstants:
       - { ConstantID: 0, Value: "not a number", Type: Int32 }
 Buffers:

--- a/test/Feature/SpecializationConstant/invalid_uint16.test
+++ b/test/Feature/SpecializationConstant/invalid_uint16.test
@@ -12,7 +12,6 @@ void main(uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
     SpecializationConstants:
       - { ConstantID: 0, Value: "not a number", Type: UInt16 }
 Buffers:

--- a/test/Feature/SpecializationConstant/invalid_uint32.test
+++ b/test/Feature/SpecializationConstant/invalid_uint32.test
@@ -12,7 +12,6 @@ void main(uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
     SpecializationConstants:
       - { ConstantID: 0, Value: "not a number", Type: UInt32 }
 Buffers:

--- a/test/Feature/SpecializationConstant/spec_const.f64.test
+++ b/test/Feature/SpecializationConstant/spec_const.f64.test
@@ -13,7 +13,6 @@ void main(uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
     SpecializationConstants:
       - { ConstantID: 0, Value: 2.718, Type: Float64 }
 Buffers:

--- a/test/Feature/SpecializationConstant/spec_const_32_bits.test
+++ b/test/Feature/SpecializationConstant/spec_const_32_bits.test
@@ -37,7 +37,6 @@ void main(uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
     SpecializationConstants:
       - { ConstantID: 0, Value: 1, Type: Bool }
       - { ConstantID: 1, Value: 42, Type: Int32 }

--- a/test/Feature/SpecializationConstant/spec_const_other_sizes.test
+++ b/test/Feature/SpecializationConstant/spec_const_other_sizes.test
@@ -20,7 +20,6 @@ void main(uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
     SpecializationConstants:
       - { ConstantID: 1, Value: 123, Type: Int16 }
       - { ConstantID: 2, Value: 456, Type: UInt16 }

--- a/test/Feature/StructuredBuffer/GetDimensions.test
+++ b/test/Feature/StructuredBuffer/GetDimensions.test
@@ -49,8 +49,9 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [4, 1, 1]
 
+DispatchParameters:
+  DispatchGroupCount: [4, 1, 1]
 Buffers:
   - Name: A
     Format: Int32

--- a/test/Feature/StructuredBuffer/dec_counter.test
+++ b/test/Feature/StructuredBuffer/dec_counter.test
@@ -14,7 +14,6 @@ void main(uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: Out
     Format: Hex32

--- a/test/Feature/StructuredBuffer/inc_counter.test
+++ b/test/Feature/StructuredBuffer/inc_counter.test
@@ -14,7 +14,6 @@ void main(uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: Out
     Format: Hex32

--- a/test/Feature/StructuredBuffer/inc_counter_array.test
+++ b/test/Feature/StructuredBuffer/inc_counter_array.test
@@ -18,7 +18,6 @@ void main(uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: Out
     Format: Hex32

--- a/test/Feature/StructuredBuffer/inc_counter_array_imm_idx.test
+++ b/test/Feature/StructuredBuffer/inc_counter_array_imm_idx.test
@@ -27,7 +27,6 @@ void main(uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: Out
     Format: Hex32

--- a/test/Feature/StructuredBuffer/layout.test
+++ b/test/Feature/StructuredBuffer/layout.test
@@ -36,7 +36,6 @@ void main(uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float32

--- a/test/Feature/StructuredBuffer/matrix.test
+++ b/test/Feature/StructuredBuffer/matrix.test
@@ -30,7 +30,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: InA
     Format: Float32

--- a/test/Feature/StructuredBuffer/matrix_assign.test
+++ b/test/Feature/StructuredBuffer/matrix_assign.test
@@ -19,7 +19,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: InA
     Format: Float32

--- a/test/Feature/StructuredBuffer/packed.test
+++ b/test/Feature/StructuredBuffer/packed.test
@@ -20,7 +20,6 @@ void main(uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: Buf
     Format: Int32

--- a/test/Feature/StructuredBuffer/simple.test
+++ b/test/Feature/StructuredBuffer/simple.test
@@ -21,7 +21,6 @@ void main(uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Hex32

--- a/test/Feature/StructuredBuffer/srv.test
+++ b/test/Feature/StructuredBuffer/srv.test
@@ -15,7 +15,6 @@ void main(uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Hex32

--- a/test/Feature/StructuredBuffer/stride.test
+++ b/test/Feature/StructuredBuffer/stride.test
@@ -15,7 +15,6 @@ void main(uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float32

--- a/test/Feature/Textures/Texture2D.Gather.test.yaml
+++ b/test/Feature/Textures/Texture2D.Gather.test.yaml
@@ -49,7 +49,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 
 Buffers:
   - Name: Tex

--- a/test/Feature/Textures/Texture2D.GatherCmp.test.yaml
+++ b/test/Feature/Textures/Texture2D.GatherCmp.test.yaml
@@ -65,7 +65,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 
 Buffers:
   - Name: Tex

--- a/test/Feature/Textures/Texture2D.GetDimensions.test.yaml
+++ b/test/Feature/Textures/Texture2D.GetDimensions.test.yaml
@@ -53,7 +53,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 
 Buffers:
   - Name: Tex1

--- a/test/Feature/Textures/Texture2D.Load.test.yaml
+++ b/test/Feature/Textures/Texture2D.Load.test.yaml
@@ -27,7 +27,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 
 Buffers:
   - Name: Tex

--- a/test/Feature/Textures/Texture2D.OperatorIndex.test.yaml
+++ b/test/Feature/Textures/Texture2D.OperatorIndex.test.yaml
@@ -16,7 +16,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 
 Buffers:
   - Name: Tex

--- a/test/Feature/Textures/Texture2D.SRVToUAV.array.test.yaml
+++ b/test/Feature/Textures/Texture2D.SRVToUAV.array.test.yaml
@@ -18,7 +18,6 @@ void main(uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float32

--- a/test/Feature/Textures/Texture2D.SRVToUAV.test.yaml
+++ b/test/Feature/Textures/Texture2D.SRVToUAV.test.yaml
@@ -14,7 +14,6 @@ void main(uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float32

--- a/test/Feature/Textures/Texture2D.SampleGrad.test.yaml
+++ b/test/Feature/Textures/Texture2D.SampleGrad.test.yaml
@@ -38,7 +38,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 
 Buffers:
   - Name: Tex

--- a/test/Feature/Textures/Texture2D.Sampler.mips.test.yaml
+++ b/test/Feature/Textures/Texture2D.Sampler.mips.test.yaml
@@ -32,7 +32,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 
 Buffers:
   - Name: Tex

--- a/test/Feature/Textures/Texture2D.mips.OperatorIndex.test.yaml
+++ b/test/Feature/Textures/Texture2D.mips.OperatorIndex.test.yaml
@@ -17,7 +17,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 
 Buffers:
   - Name: Tex

--- a/test/Feature/TypedBuffer/64bit-scalar.test
+++ b/test/Feature/TypedBuffer/64bit-scalar.test
@@ -33,7 +33,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: U0
     Format: Int64

--- a/test/Feature/TypedBuffer/64bit-vector.test
+++ b/test/Feature/TypedBuffer/64bit-vector.test
@@ -33,7 +33,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: U0
     Format: Int64

--- a/test/Feature/TypedBuffer/GetDimensions.test
+++ b/test/Feature/TypedBuffer/GetDimensions.test
@@ -26,8 +26,9 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [4, 1, 1]
 
+DispatchParameters:
+  DispatchGroupCount: [4, 1, 1]
 Buffers:
   - Name: A
     Format: Int32

--- a/test/Feature/Vk.SampledTextures/Vk.SampledTexture2D/Vk.SampledTexture2D.Gather.test.yaml
+++ b/test/Feature/Vk.SampledTextures/Vk.SampledTexture2D/Vk.SampledTexture2D.Gather.test.yaml
@@ -48,7 +48,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 
 Buffers:
   - Name: SampledTexClamp

--- a/test/Feature/Vk.SampledTextures/Vk.SampledTexture2D/Vk.SampledTexture2D.GatherCmp.test.yaml
+++ b/test/Feature/Vk.SampledTextures/Vk.SampledTexture2D/Vk.SampledTexture2D.GatherCmp.test.yaml
@@ -46,7 +46,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 
 Buffers:
   - Name: SampledTexLess

--- a/test/Feature/Vk.SampledTextures/Vk.SampledTexture2D/Vk.SampledTexture2D.GetDimensions.test.yaml
+++ b/test/Feature/Vk.SampledTextures/Vk.SampledTexture2D/Vk.SampledTexture2D.GetDimensions.test.yaml
@@ -53,7 +53,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 
 Buffers:
   - Name: SampledTex1

--- a/test/Feature/Vk.SampledTextures/Vk.SampledTexture2D/Vk.SampledTexture2D.Load.test.yaml
+++ b/test/Feature/Vk.SampledTextures/Vk.SampledTexture2D/Vk.SampledTexture2D.Load.test.yaml
@@ -27,7 +27,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 
 Buffers:
   - Name: SampledTex

--- a/test/Feature/Vk.SampledTextures/Vk.SampledTexture2D/Vk.SampledTexture2D.SampleGrad.test.yaml
+++ b/test/Feature/Vk.SampledTextures/Vk.SampledTexture2D/Vk.SampledTexture2D.SampleGrad.test.yaml
@@ -37,7 +37,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 
 Buffers:
   - Name: SampledTex0

--- a/test/Feature/Vk.SampledTextures/Vk.SampledTexture2D/Vk.SampledTexture2D.Sampler.mips.test.yaml
+++ b/test/Feature/Vk.SampledTextures/Vk.SampledTexture2D/Vk.SampledTexture2D.Sampler.mips.test.yaml
@@ -31,7 +31,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 
 Buffers:
   - Name: SampledTexMagLinearMinPoint

--- a/test/Feature/Vk.SampledTextures/Vk.SampledTexture2D/Vk.SampledTexture2D.mips.OperatorIndex.test.yaml
+++ b/test/Feature/Vk.SampledTextures/Vk.SampledTexture2D/Vk.SampledTexture2D.mips.OperatorIndex.test.yaml
@@ -17,7 +17,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 
 Buffers:
   - Name: SampledTex

--- a/test/Feature/WaveOps/WaveActiveAllTrue.test
+++ b/test/Feature/WaveOps/WaveActiveAllTrue.test
@@ -26,7 +26,6 @@ void main(uint3 threadID : SV_DispatchThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: value
     Format: Int32

--- a/test/Feature/WaveOps/WaveActiveAnyTrue.test
+++ b/test/Feature/WaveOps/WaveActiveAnyTrue.test
@@ -25,7 +25,6 @@ void main(uint3 threadID : SV_DispatchThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: value
     Format: Int32

--- a/test/Feature/WaveOps/WaveActiveCountBits.test
+++ b/test/Feature/WaveOps/WaveActiveCountBits.test
@@ -27,7 +27,6 @@ void main(uint3 threadID : SV_DispatchThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: value
     Format: Int32

--- a/test/Feature/WaveOps/WaveGetLaneIndex.test
+++ b/test/Feature/WaveOps/WaveGetLaneIndex.test
@@ -12,7 +12,8 @@ void main(uint3 threadID : SV_DispatchThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [2, 1, 1]
+DispatchParameters:
+  DispatchGroupCount: [2, 1, 1]
 Buffers:
   - Name: Out
     Format: UInt32

--- a/test/Feature/WaveOps/WaveIsFirstLane.test
+++ b/test/Feature/WaveOps/WaveIsFirstLane.test
@@ -28,7 +28,6 @@ void main(uint3 threadID : SV_DispatchThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: value
     Format: Int32

--- a/test/Tools/Offloader/BufferExact-error-array.test
+++ b/test/Tools/Offloader/BufferExact-error-array.test
@@ -15,7 +15,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: OutArray
     Format: Int32

--- a/test/Tools/Offloader/BufferExact-error.test
+++ b/test/Tools/Offloader/BufferExact-error.test
@@ -16,7 +16,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: Out
     Format: Int32

--- a/test/Tools/Offloader/BufferExact.test
+++ b/test/Tools/Offloader/BufferExact.test
@@ -19,7 +19,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: Out1
     Format: Int32

--- a/test/Tools/Offloader/BufferFloat-16bit.test
+++ b/test/Tools/Offloader/BufferFloat-16bit.test
@@ -21,7 +21,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: Out1
     Format: Float16

--- a/test/Tools/Offloader/BufferFloat-64bit.test
+++ b/test/Tools/Offloader/BufferFloat-64bit.test
@@ -19,7 +19,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: Out1
     Format: Float64

--- a/test/Tools/Offloader/BufferFloat-error-16bit.test
+++ b/test/Tools/Offloader/BufferFloat-error-16bit.test
@@ -16,7 +16,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: Out1
     Format: Float16

--- a/test/Tools/Offloader/BufferFloat-error-32bit.test
+++ b/test/Tools/Offloader/BufferFloat-error-32bit.test
@@ -14,7 +14,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: Out1
     Format: Float32

--- a/test/Tools/Offloader/BufferFloat-error-64bit.test
+++ b/test/Tools/Offloader/BufferFloat-error-64bit.test
@@ -18,7 +18,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: Out1
     Format: Float64

--- a/test/Tools/Offloader/BufferFloat-error.test
+++ b/test/Tools/Offloader/BufferFloat-error.test
@@ -16,7 +16,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: Out1
     Format: Float32

--- a/test/Tools/Offloader/BufferFloat.test
+++ b/test/Tools/Offloader/BufferFloat.test
@@ -19,7 +19,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: Out1
     Format: Float32

--- a/test/Tools/Offloader/BufferFormats.test
+++ b/test/Tools/Offloader/BufferFormats.test
@@ -22,7 +22,6 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In0
     Format: Int32

--- a/test/Tools/Offloader/BufferSizeValidation.test.yaml
+++ b/test/Tools/Offloader/BufferSizeValidation.test.yaml
@@ -3,7 +3,6 @@
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 
 Buffers:
   - Name: MismatchBuffer

--- a/test/Tools/Offloader/array-in-root-constant.test
+++ b/test/Tools/Offloader/array-in-root-constant.test
@@ -19,7 +19,8 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [4, 2, 1]
+DispatchParameters:
+  DispatchGroupCount: [4, 2, 1]
 RuntimeSettings:
   DirectX:
     RootParameters:

--- a/test/Tools/Offloader/array-in-root-descriptor.test
+++ b/test/Tools/Offloader/array-in-root-descriptor.test
@@ -18,7 +18,8 @@ void main() {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [4, 2, 1]
+DispatchParameters:
+  DispatchGroupCount: [4, 2, 1]
 RuntimeSettings:
   DirectX:
     RootParameters:

--- a/test/Tools/Offloader/missing-counter-binding.test
+++ b/test/Tools/Offloader/missing-counter-binding.test
@@ -12,7 +12,6 @@ void main(uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: Out
     Format: Hex32

--- a/test/UseCase/particle-life.test
+++ b/test/UseCase/particle-life.test
@@ -156,7 +156,8 @@ uint float_to_abgr(float3 rgb) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [32, 1, 1]
+DispatchParameters:
+  DispatchGroupCount: [32, 1, 1]
 Buffers:
   - Name: CONSTANTS
     Format: Int32

--- a/test/WaveOps/ComponentAccumulationDataRace.test
+++ b/test/WaveOps/ComponentAccumulationDataRace.test
@@ -32,7 +32,6 @@ void main(uint3 ThreadID : SV_GroupThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: Out
     Format: UInt32

--- a/test/WaveOps/ComponentDataRace.test
+++ b/test/WaveOps/ComponentDataRace.test
@@ -19,7 +19,6 @@ void main(uint3 ThreadID : SV_GroupThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: UInt32

--- a/test/WaveOps/GSFlag.test
+++ b/test/WaveOps/GSFlag.test
@@ -25,7 +25,6 @@ void main(uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: Output
     Format: Int32

--- a/test/WaveOps/GroupMemoryBarrierWithGroupSync.test
+++ b/test/WaveOps/GroupMemoryBarrierWithGroupSync.test
@@ -46,7 +46,6 @@ void main(uint3 ThreadID : SV_GroupThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: Out
     Format: UInt32

--- a/test/WaveOps/GroupSharedMatrixElementExprComponentDataRace.test
+++ b/test/WaveOps/GroupSharedMatrixElementExprComponentDataRace.test
@@ -41,7 +41,6 @@ void main(uint3 ThreadID : SV_GroupThreadID)
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float32

--- a/test/WaveOps/GroupSharedMatrixEltComponentDataRace.test
+++ b/test/WaveOps/GroupSharedMatrixEltComponentDataRace.test
@@ -26,7 +26,6 @@ void main(uint3 ThreadID : SV_GroupThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float32

--- a/test/WaveOps/GroupSharedMatrixRowComponentDataRace.test
+++ b/test/WaveOps/GroupSharedMatrixRowComponentDataRace.test
@@ -25,7 +25,6 @@ void main(uint3 ThreadID : SV_GroupThreadID, uint FlatThreadID : SV_GroupIndex) 
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float32

--- a/test/WaveOps/QuadReadAcrossDiagonal.32.test
+++ b/test/WaveOps/QuadReadAcrossDiagonal.32.test
@@ -67,7 +67,6 @@ void main(uint3 dtid : SV_DispatchThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [ 1, 1, 1 ]
 Buffers:
   - Name: In
     Format: Int32

--- a/test/WaveOps/QuadReadAcrossDiagonal.convergence.test
+++ b/test/WaveOps/QuadReadAcrossDiagonal.convergence.test
@@ -25,7 +25,6 @@ void main(uint3 dtid : SV_DispatchThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [ 1, 1, 1 ]
 Buffers:
   - Name: In
     Format: Float32

--- a/test/WaveOps/QuadReadAcrossDiagonal.fp16.test
+++ b/test/WaveOps/QuadReadAcrossDiagonal.fp16.test
@@ -27,7 +27,6 @@ void main(uint3 dtid : SV_DispatchThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [ 1, 1, 1 ]
 Buffers:
   - Name: In
     Format: Float16

--- a/test/WaveOps/QuadReadAcrossDiagonal.fp64.test
+++ b/test/WaveOps/QuadReadAcrossDiagonal.fp64.test
@@ -27,7 +27,6 @@ void main(uint3 dtid : SV_DispatchThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [ 1, 1, 1 ]
 Buffers:
   - Name: In
     Format: Float64

--- a/test/WaveOps/QuadReadAcrossDiagonal.int16.test
+++ b/test/WaveOps/QuadReadAcrossDiagonal.int16.test
@@ -48,7 +48,6 @@ void main(uint3 dtid : SV_DispatchThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [ 1, 1, 1 ]
 Buffers:
   - Name: In
     Format: Int16

--- a/test/WaveOps/QuadReadAcrossDiagonal.int64.test
+++ b/test/WaveOps/QuadReadAcrossDiagonal.int64.test
@@ -48,7 +48,6 @@ void main(uint3 dtid : SV_DispatchThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [ 1, 1, 1 ]
 Buffers:
   - Name: In
     Format: Int64

--- a/test/WaveOps/QuadReadAcrossX.32.test
+++ b/test/WaveOps/QuadReadAcrossX.32.test
@@ -67,7 +67,6 @@ void main(uint3 dtid : SV_DispatchThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [ 1, 1, 1 ]
 Buffers:
   - Name: In
     Format: Int32

--- a/test/WaveOps/QuadReadAcrossX.convergence.test
+++ b/test/WaveOps/QuadReadAcrossX.convergence.test
@@ -25,7 +25,6 @@ void main(uint3 dtid : SV_DispatchThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [ 1, 1, 1 ]
 Buffers:
   - Name: In
     Format: Float32

--- a/test/WaveOps/QuadReadAcrossX.fp16.test
+++ b/test/WaveOps/QuadReadAcrossX.fp16.test
@@ -27,7 +27,6 @@ void main(uint3 dtid : SV_DispatchThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [ 1, 1, 1 ]
 Buffers:
   - Name: In
     Format: Float16

--- a/test/WaveOps/QuadReadAcrossX.fp64.test
+++ b/test/WaveOps/QuadReadAcrossX.fp64.test
@@ -27,7 +27,6 @@ void main(uint3 dtid : SV_DispatchThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [ 1, 1, 1 ]
 Buffers:
   - Name: In
     Format: Float64

--- a/test/WaveOps/QuadReadAcrossX.int16.test
+++ b/test/WaveOps/QuadReadAcrossX.int16.test
@@ -48,7 +48,6 @@ void main(uint3 dtid : SV_DispatchThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [ 1, 1, 1 ]
 Buffers:
   - Name: In
     Format: Int16

--- a/test/WaveOps/QuadReadAcrossX.int64.test
+++ b/test/WaveOps/QuadReadAcrossX.int64.test
@@ -48,7 +48,6 @@ void main(uint3 dtid : SV_DispatchThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [ 1, 1, 1 ]
 Buffers:
   - Name: In
     Format: Int64

--- a/test/WaveOps/QuadReadAcrossY.32.test
+++ b/test/WaveOps/QuadReadAcrossY.32.test
@@ -67,7 +67,6 @@ void main(uint3 dtid : SV_DispatchThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [ 1, 1, 1 ]
 Buffers:
   - Name: In
     Format: Int32

--- a/test/WaveOps/QuadReadAcrossY.convergence.test
+++ b/test/WaveOps/QuadReadAcrossY.convergence.test
@@ -25,7 +25,6 @@ void main(uint3 dtid : SV_DispatchThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [ 1, 1, 1 ]
 Buffers:
   - Name: In
     Format: Float32

--- a/test/WaveOps/QuadReadAcrossY.fp16.test
+++ b/test/WaveOps/QuadReadAcrossY.fp16.test
@@ -27,7 +27,6 @@ void main(uint3 dtid : SV_DispatchThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [ 1, 1, 1 ]
 Buffers:
   - Name: In
     Format: Float16

--- a/test/WaveOps/QuadReadAcrossY.fp64.test
+++ b/test/WaveOps/QuadReadAcrossY.fp64.test
@@ -27,7 +27,6 @@ void main(uint3 dtid : SV_DispatchThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [ 1, 1, 1 ]
 Buffers:
   - Name: In
     Format: Float64

--- a/test/WaveOps/QuadReadAcrossY.int16.test
+++ b/test/WaveOps/QuadReadAcrossY.int16.test
@@ -48,7 +48,6 @@ void main(uint3 dtid : SV_DispatchThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [ 1, 1, 1 ]
 Buffers:
   - Name: In
     Format: Int16

--- a/test/WaveOps/QuadReadAcrossY.int64.test
+++ b/test/WaveOps/QuadReadAcrossY.int64.test
@@ -48,7 +48,6 @@ void main(uint3 dtid : SV_DispatchThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [ 1, 1, 1 ]
 Buffers:
   - Name: In
     Format: Int64

--- a/test/WaveOps/WaveActiveAllEqual.32.test
+++ b/test/WaveOps/WaveActiveAllEqual.32.test
@@ -149,7 +149,6 @@ void main(uint3 TID : SV_GroupThreadID)
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Int32

--- a/test/WaveOps/WaveActiveAllEqual.Wave128.test
+++ b/test/WaveOps/WaveActiveAllEqual.Wave128.test
@@ -65,7 +65,6 @@ void main(uint3 TID : SV_DispatchThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In1
     Format: Int32

--- a/test/WaveOps/WaveActiveAllEqual.Wave32.test
+++ b/test/WaveOps/WaveActiveAllEqual.Wave32.test
@@ -65,7 +65,6 @@ void main(uint3 TID : SV_DispatchThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In1
     Format: Int32

--- a/test/WaveOps/WaveActiveAllEqual.Wave64.test
+++ b/test/WaveOps/WaveActiveAllEqual.Wave64.test
@@ -65,7 +65,6 @@ void main(uint3 TID : SV_DispatchThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In1
     Format: Int32

--- a/test/WaveOps/WaveActiveAllEqual.fp16.test
+++ b/test/WaveOps/WaveActiveAllEqual.fp16.test
@@ -57,7 +57,6 @@ void main(uint3 TID : SV_GroupThreadID)
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   # Everything is 0xbc00, which is -1.0
   - Name: In

--- a/test/WaveOps/WaveActiveAllEqual.fp64.test
+++ b/test/WaveOps/WaveActiveAllEqual.fp64.test
@@ -57,7 +57,6 @@ void main(uint3 TID : SV_GroupThreadID)
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:  
   - Name: In
     Format: Float64

--- a/test/WaveOps/WaveActiveAllEqual.int16.test
+++ b/test/WaveOps/WaveActiveAllEqual.int16.test
@@ -106,7 +106,6 @@ void main(uint3 TID : SV_GroupThreadID)
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Int16

--- a/test/WaveOps/WaveActiveAllEqual.int64.test
+++ b/test/WaveOps/WaveActiveAllEqual.int64.test
@@ -106,7 +106,6 @@ void main(uint3 TID : SV_GroupThreadID)
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Int64

--- a/test/WaveOps/WaveActiveBallot.Modulo.Wave128.test
+++ b/test/WaveOps/WaveActiveBallot.Modulo.Wave128.test
@@ -15,7 +15,6 @@ void main(uint3 threadID : SV_DispatchThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:  
   - Name: Out
     Format: UInt32

--- a/test/WaveOps/WaveActiveBallot.Modulo.Wave32.test
+++ b/test/WaveOps/WaveActiveBallot.Modulo.Wave32.test
@@ -15,7 +15,6 @@ void main(uint3 threadID : SV_DispatchThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:  
   - Name: Out
     Format: UInt32

--- a/test/WaveOps/WaveActiveBallot.Modulo.Wave64.test
+++ b/test/WaveOps/WaveActiveBallot.Modulo.Wave64.test
@@ -15,7 +15,6 @@ void main(uint3 threadID : SV_DispatchThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:  
   - Name: Out
     Format: UInt32

--- a/test/WaveOps/WaveActiveBallot.Wave128.test
+++ b/test/WaveOps/WaveActiveBallot.Wave128.test
@@ -24,7 +24,6 @@ void main(uint3 threadID : SV_DispatchThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:  
   - Name: Out
     Format: UInt32

--- a/test/WaveOps/WaveActiveBallot.Wave32.test
+++ b/test/WaveOps/WaveActiveBallot.Wave32.test
@@ -22,7 +22,6 @@ void main(uint3 threadID : SV_DispatchThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: Out
     Format: UInt32

--- a/test/WaveOps/WaveActiveBallot.Wave64.test
+++ b/test/WaveOps/WaveActiveBallot.Wave64.test
@@ -22,7 +22,6 @@ void main(uint3 threadID : SV_DispatchThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: Out
     Format: UInt32

--- a/test/WaveOps/WaveActiveBitAnd.convergence.test
+++ b/test/WaveOps/WaveActiveBitAnd.convergence.test
@@ -42,7 +42,6 @@ void main(uint3 TID : SV_GroupThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 
 Buffers:
 

--- a/test/WaveOps/WaveActiveBitAnd.int.test
+++ b/test/WaveOps/WaveActiveBitAnd.int.test
@@ -30,7 +30,6 @@ void main(uint3 TID : SV_GroupThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 
 Buffers:
   - Name: In

--- a/test/WaveOps/WaveActiveBitAnd.int64.test
+++ b/test/WaveOps/WaveActiveBitAnd.int64.test
@@ -30,7 +30,6 @@ void main(uint3 TID : SV_GroupThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1,1,1]
 
 Buffers:
   - Name: In

--- a/test/WaveOps/WaveActiveBitOr.convergence.test
+++ b/test/WaveOps/WaveActiveBitOr.convergence.test
@@ -42,7 +42,6 @@ void main(uint3 TID : SV_GroupThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 
 Buffers:
 

--- a/test/WaveOps/WaveActiveBitOr.int.test
+++ b/test/WaveOps/WaveActiveBitOr.int.test
@@ -32,7 +32,6 @@ void main(uint3 TID : SV_GroupThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 
 Buffers:
   - Name: In

--- a/test/WaveOps/WaveActiveBitOr.int64.test
+++ b/test/WaveOps/WaveActiveBitOr.int64.test
@@ -31,7 +31,6 @@ void main(uint3 TID : SV_GroupThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 
 Buffers:
   - Name: In

--- a/test/WaveOps/WaveActiveBitXor.convergence.test
+++ b/test/WaveOps/WaveActiveBitXor.convergence.test
@@ -42,7 +42,6 @@ void main(uint3 TID : SV_GroupThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 
 Buffers:
 

--- a/test/WaveOps/WaveActiveBitXor.int.test
+++ b/test/WaveOps/WaveActiveBitXor.int.test
@@ -43,7 +43,6 @@ void main(uint3 TID : SV_GroupThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1,1,1]
 
 Buffers:
   - Name: In

--- a/test/WaveOps/WaveActiveBitXor.int64.test
+++ b/test/WaveOps/WaveActiveBitXor.int64.test
@@ -41,7 +41,6 @@ void main(uint3 TID : SV_GroupThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 
 Buffers:
   - Name: In

--- a/test/WaveOps/WaveActiveMax.fp16.test
+++ b/test/WaveOps/WaveActiveMax.fp16.test
@@ -44,7 +44,6 @@ void main(uint3 tid : SV_GroupThreadID)
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float16

--- a/test/WaveOps/WaveActiveMax.fp32.test
+++ b/test/WaveOps/WaveActiveMax.fp32.test
@@ -44,7 +44,6 @@ void main(uint3 tid : SV_GroupThreadID)
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float32

--- a/test/WaveOps/WaveActiveMax.fp64.test
+++ b/test/WaveOps/WaveActiveMax.fp64.test
@@ -43,7 +43,6 @@ void main(uint3 tid : SV_GroupThreadID)
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float64

--- a/test/WaveOps/WaveActiveMax.int16.test
+++ b/test/WaveOps/WaveActiveMax.int16.test
@@ -44,7 +44,6 @@ void main(uint3 tid : SV_GroupThreadID)
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Int16

--- a/test/WaveOps/WaveActiveMax.int32.test
+++ b/test/WaveOps/WaveActiveMax.int32.test
@@ -44,7 +44,6 @@ void main(uint3 tid : SV_GroupThreadID)
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Int32

--- a/test/WaveOps/WaveActiveMax.int64.test
+++ b/test/WaveOps/WaveActiveMax.int64.test
@@ -44,7 +44,6 @@ void main(uint3 tid : SV_GroupThreadID)
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Int64

--- a/test/WaveOps/WaveActiveMax.test
+++ b/test/WaveOps/WaveActiveMax.test
@@ -17,7 +17,6 @@ void main(uint3 TID : SV_GroupThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: Nans
     Format: Float32

--- a/test/WaveOps/WaveActiveMin.fp16.test
+++ b/test/WaveOps/WaveActiveMin.fp16.test
@@ -44,7 +44,6 @@ void main(uint3 tid : SV_GroupThreadID)
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float16

--- a/test/WaveOps/WaveActiveMin.fp32.test
+++ b/test/WaveOps/WaveActiveMin.fp32.test
@@ -44,7 +44,6 @@ void main(uint3 tid : SV_GroupThreadID)
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float32

--- a/test/WaveOps/WaveActiveMin.fp64.test
+++ b/test/WaveOps/WaveActiveMin.fp64.test
@@ -43,7 +43,6 @@ void main(uint3 tid : SV_GroupThreadID)
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float64

--- a/test/WaveOps/WaveActiveMin.int16.test
+++ b/test/WaveOps/WaveActiveMin.int16.test
@@ -44,7 +44,6 @@ void main(uint3 tid : SV_GroupThreadID)
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Int16

--- a/test/WaveOps/WaveActiveMin.int32.test
+++ b/test/WaveOps/WaveActiveMin.int32.test
@@ -44,7 +44,6 @@ void main(uint3 tid : SV_GroupThreadID)
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Int32

--- a/test/WaveOps/WaveActiveMin.int64.test
+++ b/test/WaveOps/WaveActiveMin.int64.test
@@ -44,7 +44,6 @@ void main(uint3 tid : SV_GroupThreadID)
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Int64

--- a/test/WaveOps/WaveActiveSum.convergence.test
+++ b/test/WaveOps/WaveActiveSum.convergence.test
@@ -21,7 +21,6 @@ void main(uint3 threadID : SV_DispatchThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: value
     Format: Int32

--- a/test/WaveOps/WaveActiveSum.fp16.test
+++ b/test/WaveOps/WaveActiveSum.fp16.test
@@ -53,7 +53,6 @@ void main(uint3 tid : SV_GroupThreadID)
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float16

--- a/test/WaveOps/WaveActiveSum.fp32.test
+++ b/test/WaveOps/WaveActiveSum.fp32.test
@@ -53,7 +53,6 @@ void main(uint3 tid : SV_GroupThreadID)
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float32

--- a/test/WaveOps/WaveActiveSum.fp64.test
+++ b/test/WaveOps/WaveActiveSum.fp64.test
@@ -53,7 +53,6 @@ void main(uint3 tid : SV_GroupThreadID)
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float64

--- a/test/WaveOps/WaveActiveSum.int16.test
+++ b/test/WaveOps/WaveActiveSum.int16.test
@@ -99,7 +99,6 @@ void main(uint3 tid : SV_GroupThreadID)
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Int16

--- a/test/WaveOps/WaveActiveSum.int32.test
+++ b/test/WaveOps/WaveActiveSum.int32.test
@@ -98,7 +98,6 @@ void main(uint3 tid : SV_GroupThreadID)
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Int32

--- a/test/WaveOps/WaveActiveSum.int64.test
+++ b/test/WaveOps/WaveActiveSum.int64.test
@@ -99,7 +99,6 @@ void main(uint3 tid : SV_GroupThreadID)
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Int64

--- a/test/WaveOps/WavePrefixCountBits.Wave128.test
+++ b/test/WaveOps/WavePrefixCountBits.Wave128.test
@@ -18,7 +18,6 @@ void main(uint3 tid : SV_GroupThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:  
   - Name: Out1
     Format: UInt32

--- a/test/WaveOps/WavePrefixCountBits.Wave32.test
+++ b/test/WaveOps/WavePrefixCountBits.Wave32.test
@@ -18,7 +18,6 @@ void main(uint3 tid : SV_GroupThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:  
   - Name: Out1
     Format: UInt32

--- a/test/WaveOps/WavePrefixCountBits.Wave64.test
+++ b/test/WaveOps/WavePrefixCountBits.Wave64.test
@@ -18,7 +18,6 @@ void main(uint3 tid : SV_GroupThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:  
   - Name: Out1
     Format: UInt32

--- a/test/WaveOps/WavePrefixProduct.32.test
+++ b/test/WaveOps/WavePrefixProduct.32.test
@@ -139,7 +139,6 @@ void main(uint3 tid : SV_GroupThreadID)
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [ 1, 1, 1 ]
 Buffers:
   - Name: In
     Format: Int32

--- a/test/WaveOps/WavePrefixProduct.convergence.test
+++ b/test/WaveOps/WavePrefixProduct.convergence.test
@@ -27,7 +27,6 @@ void main(uint3 threadID : SV_DispatchThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [ 1, 1, 1 ]
 Buffers:
   - Name: value
     Format: Int32

--- a/test/WaveOps/WavePrefixProduct.fp16.test
+++ b/test/WaveOps/WavePrefixProduct.fp16.test
@@ -50,7 +50,6 @@ void main(uint3 tid : SV_GroupThreadID)
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [ 1, 1, 1 ]
 Buffers:
   - Name: In
     Format: Float16

--- a/test/WaveOps/WavePrefixProduct.fp64.test
+++ b/test/WaveOps/WavePrefixProduct.fp64.test
@@ -50,7 +50,6 @@ void main(uint3 tid : SV_GroupThreadID)
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [ 1, 1, 1 ]
 Buffers:
   - Name: In
     Format: Float64

--- a/test/WaveOps/WavePrefixProduct.int16.test
+++ b/test/WaveOps/WavePrefixProduct.int16.test
@@ -95,7 +95,6 @@ void main(uint3 tid : SV_GroupThreadID)
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [ 1, 1, 1 ]
 Buffers:
   - Name: In
     Format: Int16

--- a/test/WaveOps/WavePrefixProduct.int64.test
+++ b/test/WaveOps/WavePrefixProduct.int64.test
@@ -95,7 +95,6 @@ void main(uint3 tid : SV_GroupThreadID)
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [ 1, 1, 1 ]
 Buffers:
   - Name: In
     Format: Int64

--- a/test/WaveOps/WavePrefixSum.32.test
+++ b/test/WaveOps/WavePrefixSum.32.test
@@ -139,7 +139,6 @@ void main(uint3 tid : SV_GroupThreadID)
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [ 1, 1, 1 ]
 Buffers:
   - Name: In
     Format: Int32

--- a/test/WaveOps/WavePrefixSum.convergence.test
+++ b/test/WaveOps/WavePrefixSum.convergence.test
@@ -27,7 +27,6 @@ void main(uint3 threadID : SV_DispatchThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [ 1, 1, 1 ]
 Buffers:
   - Name: value
     Format: Int32

--- a/test/WaveOps/WavePrefixSum.fp16.test
+++ b/test/WaveOps/WavePrefixSum.fp16.test
@@ -50,7 +50,6 @@ void main(uint3 tid : SV_GroupThreadID)
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [ 1, 1, 1 ]
 Buffers:
   - Name: In
     Format: Float16

--- a/test/WaveOps/WavePrefixSum.fp64.test
+++ b/test/WaveOps/WavePrefixSum.fp64.test
@@ -50,7 +50,6 @@ void main(uint3 tid : SV_GroupThreadID)
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [ 1, 1, 1 ]
 Buffers:
   - Name: In
     Format: Float64

--- a/test/WaveOps/WavePrefixSum.int16.test
+++ b/test/WaveOps/WavePrefixSum.int16.test
@@ -95,7 +95,6 @@ void main(uint3 tid : SV_GroupThreadID)
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [ 1, 1, 1 ]
 Buffers:
   - Name: In
     Format: Int16

--- a/test/WaveOps/WavePrefixSum.int64.test
+++ b/test/WaveOps/WavePrefixSum.int64.test
@@ -95,7 +95,6 @@ void main(uint3 tid : SV_GroupThreadID)
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [ 1, 1, 1 ]
 Buffers:
   - Name: In
     Format: Int64

--- a/test/WaveOps/WaveReadLaneAt.16.test
+++ b/test/WaveOps/WaveReadLaneAt.16.test
@@ -38,7 +38,8 @@ void main(uint32_t3 TID : SV_GroupThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [4, 1, 1]
+DispatchParameters:
+  DispatchGroupCount: [4, 1, 1]
 Buffers:
   - Name: InInt
     Format: Int16

--- a/test/WaveOps/WaveReadLaneAt.32.test
+++ b/test/WaveOps/WaveReadLaneAt.32.test
@@ -45,7 +45,8 @@ void main(uint3 TID : SV_GroupThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [4, 1, 1]
+DispatchParameters:
+  DispatchGroupCount: [4, 1, 1]
 Buffers:
   - Name: InInt
     Format: Int32

--- a/test/WaveOps/WaveReadLaneAt.Bool.test
+++ b/test/WaveOps/WaveReadLaneAt.Bool.test
@@ -21,7 +21,8 @@ void main(uint32_t3 TID : SV_GroupThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [4, 1, 1]
+DispatchParameters:
+  DispatchGroupCount: [4, 1, 1]
 Buffers:
   - Name: InBool
     Format: Bool

--- a/test/WaveOps/WaveReadLaneAt.Float.64.test
+++ b/test/WaveOps/WaveReadLaneAt.Float.64.test
@@ -21,7 +21,8 @@ void main(uint32_t3 TID : SV_GroupThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [4, 1, 1]
+DispatchParameters:
+  DispatchGroupCount: [4, 1, 1]
 Buffers:
   - Name: InFloat
     Format: Float64

--- a/test/WaveOps/WaveReadLaneAt.Int.64.test
+++ b/test/WaveOps/WaveReadLaneAt.Int.64.test
@@ -29,7 +29,8 @@ void main(uint32_t3 TID : SV_GroupThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [4, 1, 1]
+DispatchParameters:
+  DispatchGroupCount: [4, 1, 1]
 Buffers:
   - Name: InInt
     Format: Int64

--- a/test/WaveOps/WaveReadLaneAt.divergent.test
+++ b/test/WaveOps/WaveReadLaneAt.divergent.test
@@ -26,7 +26,8 @@ void main(uint3 TID : SV_GroupThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [16, 1, 1]
+DispatchParameters:
+  DispatchGroupCount: [16, 1, 1]
 Buffers:
   - Name: InInt
     Format: Int32

--- a/test/WaveOps/WaveReadLaneAt.index.test
+++ b/test/WaveOps/WaveReadLaneAt.index.test
@@ -39,7 +39,8 @@ void main(uint3 TID : SV_GroupThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [4, 1, 1]
+DispatchParameters:
+  DispatchGroupCount: [4, 1, 1]
 Buffers:
   - Name: InInt
     Format: Int32

--- a/test/WaveOps/WaveReadLaneAt.mtx.test
+++ b/test/WaveOps/WaveReadLaneAt.mtx.test
@@ -20,7 +20,8 @@ void main(uint3 TID : SV_GroupThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [4, 1, 1]
+DispatchParameters:
+  DispatchGroupCount: [4, 1, 1]
 Buffers:
   - Name: InMatrix
     Format: Float32

--- a/test/WaveOps/WaveReadLaneAt.udt.test
+++ b/test/WaveOps/WaveReadLaneAt.udt.test
@@ -21,7 +21,8 @@ void main(uint3 TID : SV_GroupThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [4, 1, 1]
+DispatchParameters:
+  DispatchGroupCount: [4, 1, 1]
 Buffers:
   - Name: InUDS
     Format: Hex32

--- a/test/WaveOps/WaveReadLaneFirst.128Threads.test
+++ b/test/WaveOps/WaveReadLaneFirst.128Threads.test
@@ -33,7 +33,6 @@ void main(uint3 tid : SV_GroupThreadID)
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Int32

--- a/test/WaveOps/WaveReadLaneFirst.fp16.test
+++ b/test/WaveOps/WaveReadLaneFirst.fp16.test
@@ -44,7 +44,6 @@ void main(uint3 tid : SV_GroupThreadID)
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float16

--- a/test/WaveOps/WaveReadLaneFirst.fp32.test
+++ b/test/WaveOps/WaveReadLaneFirst.fp32.test
@@ -44,7 +44,6 @@ void main(uint3 tid : SV_GroupThreadID)
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float32

--- a/test/WaveOps/WaveReadLaneFirst.fp64.test
+++ b/test/WaveOps/WaveReadLaneFirst.fp64.test
@@ -44,7 +44,6 @@ void main(uint3 tid : SV_GroupThreadID)
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float64

--- a/test/WaveOps/WaveReadLaneFirst.int16.test
+++ b/test/WaveOps/WaveReadLaneFirst.int16.test
@@ -44,7 +44,6 @@ void main(uint3 tid : SV_GroupThreadID)
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Int16

--- a/test/WaveOps/WaveReadLaneFirst.int32.test
+++ b/test/WaveOps/WaveReadLaneFirst.int32.test
@@ -44,7 +44,6 @@ void main(uint3 tid : SV_GroupThreadID)
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Int32

--- a/test/WaveOps/WaveReadLaneFirst.int64.test
+++ b/test/WaveOps/WaveReadLaneFirst.int64.test
@@ -44,7 +44,6 @@ void main(uint3 tid : SV_GroupThreadID)
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Int64


### PR DESCRIPTION
Fixes #1152 

There was no way to specify the vertex count for a test that uses the TraditionalRaster pipeline.
Since vertex buffers are not required for doing rasterization, and is actually quite a common use case, we need to be able to specify that as well.
In the future we will also need to support indexed and instanced draws, for which more parameters need to be specified.
Specifying these parameters are part of the shader doesn't really make sense since they apply to the whole pipeline.
For those reasons I am introducing a `DispatchParameters` field where the user can specify the exact parameters for how a pipeline should be dispatched.

While making this change I found that 99% of the compute shader tests dispatch a single threadgroup. Since there is no use-case for dispatching no threads (as far as I am aware), I made dispatching a single thread group a default value. This simplifies writing tests.

For TraditionalRaster tests we can still rely on calculating the vertex count from the size of the vertex buffer and vertex stride if it is not specified in the .yaml section.