### PR TITLE
Mark `CreateDesc` reference parameters as `const`

### DIFF
--- a/include/API/Device.h
+++ b/include/API/Device.h
@@ -169,11 +169,11 @@ public:
   createFence(llvm::StringRef Name) = 0;
 
   virtual llvm::Expected<std::unique_ptr<Buffer>>
-  createBuffer(std::string Name, BufferCreateDesc &Desc,
+  createBuffer(std::string Name, const BufferCreateDesc &Desc,
                size_t SizeInBytes) = 0;
 
   virtual llvm::Expected<std::unique_ptr<Texture>>
-  createTexture(std::string Name, TextureCreateDesc &Desc) = 0;
+  createTexture(std::string Name, const TextureCreateDesc &Desc) = 0;
 
   virtual void printExtra(llvm::raw_ostream &OS) {}
 

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -963,7 +963,7 @@ public:
   }
 
   llvm::Expected<std::unique_ptr<offloadtest::Buffer>>
-  createBuffer(std::string Name, BufferCreateDesc &Desc,
+  createBuffer(std::string Name, const BufferCreateDesc &Desc,
                size_t SizeInBytes) override {
     const D3D12_HEAP_TYPE HeapType = getDXHeapType(Desc.Location);
 
@@ -997,7 +997,7 @@ public:
   }
 
   llvm::Expected<std::unique_ptr<offloadtest::Texture>>
-  createTexture(std::string Name, TextureCreateDesc &Desc) override {
+  createTexture(std::string Name, const TextureCreateDesc &Desc) override {
     if (auto Err = validateTextureCreateDesc(Desc))
       return Err;
 

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -812,7 +812,7 @@ public:
   }
 
   llvm::Expected<std::unique_ptr<offloadtest::Buffer>>
-  createBuffer(std::string Name, BufferCreateDesc &Desc,
+  createBuffer(std::string Name, const BufferCreateDesc &Desc,
                size_t SizeInBytes) override {
     MTL::Buffer *Buf = Device->newBuffer(
         SizeInBytes, getMetalBufferResourceOptions(Desc.Location));
@@ -823,7 +823,7 @@ public:
   }
 
   llvm::Expected<std::unique_ptr<offloadtest::Texture>>
-  createTexture(std::string Name, TextureCreateDesc &Desc) override {
+  createTexture(std::string Name, const TextureCreateDesc &Desc) override {
     if (auto Err = validateTextureCreateDesc(Desc))
       return Err;
 

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -1433,7 +1433,7 @@ public:
   }
 
   llvm::Expected<std::unique_ptr<offloadtest::Buffer>>
-  createBuffer(std::string Name, BufferCreateDesc &Desc,
+  createBuffer(std::string Name, const BufferCreateDesc &Desc,
                size_t SizeInBytes) override {
     VkBufferCreateInfo BufInfo = {};
     BufInfo.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
@@ -1484,7 +1484,7 @@ public:
   }
 
   llvm::Expected<std::unique_ptr<offloadtest::Texture>>
-  createTexture(std::string Name, TextureCreateDesc &Desc) override {
+  createTexture(std::string Name, const TextureCreateDesc &Desc) override {
     if (auto Err = validateTextureCreateDesc(Desc))
       return Err;
 


### PR DESCRIPTION
Saw this one while working on something else. This was an oversight when these functions were introduced.