### PR TITLE
Update InterlockedAdd tests to use the new method to specify the dispatch size.

### DIFF
--- a/test/Feature/HLSLLib/InterlockedAdd.32.test
+++ b/test/Feature/HLSLLib/InterlockedAdd.32.test
@@ -73,7 +73,6 @@ void main(uint3 GTID : SV_GroupThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: OutSlotsInt
     Format: UInt32

--- a/test/Feature/HLSLLib/InterlockedAdd.int64.test
+++ b/test/Feature/HLSLLib/InterlockedAdd.int64.test
@@ -81,7 +81,6 @@ void main(uint3 GTID : SV_GroupThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: OutSlotsInt
     Format: UInt32


### PR DESCRIPTION
[#1163](https://github.com/llvm/offload-test-suite/pull/1163) got merged, but was not rebased on [#1153](https://github.com/llvm/offload-test-suite/pull/1153), causing `main` to now fail CI.

This PR updates the `InterlockedAdd` tests to use the new DispatchArgs format, including the use of the default dispatch size of [1, 1, 1].