### PR TITLE
Add tests for InterlockedAdd

### DIFF
--- a/lib/API/DX/DXFeatures.def
+++ b/lib/API/DX/DXFeatures.def
@@ -31,6 +31,7 @@ D3D_FEATURE_ENUM(directx::RootSignature, HighestRootSignatureVersion)
 #ifdef D3D_FEATURE_BOOL
 D3D_FEATURE_BOOL(Native16BitShaderOpsSupported)
 D3D_FEATURE_BOOL(Int64ShaderOps)
+D3D_FEATURE_BOOL(AtomicInt64OnGroupSharedSupported)
 D3D_FEATURE_BOOL(DoublePrecisionFloatShaderOps)
 D3D_FEATURE_BOOL(WaveOps)
 #undef D3D_FEATURE_BOOL

--- a/test/Feature/HLSLLib/InterlockedAdd.32.test
+++ b/test/Feature/HLSLLib/InterlockedAdd.32.test
@@ -78,7 +78,7 @@ Buffers:
   - Name: OutSlotsInt
     Format: UInt32
     Stride: 4
-    ZeroInitSize: 256
+    FillSize: 256
   - Name: ExpectedSlotsInt
     Format: UInt32
     Stride: 4
@@ -89,7 +89,7 @@ Buffers:
   - Name: OutSlotsUInt
     Format: UInt32
     Stride: 4
-    ZeroInitSize: 256
+    FillSize: 256
   - Name: ExpectedSlotsUInt
     Format: UInt32
     Stride: 4
@@ -100,7 +100,7 @@ Buffers:
   - Name: OutFinal
     Format: Int32
     Stride: 4
-    ZeroInitSize: 20
+    FillSize: 20
   - Name: ExpectedFinal
     Format: Int32
     Stride: 4

