### PR TITLE
Fix warning: "Not all control paths return a value".

### DIFF
--- a/include/Support/Pipeline.h
+++ b/include/Support/Pipeline.h
@@ -253,6 +253,7 @@ struct Resource {
     case ResourceKind::SampledTexture2D:
       return false;
     }
+    llvm_unreachable("All cases handled");
   }
 
   bool isTexture() const {

--- a/lib/Image/ImageComparators.cpp
+++ b/lib/Image/ImageComparators.cpp
@@ -83,4 +83,5 @@ bool ImageComparatorDistance::evaluateCheck(const CompareCheck &C,
   case CompareCheck::None:
     llvm_unreachable("Check run with no rule");
   }
+  llvm_unreachable("All cases handled");
 }

--- a/lib/Support/Check.cpp
+++ b/lib/Support/Check.cpp
@@ -373,6 +373,7 @@ static const std::string getBufferStr(offloadtest::CPUBuffer *B) {
     return formatBuffer<uint32_t>(B); // Because sizeof(bool) is 1 but HLSL
                                       // represents a bool using 4 bytes.
   }
+  llvm_unreachable("All cases handled");
 }
 
 llvm::Error verifyResult(offloadtest::Result R) {


### PR DESCRIPTION
MSVC was warning that not all control paths return a value on various funcions. By adding an `llvm_unreachable("All cases handled");` we can verify at runtime (in debug builds) that no unhandled cases occur, and get rid of the warning.