### PR TITLE
Remove error return value from `unmap()`.

### DIFF
--- a/include/API/Buffer.h
+++ b/include/API/Buffer.h
@@ -41,7 +41,7 @@ public:
   // GpuToCpu buffers; returns an error for GpuOnly. Each successful map() must
   // be paired with a call to unmap() before the buffer is used on the GPU.
   virtual llvm::Expected<void *> map() = 0;
-  virtual llvm::Error unmap() = 0;
+  virtual void unmap() = 0;
 
   Buffer(const Buffer &) = delete;
   Buffer &operator=(const Buffer &) = delete;

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -358,10 +358,7 @@ public:
     return Ptr;
   }
 
-  llvm::Error unmap() override {
-    Buffer->Unmap(0, nullptr);
-    return llvm::Error::success();
-  }
+  void unmap() override { Buffer->Unmap(0, nullptr); }
 
   static bool classof(const offloadtest::Buffer *B) {
     return B->getAPI() == GPUAPI::DirectX;

--- a/lib/API/Device.cpp
+++ b/lib/API/Device.cpp
@@ -108,8 +108,7 @@ offloadtest::createVertexBufferFromCPUBuffer(Device &Dev,
   if (!PtrOrErr)
     return PtrOrErr.takeError();
   memcpy(*PtrOrErr, Buf.Data[0].get(), Buf.size());
-  if (auto Err = VB->unmap())
-    return std::move(Err);
+  VB->unmap();
 
   return VB;
 }

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -168,13 +168,12 @@ public:
     return Buf->contents();
   }
 
-  llvm::Error unmap() override {
+  void unmap() override {
     // Managed storage (CpuToGpu) requires an explicit didModifyRange to
     // propagate CPU-side writes to the GPU. Shared storage (GpuToCpu) is
     // coherent and needs no action.
     if (Desc.Location == MemoryLocation::CpuToGpu)
       Buf->didModifyRange(NS::Range::Make(0, SizeInBytes));
-    return llvm::Error::success();
   }
 
   ~MTLBuffer() override {

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -419,10 +419,7 @@ public:
     return Ptr;
   }
 
-  llvm::Error unmap() override {
-    vkUnmapMemory(Dev, Memory);
-    return llvm::Error::success();
-  }
+  void unmap() override { vkUnmapMemory(Dev, Memory); }
 
   ~VulkanBuffer() override {
     vkDestroyBuffer(Dev, Buffer, nullptr);


### PR DESCRIPTION
`unmap` never returns an error value, so there is no point in having all the users of this function checking for errors. Instead it can just have a void return type.