--- a/test/Feature/HLSLLib/InterlockedAdd.32.test
+++ b/test/Feature/HLSLLib/InterlockedAdd.32.test
@@ -1,0 +1,152 @@
+#--- source.hlsl
+
+// This test exercises InterlockedAdd against non-resource (groupshared)
+// destinations. A single threadgroup of 64 threads concurrently updates
+// shared counters, so the test actually exercises atomic behavior.
+//
+// Both the 2-argument and 3-argument overloads are covered for int and uint.
+//
+// Atomicity of the 3-argument form is verified by using each thread's
+// returned original value as an index into a groupshared "seen" array.
+// If every original value is unique (i.e. no add was lost), the array is
+// all-ones after the dispatch.
+
+RWStructuredBuffer<uint> OutSlotsInt : register(u0);
+RWStructuredBuffer<uint> OutSlotsUInt : register(u1);
+RWStructuredBuffer<int> OutFinal : register(u2);
+
+groupshared int  CounterInt;          // 3-arg form, signed
+groupshared uint CounterUInt;         // 3-arg form, unsigned
+groupshared int  CounterIntNoOrig;    // 2-arg form, signed
+groupshared uint CounterUIntNoOrig;   // 2-arg form, unsigned
+groupshared int  SignedCounter;       // 2-arg form with negative addend
+
+groupshared uint SlotsInt[64];
+groupshared uint SlotsUInt[64];
+
+[numthreads(64, 1, 1)]
+void main(uint3 GTID : SV_GroupThreadID) {
+  if (GTID.x == 0) {
+    CounterInt = 0;
+    CounterUInt = 0;
+    CounterIntNoOrig = 0;
+    CounterUIntNoOrig = 0;
+    SignedCounter = 1000;
+  }
+  SlotsInt[GTID.x] = 0;
+  SlotsUInt[GTID.x] = 0;
+  GroupMemoryBarrierWithGroupSync();
+
+  // 3-argument form: capture original.
+  int origI;
+  InterlockedAdd(CounterInt, 1, origI);
+  SlotsInt[origI] = 1;
+
+  uint origU;
+  InterlockedAdd(CounterUInt, 1u, origU);
+  SlotsUInt[origU] = 1u;
+
+  // 2-argument form: no original captured.
+  InterlockedAdd(CounterIntNoOrig, 2);
+  InterlockedAdd(CounterUIntNoOrig, 3u);
+
+  // 2-argument form with negative addend (signedness test).
+  InterlockedAdd(SignedCounter, -1);
+
+  GroupMemoryBarrierWithGroupSync();
+
+  OutSlotsInt[GTID.x] = SlotsInt[GTID.x];
+  OutSlotsUInt[GTID.x] = SlotsUInt[GTID.x];
+
+  if (GTID.x == 0) {
+    OutFinal[0] = CounterInt;          // 64
+    OutFinal[1] = (int)CounterUInt;    // 64
+    OutFinal[2] = CounterIntNoOrig;    // 128
+    OutFinal[3] = (int)CounterUIntNoOrig; // 192
+    OutFinal[4] = SignedCounter;       // 1000 - 64 = 936
+  }
+}
+
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+    DispatchSize: [1, 1, 1]
+Buffers:
+  - Name: OutSlotsInt
+    Format: UInt32
+    Stride: 4
+    ZeroInitSize: 256
+  - Name: ExpectedSlotsInt
+    Format: UInt32
+    Stride: 4
+    Data: [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ]
+  - Name: OutSlotsUInt
+    Format: UInt32
+    Stride: 4
+    ZeroInitSize: 256
+  - Name: ExpectedSlotsUInt
+    Format: UInt32
+    Stride: 4
+    Data: [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ]
+  - Name: OutFinal
+    Format: Int32
+    Stride: 4
+    ZeroInitSize: 20
+  - Name: ExpectedFinal
+    Format: Int32
+    Stride: 4
+    Data: [ 64, 64, 128, 192, 936 ]
+Results:
+  - Result: TestSlotsInt
+    Rule: BufferExact
+    Actual: OutSlotsInt
+    Expected: ExpectedSlotsInt
+  - Result: TestSlotsUInt
+    Rule: BufferExact
+    Actual: OutSlotsUInt
+    Expected: ExpectedSlotsUInt
+  - Result: TestFinal
+    Rule: BufferExact
+    Actual: OutFinal
+    Expected: ExpectedFinal
+DescriptorSets:
+  - Resources:
+    - Name: OutSlotsInt
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: OutSlotsUInt
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+    - Name: OutFinal
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 2
+        Space: 0
+      VulkanBinding:
+        Binding: 2
+...
+#--- end
+
+# Unimplemented: https://github.com/llvm/llvm-project/issues/99122
+# XFAIL: Clang
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/InterlockedAdd.int64.test
+++ b/test/Feature/HLSLLib/InterlockedAdd.int64.test
@@ -1,0 +1,163 @@
+#--- source.hlsl
+
+// This test exercises InterlockedAdd against non-resource (groupshared)
+// destinations using 64-bit integer types. A single threadgroup of 64
+// threads concurrently updates shared counters, so the test actually
+// exercises atomic behavior.
+//
+// Both the 2-argument and 3-argument overloads are covered for int64_t
+// and uint64_t.
+//
+// Atomicity of the 3-argument form is verified by using each thread's
+// returned original value as an index into a groupshared "seen" array.
+// If every original value is unique (i.e. no add was lost), the array is
+// all-ones after the dispatch.
+
+RWStructuredBuffer<uint> OutSlotsInt : register(u0);
+RWStructuredBuffer<uint> OutSlotsUInt : register(u1);
+RWStructuredBuffer<int64_t> OutFinal : register(u2);
+
+groupshared int64_t  CounterInt;          // 3-arg form, signed
+groupshared uint64_t CounterUInt;         // 3-arg form, unsigned
+groupshared int64_t  CounterIntNoOrig;    // 2-arg form, signed
+groupshared uint64_t CounterUIntNoOrig;   // 2-arg form, unsigned
+groupshared int64_t  SignedCounter;       // 2-arg form with negative addend
+groupshared uint64_t LargeCounter;        // 2-arg form starting above 2^32
+
+groupshared uint SlotsInt[64];
+groupshared uint SlotsUInt[64];
+
+[numthreads(64, 1, 1)]
+void main(uint3 GTID : SV_GroupThreadID) {
+  if (GTID.x == 0) {
+    CounterInt = 0;
+    CounterUInt = 0;
+    CounterIntNoOrig = 0;
+    CounterUIntNoOrig = 0;
+    SignedCounter = 1000;
+    LargeCounter = 0x100000000ull; // 2^32
+  }
+  SlotsInt[GTID.x] = 0;
+  SlotsUInt[GTID.x] = 0;
+  GroupMemoryBarrierWithGroupSync();
+
+  // 3-argument form: capture original.
+  int64_t origI;
+  InterlockedAdd(CounterInt, (int64_t)1, origI);
+  SlotsInt[(uint)origI] = 1;
+
+  uint64_t origU;
+  InterlockedAdd(CounterUInt, (uint64_t)1, origU);
+  SlotsUInt[(uint)origU] = 1u;
+
+  // 2-argument form: no original captured.
+  InterlockedAdd(CounterIntNoOrig, (int64_t)2);
+  InterlockedAdd(CounterUIntNoOrig, (uint64_t)3);
+
+  // 2-argument form with negative addend (signedness test).
+  InterlockedAdd(SignedCounter, (int64_t)-1);
+
+  // 2-argument form with a value that exercises the upper 32 bits.
+  InterlockedAdd(LargeCounter, 0x100000000ull);
+
+  GroupMemoryBarrierWithGroupSync();
+
+  OutSlotsInt[GTID.x] = SlotsInt[GTID.x];
+  OutSlotsUInt[GTID.x] = SlotsUInt[GTID.x];
+
+  if (GTID.x == 0) {
+    OutFinal[0] = CounterInt;                 // 64
+    OutFinal[1] = (int64_t)CounterUInt;       // 64
+    OutFinal[2] = CounterIntNoOrig;           // 128
+    OutFinal[3] = (int64_t)CounterUIntNoOrig; // 192
+    OutFinal[4] = SignedCounter;              // 1000 - 64 = 936
+    OutFinal[5] = (int64_t)LargeCounter;      // 2^32 + 64*2^32 = 65 * 2^32
+  }
+}
+
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+    DispatchSize: [1, 1, 1]
+Buffers:
+  - Name: OutSlotsInt
+    Format: UInt32
+    Stride: 4
+    ZeroInitSize: 256
+  - Name: ExpectedSlotsInt
+    Format: UInt32
+    Stride: 4
+    Data: [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ]
+  - Name: OutSlotsUInt
+    Format: UInt32
+    Stride: 4
+    ZeroInitSize: 256
+  - Name: ExpectedSlotsUInt
+    Format: UInt32
+    Stride: 4
+    Data: [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ]
+  - Name: OutFinal
+    Format: Int64
+    Stride: 8
+    ZeroInitSize: 48
+  - Name: ExpectedFinal
+    Format: Int64
+    Stride: 8
+    Data: [ 64, 64, 128, 192, 936, 279172874240 ]
+    
+Results:
+  - Result: TestSlotsInt
+    Rule: BufferExact
+    Actual: OutSlotsInt
+    Expected: ExpectedSlotsInt
+  - Result: TestSlotsUInt
+    Rule: BufferExact
+    Actual: OutSlotsUInt
+    Expected: ExpectedSlotsUInt
+  - Result: TestFinal
+    Rule: BufferExact
+    Actual: OutFinal
+    Expected: ExpectedFinal
+DescriptorSets:
+  - Resources:
+    - Name: OutSlotsInt
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: OutSlotsUInt
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+    - Name: OutFinal
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 2
+        Space: 0
+      VulkanBinding:
+        Binding: 2
+...
+#--- end
+
+# REQUIRES: Int64
+
+# Unimplemented: https://github.com/llvm/llvm-project/issues/99122
+# XFAIL: Clang
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -HV 202x -T cs_6_6 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/InterlockedAdd.int64.test
+++ b/test/Feature/HLSLLib/InterlockedAdd.int64.test
@@ -153,7 +153,7 @@ DescriptorSets:
 ...
 #--- end
 
