### PR TITLE
Add `ClipDistance` and `CullDistance` tests

### DIFF
--- a/test/Feature/Semantics/ClipDistance.test
+++ b/test/Feature/Semantics/ClipDistance.test
@@ -1,0 +1,95 @@
+#--- vertex.hlsl
+struct VSInput {
+    float4 pos      : POSITION;
+    float  clipDist : CLIPDIST;
+};
+
+struct VSOutput {
+    float4 position : SV_POSITION;
+    float  clipDist : SV_ClipDistance0;
+};
+
+VSOutput main(VSInput input) {
+    VSOutput o;
+    o.position = input.pos;
+    o.clipDist = input.clipDist;
+    return o;
+}
+
+#--- pixel.hlsl
+struct PSInput {
+    float4 position : SV_POSITION;
+};
+
+float4 main(PSInput input) : SV_TARGET {
+    return float4(1.0, 0.0, 0.0, 1.0);
+}
+
+#--- pipeline.yaml
+---
+Shaders:
+  - Stage: Vertex
+    Entry: main
+  - Stage: Pixel
+    Entry: main
+Buffers:
+  # Fullscreen quad over a 4x1 render target. Pixel centers in NDC fall at
+  # x in {-0.75, -0.25, +0.25, +0.75}. In the vertex data below the CLIPDIST
+  # attribute (5th column) is initialized to equal POSITION.x (1st column)
+  # at every vertex; the vertex shader passes it through to SV_ClipDistance0
+  # unchanged, so the rasterizer-interpolated value at each pixel center
+  # matches that pixel's NDC x:
+  #   * Pixels 0, 1 (x < 0)  -> clipDist < 0 -> pixel clipped, RT untouched
+  #   * Pixels 2, 3 (x > 0)  -> clipDist > 0 -> pixel rendered (red)
+  - Name: VertexData
+    Format: Float32
+    Stride: 20  # float4 pos (16) + float clipDist (4)
+    Data: [
+      -1.0, -1.0, 0.0, 1.0,  -1.0,
+      -1.0,  1.0, 0.0, 1.0,  -1.0,
+       1.0,  1.0, 0.0, 1.0,   1.0,
+       1.0,  1.0, 0.0, 1.0,   1.0,
+       1.0, -1.0, 0.0, 1.0,   1.0,
+      -1.0, -1.0, 0.0, 1.0,  -1.0,
+    ]
+  - Name: Output
+    Format: Float32
+    Channels: 4
+    FillSize: 64 # 4x1 @ 16 bytes per pixel
+    OutputProps:
+      Height: 1
+      Width: 4
+      Depth: 1
+Bindings:
+  VertexBuffer: VertexData
+  VertexAttributes:
+    - Format: Float32
+      Channels: 4
+      Offset: 0
+      Name: POSITION
+    - Format: Float32
+      Channels: 1
+      Offset: 16
+      Name: CLIPDIST
+  RenderTarget: Output
+DescriptorSets: []
+...
+#--- end
+
+# SV_ClipDistance: per-pixel clipping. A fragment is discarded by the
+# rasterizer when its interpolated clip-distance is negative; positive values
+# pass through unchanged. Tracked under
+# https://github.com/llvm/wg-hlsl/issues/25.
+# Clang's HLSL frontend does not yet lower SV_ClipDistance on either the
+# DXIL or SPIR-V path.
+# XFAIL: Clang
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T vs_6_0 -Fo %t-vertex.o %t/vertex.hlsl
+# RUN: %dxc_target -T ps_6_0 -Fo %t-pixel.o %t/pixel.hlsl
+# RUN: %offloader %t/pipeline.yaml %t-vertex.o %t-pixel.o | FileCheck %s
+
+# Pixels 0,1 clipped -> zero-initialized clear (0,0,0,0).
+# Pixels 2,3 rendered red (1,0,0,1).
+# CHECK: Name: Output
+# CHECK: Data: [ 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 1, 0, 0, 1 ]