-# REQUIRES: Int64
+# REQUIRES: Int64 && Int64GroupSharedAtomics
 
 # Unimplemented: https://github.com/llvm/llvm-project/issues/99122
 # XFAIL: Clang

--- a/test/Feature/HLSLLib/InterlockedAdd.int64.test
+++ b/test/Feature/HLSLLib/InterlockedAdd.int64.test
@@ -158,6 +158,9 @@ DescriptorSets:
 # Unimplemented: https://github.com/llvm/llvm-project/issues/99122
 # XFAIL: Clang
 
+# Bug: https://github.com/llvm/offload-test-suite/issues/1164
+# XFAIL: DXC && Metal
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -HV 202x -T cs_6_6 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/InterlockedAdd.int64.test
+++ b/test/Feature/HLSLLib/InterlockedAdd.int64.test
@@ -86,7 +86,7 @@ Buffers:
   - Name: OutSlotsInt
     Format: UInt32
     Stride: 4
-    ZeroInitSize: 256
+    FillSize: 256
   - Name: ExpectedSlotsInt
     Format: UInt32
     Stride: 4
@@ -97,7 +97,7 @@ Buffers:
   - Name: OutSlotsUInt
     Format: UInt32
     Stride: 4
-    ZeroInitSize: 256
+    FillSize: 256
   - Name: ExpectedSlotsUInt
     Format: UInt32
     Stride: 4
@@ -108,7 +108,7 @@ Buffers:
   - Name: OutFinal
     Format: Int64
     Stride: 8
-    ZeroInitSize: 48
+    FillSize: 48
   - Name: ExpectedFinal
     Format: Int64
     Stride: 8

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -148,6 +148,8 @@ def setDeviceFeatures(config, device, compiler):
             config.available_features.add("Double")
         if device["Features"].get("Int64ShaderOps", False):
             config.available_features.add("Int64")
+        if device["Features"].get("AtomicInt64OnGroupSharedSupported", False):
+            config.available_features.add("Int64GroupSharedAtomics")
         setWaveSizeFeaturesDirectX(config, device)
 
     if device["API"] == "Metal":
@@ -164,6 +166,8 @@ def setDeviceFeatures(config, device, compiler):
             config.available_features.add("Double")
         if device["Features"].get("shaderInt64", False):
             config.available_features.add("Int64")
+        if device["Features"].get("shaderSharedInt64Atomics", False):
+            config.available_features.add("Int64GroupSharedAtomics")
 
         # Add supported extensions.
         for Extension in device["Extensions"]:


### PR DESCRIPTION
This PR adds tests for the InterlockedAdd HLSL function, specifically for overloads where the destination parameter is not a resource handle.
Addresses https://github.com/llvm/offload-test-suite/issues/102