--- a/test/Feature/Semantics/CullDistance.test
+++ b/test/Feature/Semantics/CullDistance.test
@@ -1,0 +1,98 @@
+#--- vertex.hlsl
+struct VSInput {
+    float4 pos      : POSITION;
+    float  cullDist : CULLDIST;
+};
+
+struct VSOutput {
+    float4 position : SV_POSITION;
+    float  cullDist : SV_CullDistance0;
+};
+
+VSOutput main(VSInput input) {
+    VSOutput o;
+    o.position = input.pos;
+    o.cullDist = input.cullDist;
+    return o;
+}
+
+#--- pixel.hlsl
+struct PSInput {
+    float4 position : SV_POSITION;
+};
+
+float4 main(PSInput input) : SV_TARGET {
+    return float4(1.0, 0.0, 0.0, 1.0);
+}
+
+#--- pipeline.yaml
+---
+Shaders:
+  - Stage: Vertex
+    Entry: main
+  - Stage: Pixel
+    Entry: main
+Buffers:
+  # Two triangles drawn into a 4x1 render target. Each triangle covers one
+  # half of the viewport at y = 0 (the only row of pixel centers); both
+  # triangles extend past y = +/-1 to guarantee coverage independent of the
+  # tile/scan layout.
+  #
+  #   Triangle A: apex at NDC (0, 0), base on x = -1. Covers pixels 0, 1.
+  #     cullDist = +1 at every vertex -> primitive kept, rendered red.
+  #   Triangle B: apex at NDC (0, 0), base on x = +1. Covers pixels 2, 3.
+  #     cullDist = -1 at every vertex -> entire primitive culled, never
+  #     rasterized, target pixels remain at the clear value.
+  - Name: VertexData
+    Format: Float32
+    Stride: 20  # float4 pos (16) + float cullDist (4)
+    Data: [
+      # Triangle A (rendered)
+      -1.0, -3.0, 0.0, 1.0,   1.0,
+      -1.0,  3.0, 0.0, 1.0,   1.0,
+       0.0,  0.0, 0.0, 1.0,   1.0,
+      # Triangle B (culled)
+       0.0,  0.0, 0.0, 1.0,  -1.0,
+       1.0, -3.0, 0.0, 1.0,  -1.0,
+       1.0,  3.0, 0.0, 1.0,  -1.0,
+    ]
+  - Name: Output
+    Format: Float32
+    Channels: 4
+    FillSize: 64 # 4x1 @ 16 bytes per pixel
+    OutputProps:
+      Height: 1
+      Width: 4
+      Depth: 1
+Bindings:
+  VertexBuffer: VertexData
+  VertexAttributes:
+    - Format: Float32
+      Channels: 4
+      Offset: 0
+      Name: POSITION
+    - Format: Float32
+      Channels: 1
+      Offset: 16
+      Name: CULLDIST
+  RenderTarget: Output
+DescriptorSets: []
+...
+#--- end
+
+# SV_CullDistance: whole-primitive culling. A primitive is dropped before
+# rasterization when, for some component, every vertex carries a negative
+# value. Tracked under https://github.com/llvm/wg-hlsl/issues/25.
+# Clang's HLSL frontend does not yet lower SV_CullDistance on either the
+# DXIL or SPIR-V path.
+# XFAIL: Clang
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T vs_6_0 -Fo %t-vertex.o %t/vertex.hlsl
+# RUN: %dxc_target -T ps_6_0 -Fo %t-pixel.o %t/pixel.hlsl
+# RUN: %offloader %t/pipeline.yaml %t-vertex.o %t-pixel.o | FileCheck %s
+
+# Pixels 0,1 rendered red (triangle A kept).
+# Pixels 2,3 zero-initialized clear (triangle B culled).
+# CHECK: Name: Output
+# CHECK: Data: [ 1, 0, 0, 1, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0 ]


### PR DESCRIPTION
Adds baseline tests for two graphics-stage system values from the
rasterization-coverage epic (#1146).
Both attach a `float` to a vertex. The rasterizer reads them and decides
whether to draw — but at different granularities:

- **`SV_ClipDistance`**: the value is **interpolated** across the
  primitive. Any pixel whose interpolated value is negative is dropped
  before the pixel shader runs.
- **`SV_CullDistance`**: the value is **not interpolated**. If *every*
  vertex of a primitive has a negative value, the entire primitive is
  dropped before rasterization.

-----------------------------


## ClipDistance.test

A fullscreen quad over a 4×1 render target. The vertex buffer is set up
so that `clipDist == NDC.x` at every vertex. After linear interpolation
across the quad, every pixel's `clipDist` equals its own NDC x.

Pixel centers in NDC land at `-0.75, -0.25, +0.25, +0.75`, so:

- Pixels 0, 1 get a negative clip-distance → clipped, RT stays cleared.
- Pixels 2, 3 get a positive clip-distance → pixel shader runs, writes red.

-----------------------------


## CullDistance.test

Two separate triangles drawn in a single call onto a 4×1 RT, each with
a uniform `cullDist` at all three of its vertices:

- Triangle A covers pixels 0 and 1, `cullDist = +1` everywhere → kept,
  pixel shader writes red.
- Triangle B covers pixels 2 and 3, `cullDist = -1` everywhere → **entire
  primitive dropped before rasterization**, pixels stay cleared.