### PR TITLE
Implement a RenderEncoder for API agnostic render command recording.

### DIFF
--- a/include/API/CommandBuffer.h
+++ b/include/API/CommandBuffer.h
@@ -19,11 +19,28 @@
 #include "API/API.h"
 #include "API/Encoder.h"
 
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Error.h"
 
 #include <memory>
 
 namespace offloadtest {
+
+class RenderPass;
+class Texture;
+
+/// Description used to begin a render pass for one render encoder. The
+/// RenderPass itself carries the format / load / store policy and is
+/// expected to be created up-front via Device::createRenderPass; this
+/// struct binds it to the actual textures for a single encoder's lifetime.
+/// The texture count and order must match the RenderPass's attachment
+/// layout: one texture per color attachment, plus the depth-stencil
+/// texture iff the RenderPass has one.
+struct RenderPassBeginDesc {
+  RenderPass *Pass = nullptr;
+  llvm::SmallVector<Texture *, 8> ColorAttachments;
+  Texture *DepthStencil = nullptr;
+};
 
 class CommandBuffer {
   GPUAPI Kind;
@@ -43,6 +60,18 @@ public:
     return llvm::createStringError(
         std::errc::not_supported,
         "createComputeEncoder not implemented for this backend");
+  }
+
+  /// Create a render command encoder for recording draw commands. The
+  /// returned encoder begins the render pass referenced by \p Desc.Pass
+  /// against the textures in \p Desc; the pass ends when the encoder's
+  /// endEncoding() runs (explicitly or from its destructor).
+  virtual llvm::Expected<std::unique_ptr<RenderEncoder>>
+  createRenderEncoder(const RenderPassBeginDesc &Desc) {
+    (void)Desc;
+    return llvm::createStringError(
+        std::errc::not_supported,
+        "createRenderEncoder not implemented for this backend");
   }
 };
 

--- a/include/API/CommandBuffer.h
+++ b/include/API/CommandBuffer.h
@@ -29,13 +29,6 @@ namespace offloadtest {
 class RenderPass;
 class Texture;
 
-/// Description used to begin a render pass for one render encoder. The
-/// RenderPass itself carries the format / load / store policy and is
-/// expected to be created up-front via Device::createRenderPass; this
-/// struct binds it to the actual textures for a single encoder's lifetime.
-/// The texture count and order must match the RenderPass's attachment
-/// layout: one texture per color attachment, plus the depth-stencil
-/// texture iff the RenderPass has one.
 struct RenderPassBeginDesc {
   RenderPass *Pass = nullptr;
   llvm::SmallVector<Texture *, 8> ColorAttachments;
@@ -62,10 +55,7 @@ public:
         "createComputeEncoder not implemented for this backend");
   }
 
-  /// Create a render command encoder for recording draw commands. The
-  /// returned encoder begins the render pass referenced by \p Desc.Pass
-  /// against the textures in \p Desc; the pass ends when the encoder's
-  /// endEncoding() runs (explicitly or from its destructor).
+  /// Create a render command encoder for recording draw commands.
   virtual llvm::Expected<std::unique_ptr<RenderEncoder>>
   createRenderEncoder(const RenderPassBeginDesc &Desc) {
     (void)Desc;

--- a/include/API/CommandBuffer.h
+++ b/include/API/CommandBuffer.h
@@ -49,20 +49,11 @@ public:
   /// Create a compute command encoder for recording dispatch commands.
   /// Barriers are automatically inserted between commands.
   virtual llvm::Expected<std::unique_ptr<ComputeEncoder>>
-  createComputeEncoder() {
-    return llvm::createStringError(
-        std::errc::not_supported,
-        "createComputeEncoder not implemented for this backend");
-  }
+  createComputeEncoder() = 0;
 
   /// Create a render command encoder for recording draw commands.
   virtual llvm::Expected<std::unique_ptr<RenderEncoder>>
-  createRenderEncoder(const RenderPassBeginDesc &Desc) {
-    (void)Desc;
-    return llvm::createStringError(
-        std::errc::not_supported,
-        "createRenderEncoder not implemented for this backend");
-  }
+  createRenderEncoder(const RenderPassBeginDesc &Desc) = 0;
 };
 
 } // namespace offloadtest

--- a/include/API/Device.h
+++ b/include/API/Device.h
@@ -18,6 +18,7 @@
 #include "API/Buffer.h"
 #include "API/Capabilities.h"
 #include "API/CommandBuffer.h"
+#include "API/RenderPass.h"
 #include "API/Texture.h"
 
 #include "Support/Pipeline.h"
@@ -174,6 +175,9 @@ public:
 
   virtual llvm::Expected<std::unique_ptr<Texture>>
   createTexture(std::string Name, const TextureCreateDesc &Desc) = 0;
+
+  virtual llvm::Expected<std::unique_ptr<RenderPass>>
+  createRenderPass(const RenderPassDesc &Desc) = 0;
 
   virtual void printExtra(llvm::raw_ostream &OS) {}
 

--- a/include/API/Encoder.h
+++ b/include/API/Encoder.h
@@ -20,6 +20,7 @@
 namespace offloadtest {
 
 class Buffer;
+class PipelineState;
 
 /// Base class for all command encoders. An encoder records commands into a
 /// command buffer. Call endEncoding() when done recording. Barriers are
@@ -80,6 +81,57 @@ public:
   /// pipeline state (e.g. the shader's numthreads attribute).
   virtual llvm::Error dispatch(uint32_t GroupCountX, uint32_t GroupCountY,
                                uint32_t GroupCountZ) = 0;
+};
+
+/// Primitive topology used at draw time. The bound pipeline's topology
+/// category (point / line / triangle) must match the value passed to draw().
+enum class PrimitiveTopology {
+  TriangleList,
+};
+
+struct Viewport {
+  float X = 0.0f, Y = 0.0f;
+  float Width = 0.0f, Height = 0.0f;
+  float MinDepth = 0.0f, MaxDepth = 1.0f;
+};
+
+struct ScissorRect {
+  int32_t X = 0, Y = 0;
+  uint32_t Width = 0, Height = 0;
+};
+
+/// Encoder for recording rasterization draw commands within a render pass.
+/// Created via CommandBuffer::createRenderEncoder(const RenderPassDesc &).
+///
+/// State model: every encoder starts with no viewport, scissor, or vertex
+/// buffer bindings. The caller is required to set viewport and scissor (and
+/// any vertex buffers needed by the pipeline) before the first draw — there
+/// is no carry-over from a previous pass. The pipeline state is passed
+/// directly to draw() so a draw cannot be issued with no pipeline bound or
+/// a stale pipeline from another pass.
+class RenderEncoder : public CommandEncoder {
+public:
+  using CommandEncoder::CommandEncoder;
+
+  virtual void setViewport(const Viewport &VP) = 0;
+  virtual void setScissor(const ScissorRect &Rect) = 0;
+
+  /// Bind a vertex buffer at \p Slot with the given per-vertex \p Stride in
+  /// bytes. \p Stride is required at set time (DX12 carries it on the buffer
+  /// view, not the PSO). Pass nullptr to unbind; \p Stride is ignored when
+  /// unbinding.
+  virtual void setVertexBuffer(uint32_t Slot, Buffer *VB, size_t Offset,
+                               uint32_t Stride) = 0;
+
+  /// Non-indexed instanced draw. Mirrors DX12 DrawInstanced / vkCmdDraw /
+  /// MTL drawPrimitives. The pipeline is bound as part of the call.
+  /// Resource bindings (root descriptor tables, descriptor sets, argument
+  /// buffers) must be set up on the underlying command buffer before draw —
+  /// the abstraction for those is still WIP.
+  virtual llvm::Error
+  drawInstanced(const PipelineState &PSO, PrimitiveTopology Topology,
+                uint32_t VertexCount, uint32_t InstanceCount,
+                uint32_t FirstVertex = 0, uint32_t FirstInstance = 0) = 0;
 };
 
 } // namespace offloadtest

--- a/include/API/Encoder.h
+++ b/include/API/Encoder.h
@@ -94,15 +94,6 @@ struct ScissorRect {
   uint32_t Width = 0, Height = 0;
 };
 
-/// Encoder for recording rasterization draw commands within a render pass.
-/// Created via CommandBuffer::createRenderEncoder(const RenderPassDesc &).
-///
-/// State model: every encoder starts with no viewport, scissor, or vertex
-/// buffer bindings. The caller is required to set viewport and scissor (and
-/// any vertex buffers needed by the pipeline) before the first draw — there
-/// is no carry-over from a previous pass. The pipeline state is passed
-/// directly to draw() so a draw cannot be issued with no pipeline bound or
-/// a stale pipeline from another pass.
 class RenderEncoder : public CommandEncoder {
 public:
   using CommandEncoder::CommandEncoder;
@@ -110,18 +101,9 @@ public:
   virtual void setViewport(const Viewport &VP) = 0;
   virtual void setScissor(const ScissorRect &Rect) = 0;
 
-  /// Bind a vertex buffer at \p Slot with the given per-vertex \p Stride in
-  /// bytes. \p Stride is required at set time (DX12 carries it on the buffer
-  /// view, not the PSO). Pass nullptr to unbind; \p Stride is ignored when
-  /// unbinding.
   virtual void setVertexBuffer(uint32_t Slot, Buffer *VB, size_t Offset,
                                uint32_t Stride) = 0;
 
-  /// Non-indexed instanced draw. Mirrors DX12 DrawInstanced / vkCmdDraw /
-  /// MTL drawPrimitives. The pipeline is bound as part of the call.
-  /// Resource bindings (root descriptor tables, descriptor sets, argument
-  /// buffers) must be set up on the underlying command buffer before draw —
-  /// the abstraction for those is still WIP.
   virtual llvm::Error drawInstanced(const PipelineState &PSO,
                                     uint32_t VertexCount,
                                     uint32_t InstanceCount,

--- a/include/API/Encoder.h
+++ b/include/API/Encoder.h
@@ -43,12 +43,6 @@ public:
   GPUAPI getAPI() const { return API; }
   bool isEnded() const { return Ended; }
 
-  /// Copy \p Size bytes from \p Src at \p SrcOffset to \p Dst at
-  /// \p DstOffset.
-  virtual llvm::Error copyBufferToBuffer(Buffer &Src, size_t SrcOffset,
-                                         Buffer &Dst, size_t DstOffset,
-                                         size_t Size) = 0;
-
   /// Begin a named debug group. Visible in GPU debuggers (PIX, RenderDoc,
   /// Xcode). Must be balanced by a corresponding popDebugGroup() call.
   virtual void pushDebugGroup(llvm::StringRef Label) {}
@@ -81,6 +75,12 @@ public:
   /// pipeline state (e.g. the shader's numthreads attribute).
   virtual llvm::Error dispatch(uint32_t GroupCountX, uint32_t GroupCountY,
                                uint32_t GroupCountZ) = 0;
+
+  /// Copy \p Size bytes from \p Src at \p SrcOffset to \p Dst at
+  /// \p DstOffset.
+  virtual llvm::Error copyBufferToBuffer(Buffer &Src, size_t SrcOffset,
+                                         Buffer &Dst, size_t DstOffset,
+                                         size_t Size) = 0;
 };
 
 /// Primitive topology used at draw time. The bound pipeline's topology

--- a/include/API/Encoder.h
+++ b/include/API/Encoder.h
@@ -83,12 +83,6 @@ public:
                                          size_t Size) = 0;
 };
 
-/// Primitive topology used at draw time. The bound pipeline's topology
-/// category (point / line / triangle) must match the value passed to draw().
-enum class PrimitiveTopology {
-  TriangleList,
-};
-
 struct Viewport {
   float X = 0.0f, Y = 0.0f;
   float Width = 0.0f, Height = 0.0f;
@@ -128,10 +122,11 @@ public:
   /// Resource bindings (root descriptor tables, descriptor sets, argument
   /// buffers) must be set up on the underlying command buffer before draw —
   /// the abstraction for those is still WIP.
-  virtual llvm::Error
-  drawInstanced(const PipelineState &PSO, PrimitiveTopology Topology,
-                uint32_t VertexCount, uint32_t InstanceCount,
-                uint32_t FirstVertex = 0, uint32_t FirstInstance = 0) = 0;
+  virtual llvm::Error drawInstanced(const PipelineState &PSO,
+                                    uint32_t VertexCount,
+                                    uint32_t InstanceCount,
+                                    uint32_t FirstVertex = 0,
+                                    uint32_t FirstInstance = 0) = 0;
 };
 
 } // namespace offloadtest

--- a/include/API/Enums.h
+++ b/include/API/Enums.h
@@ -31,6 +31,19 @@ enum ShaderContainerType {
   Metal,
 };
 
+/// Action applied to an attachment when a render pass begins.
+enum class LoadAction {
+  Load,     ///< Preserve existing contents.
+  Clear,    ///< Clear to the texture's OptimizedClearValue at encoder time.
+  DontCare, ///< Contents are undefined; the driver may discard.
+};
+
+/// Action applied to an attachment when a render pass ends.
+enum class StoreAction {
+  Store,    ///< Write the rendered contents back to memory.
+  DontCare, ///< Contents may be discarded after the pass.
+};
+
 } // namespace offloadtest
 
 #endif // OFFLOADTEST_API_ENUMS_H

--- a/include/API/RenderPass.h
+++ b/include/API/RenderPass.h
@@ -1,0 +1,65 @@
+//===- RenderPass.h - Offload API Render Pass -----------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Defines the RenderPass abstract base class. A RenderPass describes the
+// formats and load / store actions of one or more attachments. It carries no
+// reference to specific textures: those are bound at encoder creation time.
+// Backends that have a corresponding native object (Vulkan's VkRenderPass)
+// build it once at creation time so it can be reused across encoders.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef OFFLOADTEST_API_RENDERPASS_H
+#define OFFLOADTEST_API_RENDERPASS_H
+
+#include "API/API.h"
+#include "API/Enums.h"
+#include "API/Resources.h"
+
+#include "llvm/ADT/SmallVector.h"
+
+#include <optional>
+
+namespace offloadtest {
+
+struct ColorAttachmentFormatDesc {
+  Format Fmt;
+  LoadAction Load = LoadAction::Clear;
+  StoreAction Store = StoreAction::Store;
+};
+
+struct DepthStencilAttachmentFormatDesc {
+  Format Fmt;
+  LoadAction DepthLoad = LoadAction::Clear;
+  StoreAction DepthStore = StoreAction::Store;
+  LoadAction StencilLoad = LoadAction::DontCare;
+  StoreAction StencilStore = StoreAction::DontCare;
+};
+
+struct RenderPassDesc {
+  llvm::SmallVector<ColorAttachmentFormatDesc, 8> ColorAttachments;
+  std::optional<DepthStencilAttachmentFormatDesc> DepthStencil;
+};
+
+class RenderPass {
+  GPUAPI API;
+
+public:
+  virtual ~RenderPass();
+  RenderPass(const RenderPass &) = delete;
+  RenderPass &operator=(const RenderPass &) = delete;
+
+  GPUAPI getAPI() const { return API; }
+
+protected:
+  explicit RenderPass(GPUAPI API) : API(API) {}
+};
+
+} // namespace offloadtest
+
+#endif // OFFLOADTEST_API_RENDERPASS_H

--- a/include/API/Texture.h
+++ b/include/API/Texture.h
@@ -150,6 +150,7 @@ public:
   Texture &operator=(const Texture &) = delete;
 
   GPUAPI getAPI() const { return API; }
+  virtual const TextureCreateDesc &getDesc() const = 0;
 
 protected:
   explicit Texture(GPUAPI API) : API(API) {}

--- a/lib/API/CMakeLists.txt
+++ b/lib/API/CMakeLists.txt
@@ -34,6 +34,7 @@ endif()
 add_offloadtest_library(API
   Capabilities.cpp
   Device.cpp
+  Util.cpp
   ${api_sources})
 
 target_include_directories(OffloadTestAPI SYSTEM BEFORE ${api_headers})

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -673,15 +673,6 @@ public:
   }
 };
 
-static D3D_PRIMITIVE_TOPOLOGY
-getDXTopology(offloadtest::PrimitiveTopology Topology) {
-  switch (Topology) {
-  case offloadtest::PrimitiveTopology::TriangleList:
-    return D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST;
-  }
-  llvm_unreachable("All PrimitiveTopology cases handled");
-}
-
 class DXRenderEncoder : public offloadtest::RenderEncoder {
   DXCommandBuffer &CB;
 
@@ -689,8 +680,7 @@ class DXRenderEncoder : public offloadtest::RenderEncoder {
   bool ViewportSet = false;
   bool ScissorSet = false;
 
-  llvm::Error bindCommonDrawState(const offloadtest::PipelineState &PSO,
-                                  offloadtest::PrimitiveTopology Topology) {
+  llvm::Error bindCommonDrawState(const offloadtest::PipelineState &PSO) {
     if (!ViewportSet)
       return llvm::createStringError(std::errc::invalid_argument,
                                      "Viewport must be set before drawing.");
@@ -701,7 +691,7 @@ class DXRenderEncoder : public offloadtest::RenderEncoder {
     const auto &DXPSO = llvm::cast<DXPipelineState>(PSO);
     CB.CmdList->SetGraphicsRootSignature(DXPSO.RootSig.Get());
     CB.CmdList->SetPipelineState(DXPSO.PSO.Get());
-    CB.CmdList->IASetPrimitiveTopology(getDXTopology(Topology));
+    CB.CmdList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
     return llvm::Error::success();
   }
 
@@ -755,11 +745,10 @@ public:
   }
 
   llvm::Error drawInstanced(const offloadtest::PipelineState &PSO,
-                            offloadtest::PrimitiveTopology Topology,
                             uint32_t VertexCount, uint32_t InstanceCount,
                             uint32_t FirstVertex,
                             uint32_t FirstInstance) override {
-    if (auto Err = bindCommonDrawState(PSO, Topology))
+    if (auto Err = bindCommonDrawState(PSO))
       return Err;
     CB.CmdList->DrawInstanced(VertexCount, InstanceCount, FirstVertex,
                               FirstInstance);
@@ -2184,9 +2173,7 @@ public:
     if (IS.VB)
       Encoder.setVertexBuffer(0, IS.VB.get(), 0, P.Bindings.getVertexStride());
 
-    if (auto Err = Encoder.drawInstanced(*IS.Pipeline.get(),
-                                         PrimitiveTopology::TriangleList,
-                                         P.getVertexCount(),
+    if (auto Err = Encoder.drawInstanced(*IS.Pipeline.get(), P.getVertexCount(),
                                          /*InstanceCount=*/1))
       return Err;
     Encoder.endEncoding();

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -47,6 +47,8 @@
 #include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/Signals.h"
 
+#include "../Util.h"
+
 #include <atomic>
 #include <codecvt>
 #include <locale>
@@ -779,6 +781,9 @@ DXCommandBuffer::createRenderEncoder(
     return llvm::createStringError(std::errc::invalid_argument,
                                    "RenderPassBeginDesc depth-stencil "
                                    "presence does not match its RenderPass.");
+
+  if (auto Err = findAndValidateRenderPassTextureSize(Desc, nullptr, nullptr))
+    return Err;
 
   // Validate attachments and gather the RTV / DSV CPU handles. RT and DSV
   // descriptors are owned by the textures themselves; this just collects

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -657,10 +657,6 @@ DXCommandBuffer::createComputeEncoder() {
   return Enc;
 }
 
-/// DX12 has no native render-pass object in the path this backend uses
-/// (we drive raster via OMSetRenderTargets + ClearRenderTargetView /
-/// ClearDepthStencilView, not BeginRenderPass). The render pass therefore
-/// just stores its description for the encoder to consult later.
 class DXRenderPass final : public offloadtest::RenderPass {
 public:
   offloadtest::RenderPassDesc Desc;
@@ -819,10 +815,6 @@ DXCommandBuffer::createRenderEncoder(
       static_cast<UINT>(RTVHandles.size()), RTVHandles.data(),
       /*RTsSingleHandleToDescriptorRange=*/false, DSVPtr);
 
-  // Apply LoadAction::Clear for each attachment that requested it. Clear
-  // values come from the texture's OptimizedClearValue — both because DX12
-  // requires a matching clear value to skip a clear-color fixup pass, and
-  // because tests don't currently need pass-level overrides.
   for (size_t I = 0; I < PassDesc.ColorAttachments.size(); ++I) {
     if (PassDesc.ColorAttachments[I].Load != offloadtest::LoadAction::Clear)
       continue;

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -652,6 +652,22 @@ DXCommandBuffer::createComputeEncoder() {
   return Enc;
 }
 
+/// DX12 has no native render-pass object in the path this backend uses
+/// (we drive raster via OMSetRenderTargets + ClearRenderTargetView /
+/// ClearDepthStencilView, not BeginRenderPass). The render pass therefore
+/// just stores its description for the encoder to consult later.
+class DXRenderPass final : public offloadtest::RenderPass {
+public:
+  offloadtest::RenderPassDesc Desc;
+
+  explicit DXRenderPass(offloadtest::RenderPassDesc Desc)
+      : RenderPass(GPUAPI::DirectX), Desc(std::move(Desc)) {}
+
+  static bool classof(const offloadtest::RenderPass *RP) {
+    return RP->getAPI() == GPUAPI::DirectX;
+  }
+};
+
 class DXDevice : public offloadtest::Device {
 private:
   ComPtr<IDXCoreAdapter> Adapter;
@@ -1153,6 +1169,11 @@ public:
   llvm::Expected<std::unique_ptr<offloadtest::CommandBuffer>>
   createCommandBuffer() override {
     return DXCommandBuffer::create(Device);
+  }
+
+  llvm::Expected<std::unique_ptr<offloadtest::RenderPass>>
+  createRenderPass(const offloadtest::RenderPassDesc &Desc) override {
+    return std::make_unique<DXRenderPass>(Desc);
   }
 
   void addResourceUploadCommands(Resource &R, InvocationState &IS,

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -694,6 +694,10 @@ class DXRenderEncoder : public offloadtest::RenderEncoder {
 public:
   DXRenderEncoder(DXCommandBuffer &CB)
       : RenderEncoder(GPUAPI::DirectX), CB(CB) {}
+  DXRenderEncoder(const DXRenderEncoder &CB) = delete;
+  DXRenderEncoder(DXRenderEncoder &&CB) = delete;
+  DXRenderEncoder &operator=(DXRenderEncoder &CB) = delete;
+  DXRenderEncoder &operator=(const DXRenderEncoder &&CB) = delete;
 
   ~DXRenderEncoder() override { endEncoding(); }
 

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -361,6 +361,8 @@ public:
       : offloadtest::Texture(GPUAPI::DirectX), Resource(Resource), Name(Name),
         Desc(Desc) {}
 
+  const TextureCreateDesc &getDesc() const override { return Desc; }
+
   static bool classof(const offloadtest::Texture *T) {
     return T->getAPI() == GPUAPI::DirectX;
   }
@@ -546,6 +548,9 @@ public:
   llvm::Expected<std::unique_ptr<offloadtest::ComputeEncoder>>
   createComputeEncoder() override;
 
+  llvm::Expected<std::unique_ptr<offloadtest::RenderEncoder>>
+  createRenderEncoder(const offloadtest::RenderPassBeginDesc &Desc) override;
+
 private:
   DXCommandBuffer() : CommandBuffer(GPUAPI::DirectX) {}
 };
@@ -668,6 +673,217 @@ public:
   }
 };
 
+static D3D_PRIMITIVE_TOPOLOGY
+getDXTopology(offloadtest::PrimitiveTopology Topology) {
+  switch (Topology) {
+  case offloadtest::PrimitiveTopology::TriangleList:
+    return D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST;
+  }
+  llvm_unreachable("All PrimitiveTopology cases handled");
+}
+
+class DXRenderEncoder : public offloadtest::RenderEncoder {
+  DXCommandBuffer &CB;
+
+  // Encoder contract: viewport and scissor must both be set before draw().
+  bool ViewportSet = false;
+  bool ScissorSet = false;
+
+  llvm::Error bindCommonDrawState(const offloadtest::PipelineState &PSO,
+                                  offloadtest::PrimitiveTopology Topology) {
+    if (!ViewportSet)
+      return llvm::createStringError(std::errc::invalid_argument,
+                                     "Viewport must be set before drawing.");
+    if (!ScissorSet)
+      return llvm::createStringError(std::errc::invalid_argument,
+                                     "Scissor must be set before drawing.");
+
+    const auto &DXPSO = llvm::cast<DXPipelineState>(PSO);
+    CB.CmdList->SetGraphicsRootSignature(DXPSO.RootSig.Get());
+    CB.CmdList->SetPipelineState(DXPSO.PSO.Get());
+    CB.CmdList->IASetPrimitiveTopology(getDXTopology(Topology));
+    return llvm::Error::success();
+  }
+
+public:
+  DXRenderEncoder(DXCommandBuffer &CB)
+      : RenderEncoder(GPUAPI::DirectX), CB(CB) {}
+
+  ~DXRenderEncoder() override { endEncoding(); }
+
+  static bool classof(const CommandEncoder *E) {
+    return E->getAPI() == GPUAPI::DirectX;
+  }
+
+  // See DXComputeEncoder for why these are no-ops.
+  void pushDebugGroup(llvm::StringRef Label) override {}
+  void popDebugGroup() override {}
+  void insertDebugSignpost(llvm::StringRef Label) override {}
+
+  void setViewport(const offloadtest::Viewport &VP) override {
+    D3D12_VIEWPORT DXVP = {};
+    DXVP.TopLeftX = VP.X;
+    DXVP.TopLeftY = VP.Y;
+    DXVP.Width = VP.Width;
+    DXVP.Height = VP.Height;
+    DXVP.MinDepth = VP.MinDepth;
+    DXVP.MaxDepth = VP.MaxDepth;
+    CB.CmdList->RSSetViewports(1, &DXVP);
+    ViewportSet = true;
+  }
+
+  void setScissor(const offloadtest::ScissorRect &Rect) override {
+    const D3D12_RECT DXRect = {Rect.X, Rect.Y,
+                               static_cast<LONG>(Rect.X + Rect.Width),
+                               static_cast<LONG>(Rect.Y + Rect.Height)};
+    CB.CmdList->RSSetScissorRects(1, &DXRect);
+    ScissorSet = true;
+  }
+
+  void setVertexBuffer(uint32_t Slot, offloadtest::Buffer *VB, size_t Offset,
+                       uint32_t Stride) override {
+    if (!VB) {
+      CB.CmdList->IASetVertexBuffers(Slot, 1, nullptr);
+      return;
+    }
+    auto &DXVB = llvm::cast<DXBuffer>(*VB);
+    D3D12_VERTEX_BUFFER_VIEW VBView = {};
+    VBView.BufferLocation = DXVB.Buffer->GetGPUVirtualAddress() + Offset;
+    VBView.SizeInBytes = static_cast<UINT>(DXVB.getSizeInBytes() - Offset);
+    VBView.StrideInBytes = Stride;
+    CB.CmdList->IASetVertexBuffers(Slot, 1, &VBView);
+  }
+
+  llvm::Error drawInstanced(const offloadtest::PipelineState &PSO,
+                            offloadtest::PrimitiveTopology Topology,
+                            uint32_t VertexCount, uint32_t InstanceCount,
+                            uint32_t FirstVertex,
+                            uint32_t FirstInstance) override {
+    if (auto Err = bindCommonDrawState(PSO, Topology))
+      return Err;
+    CB.CmdList->DrawInstanced(VertexCount, InstanceCount, FirstVertex,
+                              FirstInstance);
+    return llvm::Error::success();
+  }
+
+  llvm::Error copyBufferToBuffer(offloadtest::Buffer &Src, size_t SrcOffset,
+                                 offloadtest::Buffer &Dst, size_t DstOffset,
+                                 size_t Size) override {
+    auto &DXSrc = static_cast<DXBuffer &>(Src);
+    auto &DXDst = static_cast<DXBuffer &>(Dst);
+    CB.CmdList->CopyBufferRegion(DXDst.Buffer.Get(), DstOffset,
+                                 DXSrc.Buffer.Get(), SrcOffset, Size);
+    return llvm::Error::success();
+  }
+
+  void endEncodingImpl() override { popDebugGroup(); }
+};
+
+llvm::Expected<std::unique_ptr<offloadtest::RenderEncoder>>
+DXCommandBuffer::createRenderEncoder(
+    const offloadtest::RenderPassBeginDesc &Desc) {
+  // The pass carries format / load / store policy; the begin desc supplies
+  // the actual textures. Walk both in lockstep.
+  if (!Desc.Pass)
+    return llvm::createStringError(
+        std::errc::invalid_argument,
+        "RenderPassBeginDesc is missing its RenderPass.");
+  auto &DXPass = llvm::cast<DXRenderPass>(*Desc.Pass);
+  const offloadtest::RenderPassDesc &PassDesc = DXPass.Desc;
+
+  if (Desc.ColorAttachments.size() != PassDesc.ColorAttachments.size())
+    return llvm::createStringError(
+        std::errc::invalid_argument,
+        "RenderPassBeginDesc color attachment count does not match its "
+        "RenderPass.");
+  if (PassDesc.DepthStencil.has_value() != (Desc.DepthStencil != nullptr))
+    return llvm::createStringError(std::errc::invalid_argument,
+                                   "RenderPassBeginDesc depth-stencil "
+                                   "presence does not match its RenderPass.");
+
+  // Validate attachments and gather the RTV / DSV CPU handles. RT and DSV
+  // descriptors are owned by the textures themselves; this just collects
+  // them for OMSetRenderTargets.
+  llvm::SmallVector<DXTexture *, 8> RTTextures;
+  llvm::SmallVector<D3D12_CPU_DESCRIPTOR_HANDLE, 8> RTVHandles;
+  RTTextures.reserve(Desc.ColorAttachments.size());
+  RTVHandles.reserve(Desc.ColorAttachments.size());
+  for (offloadtest::Texture *Tex : Desc.ColorAttachments) {
+    if (!Tex)
+      return llvm::createStringError(
+          std::errc::invalid_argument,
+          "RenderPassBeginDesc has a null color attachment texture.");
+    auto &DXTex = llvm::cast<DXTexture>(*Tex);
+    if (DXTex.RTVHandle.ptr == 0)
+      return llvm::createStringError(
+          std::errc::invalid_argument,
+          "Color attachment texture was not created with RenderTarget usage.");
+    RTTextures.push_back(&DXTex);
+    RTVHandles.push_back(DXTex.RTVHandle);
+  }
+
+  DXTexture *DSTexture = nullptr;
+  D3D12_CPU_DESCRIPTOR_HANDLE DSVHandle = {};
+  const D3D12_CPU_DESCRIPTOR_HANDLE *DSVPtr = nullptr;
+  if (Desc.DepthStencil) {
+    auto &DXDS = llvm::cast<DXTexture>(*Desc.DepthStencil);
+    if (DXDS.DSVHandle.ptr == 0)
+      return llvm::createStringError(
+          std::errc::invalid_argument,
+          "Depth-stencil texture was not created with DepthStencil usage.");
+    DSTexture = &DXDS;
+    DSVHandle = DXDS.DSVHandle;
+    DSVPtr = &DSVHandle;
+  }
+
+  CmdList->OMSetRenderTargets(
+      static_cast<UINT>(RTVHandles.size()), RTVHandles.data(),
+      /*RTsSingleHandleToDescriptorRange=*/false, DSVPtr);
+
+  // Apply LoadAction::Clear for each attachment that requested it. Clear
+  // values come from the texture's OptimizedClearValue — both because DX12
+  // requires a matching clear value to skip a clear-color fixup pass, and
+  // because tests don't currently need pass-level overrides.
+  for (size_t I = 0; I < PassDesc.ColorAttachments.size(); ++I) {
+    if (PassDesc.ColorAttachments[I].Load != offloadtest::LoadAction::Clear)
+      continue;
+    if (!RTTextures[I]->Desc.OptimizedClearValue)
+      return llvm::createStringError(
+          std::errc::invalid_argument,
+          "LoadAction::Clear requires the render target to have been "
+          "created with an OptimizedClearValue.");
+    const auto *CV =
+        std::get_if<ClearColor>(&*RTTextures[I]->Desc.OptimizedClearValue);
+    assert(CV && "RenderTarget OptimizedClearValue must be a ClearColor");
+    const float ClearArr[4] = {CV->R, CV->G, CV->B, CV->A};
+    CmdList->ClearRenderTargetView(RTVHandles[I], ClearArr, 0, nullptr);
+  }
+  if (PassDesc.DepthStencil) {
+    D3D12_CLEAR_FLAGS Flags = static_cast<D3D12_CLEAR_FLAGS>(0);
+    if (PassDesc.DepthStencil->DepthLoad == offloadtest::LoadAction::Clear)
+      Flags |= D3D12_CLEAR_FLAG_DEPTH;
+    if (PassDesc.DepthStencil->StencilLoad == offloadtest::LoadAction::Clear)
+      Flags |= D3D12_CLEAR_FLAG_STENCIL;
+    if (Flags != 0) {
+      if (!DSTexture->Desc.OptimizedClearValue)
+        return llvm::createStringError(
+            std::errc::invalid_argument,
+            "LoadAction::Clear requires the depth-stencil texture to have "
+            "been created with an OptimizedClearValue.");
+      const auto *CV =
+          std::get_if<ClearDepthStencil>(&*DSTexture->Desc.OptimizedClearValue);
+      assert(CV &&
+             "DepthStencil OptimizedClearValue must be a ClearDepthStencil");
+      CmdList->ClearDepthStencilView(DSVHandle, Flags, CV->Depth, CV->Stencil,
+                                     0, nullptr);
+    }
+  }
+
+  auto Enc = std::make_unique<DXRenderEncoder>(*this);
+  Enc->pushDebugGroup("RenderEncoder");
+  return Enc;
+}
+
 class DXDevice : public offloadtest::Device {
 private:
   ComPtr<IDXCoreAdapter> Adapter;
@@ -703,9 +919,10 @@ private:
     std::unique_ptr<PipelineState> Pipeline;
 
     // Resources for graphics pipelines.
-    std::unique_ptr<offloadtest::Texture> RT;
+    std::unique_ptr<offloadtest::RenderPass> RenderPass;
+    std::unique_ptr<offloadtest::Texture> RenderTarget;
     std::unique_ptr<offloadtest::Buffer> RTReadback;
-    std::unique_ptr<offloadtest::Texture> DS;
+    std::unique_ptr<offloadtest::Texture> DepthStencil;
     std::unique_ptr<offloadtest::Buffer> VB;
 
     llvm::SmallVector<DescriptorTable> DescTables;
@@ -1883,7 +2100,7 @@ public:
 
     // Query the copy footprint to get the actual padded row pitch used by
     // the copy operation (D3D12 requires 256-byte aligned rows).
-    auto &RT = llvm::cast<DXTexture>(*IS.RT);
+    auto &RT = llvm::cast<DXTexture>(*IS.RenderTarget);
     const D3D12_RESOURCE_DESC RTDesc = RT.Resource->GetDesc();
     D3D12_PLACED_SUBRESOURCE_FOOTPRINT Placed = {};
     uint32_t NumRows = 0;
@@ -1909,7 +2126,7 @@ public:
     if (!TexOrErr)
       return TexOrErr.takeError();
 
-    IS.RT = std::move(*TexOrErr);
+    IS.RenderTarget = std::move(*TexOrErr);
 
     // Create readback buffer sized for the pixel data with row pitch padded
     // up to D3D12_TEXTURE_DATA_PITCH_ALIGNMENT, which is what D3D12 requires
@@ -1933,13 +2150,13 @@ public:
         P.Bindings.RTargetBufferPtr->OutputProps.Height);
     if (!TexOrErr)
       return TexOrErr.takeError();
-    IS.DS = std::move(*TexOrErr);
+    IS.DepthStencil = std::move(*TexOrErr);
     return llvm::Error::success();
   }
 
   llvm::Error createGraphicsCommands(Pipeline &P, InvocationState &IS) {
-    auto &RT = llvm::cast<DXTexture>(*IS.RT);
-    auto &DS = llvm::cast<DXTexture>(*IS.DS);
+    auto &RT = llvm::cast<DXTexture>(*IS.RenderTarget);
+    auto &DS = llvm::cast<DXTexture>(*IS.DepthStencil);
     auto &RTReadback = llvm::cast<DXBuffer>(*IS.RTReadback);
 
     const DXPipelineState &DXPipeline =
@@ -1951,46 +2168,38 @@ public:
       IS.CB->CmdList->SetGraphicsRootDescriptorTable(
           0, IS.DescHeap->GetGPUDescriptorHandleForHeapStart());
     }
-    IS.CB->CmdList->SetPipelineState(DXPipeline.PSO.Get());
 
-    IS.CB->CmdList->OMSetRenderTargets(1, &RT.RTVHandle, false, &DS.DSVHandle);
+    RenderPassBeginDesc BeginDesc = {};
+    BeginDesc.Pass = IS.RenderPass.get();
+    BeginDesc.ColorAttachments.push_back(&RT);
+    BeginDesc.DepthStencil = &DS;
 
-    const auto *DepthCV =
-        std::get_if<ClearDepthStencil>(&*DS.Desc.OptimizedClearValue);
-    if (!DepthCV)
-      return llvm::createStringError(
-          std::errc::invalid_argument,
-          "Depth/stencil clear value must be a ClearDepthStencil.");
-    IS.CB->CmdList->ClearDepthStencilView(
-        DS.DSVHandle, D3D12_CLEAR_FLAG_DEPTH | D3D12_CLEAR_FLAG_STENCIL,
-        DepthCV->Depth, DepthCV->Stencil, 0, nullptr);
+    auto EncOrErr = IS.CB->createRenderEncoder(BeginDesc);
+    if (!EncOrErr)
+      return EncOrErr.takeError();
+    auto &Encoder = *EncOrErr.get();
 
-    D3D12_VIEWPORT VP = {};
+    Viewport VP;
     VP.Width =
         static_cast<float>(P.Bindings.RTargetBufferPtr->OutputProps.Width);
     VP.Height =
         static_cast<float>(P.Bindings.RTargetBufferPtr->OutputProps.Height);
-    VP.MinDepth = 0.0f;
-    VP.MaxDepth = 1.0f;
-    VP.TopLeftX = 0.0f;
-    VP.TopLeftY = 0.0f;
-    IS.CB->CmdList->RSSetViewports(1, &VP);
-    const D3D12_RECT Scissor = {0, 0, static_cast<LONG>(VP.Width),
-                                static_cast<LONG>(VP.Height)};
-    IS.CB->CmdList->RSSetScissorRects(1, &Scissor);
+    Encoder.setViewport(VP);
 
-    if (IS.VB) {
-      auto &VBBuf = llvm::cast<DXBuffer>(*IS.VB);
-      D3D12_VERTEX_BUFFER_VIEW VBView = {};
-      VBView.BufferLocation = VBBuf.Buffer->GetGPUVirtualAddress();
-      VBView.SizeInBytes = static_cast<UINT>(IS.VB->getSizeInBytes());
-      VBView.StrideInBytes = P.Bindings.getVertexStride();
-      IS.CB->CmdList->IASetVertexBuffers(0, 1, &VBView);
-    }
+    ScissorRect Scissor;
+    Scissor.Width = static_cast<uint32_t>(VP.Width);
+    Scissor.Height = static_cast<uint32_t>(VP.Height);
+    Encoder.setScissor(Scissor);
 
-    IS.CB->CmdList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+    if (IS.VB)
+      Encoder.setVertexBuffer(0, IS.VB.get(), 0, P.Bindings.getVertexStride());
 
-    IS.CB->CmdList->DrawInstanced(P.getVertexCount(), 1, 0, 0);
+    if (auto Err = Encoder.drawInstanced(*IS.Pipeline.get(),
+                                         PrimitiveTopology::TriangleList,
+                                         P.getVertexCount(),
+                                         /*InstanceCount=*/1))
+      return Err;
+    Encoder.endEncoding();
 
     // Transition the render target to copy source and copy to the readback
     // buffer.
@@ -2159,6 +2368,31 @@ public:
         return PipelineStateOrErr.takeError();
       State.Pipeline = std::move(*PipelineStateOrErr);
       llvm::outs() << "Graphics Pipeline created.\n";
+
+      // Begin a render pass: bind RT/DSV and clear depth-stencil. Color
+      // load action is Load — the existing inline code didn't clear color.
+      ColorAttachmentFormatDesc ColorAttachment = {};
+      ColorAttachment.Fmt = State.RenderTarget->getDesc().Fmt;
+      ColorAttachment.Load = LoadAction::Load;
+      ColorAttachment.Store = StoreAction::Store;
+
+      DepthStencilAttachmentFormatDesc DSAttachment = {};
+      DSAttachment.Fmt = State.DepthStencil->getDesc().Fmt;
+      DSAttachment.DepthLoad = LoadAction::Clear;
+      DSAttachment.DepthStore = StoreAction::Store;
+      DSAttachment.StencilLoad = LoadAction::DontCare;
+      DSAttachment.StencilStore = StoreAction::DontCare;
+
+      RenderPassDesc PassDesc;
+      PassDesc.ColorAttachments.push_back(ColorAttachment);
+      PassDesc.DepthStencil = DSAttachment;
+
+      auto RenderPassOrErr = createRenderPass(PassDesc);
+      if (!RenderPassOrErr)
+        return RenderPassOrErr.takeError();
+      State.RenderPass = std::move(*RenderPassOrErr);
+      llvm::outs() << "Render pass created.\n";
+
       if (auto Err = createGraphicsCommands(P, State))
         return Err;
       llvm::outs() << "Graphics command list created complete.\n";

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -766,16 +766,6 @@ public:
     return llvm::Error::success();
   }
 
-  llvm::Error copyBufferToBuffer(offloadtest::Buffer &Src, size_t SrcOffset,
-                                 offloadtest::Buffer &Dst, size_t DstOffset,
-                                 size_t Size) override {
-    auto &DXSrc = static_cast<DXBuffer &>(Src);
-    auto &DXDst = static_cast<DXBuffer &>(Dst);
-    CB.CmdList->CopyBufferRegion(DXDst.Buffer.Get(), DstOffset,
-                                 DXSrc.Buffer.Get(), SrcOffset, Size);
-    return llvm::Error::success();
-  }
-
   void endEncodingImpl() override { popDebugGroup(); }
 };
 

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -732,16 +732,16 @@ public:
 
   void setVertexBuffer(uint32_t Slot, offloadtest::Buffer *VB, size_t Offset,
                        uint32_t Stride) override {
-    if (!VB) {
+    if (VB) {
+      auto &DXVB = llvm::cast<DXBuffer>(*VB);
+      D3D12_VERTEX_BUFFER_VIEW VBView = {};
+      VBView.BufferLocation = DXVB.Buffer->GetGPUVirtualAddress() + Offset;
+      VBView.SizeInBytes = static_cast<UINT>(DXVB.getSizeInBytes() - Offset);
+      VBView.StrideInBytes = Stride;
+      CB.CmdList->IASetVertexBuffers(Slot, 1, &VBView);
+    } else {
       CB.CmdList->IASetVertexBuffers(Slot, 1, nullptr);
-      return;
     }
-    auto &DXVB = llvm::cast<DXBuffer>(*VB);
-    D3D12_VERTEX_BUFFER_VIEW VBView = {};
-    VBView.BufferLocation = DXVB.Buffer->GetGPUVirtualAddress() + Offset;
-    VBView.SizeInBytes = static_cast<UINT>(DXVB.getSizeInBytes() - Offset);
-    VBView.StrideInBytes = Stride;
-    CB.CmdList->IASetVertexBuffers(Slot, 1, &VBView);
   }
 
   llvm::Error drawInstanced(const offloadtest::PipelineState &PSO,

--- a/lib/API/Device.cpp
+++ b/lib/API/Device.cpp
@@ -34,6 +34,8 @@ Queue::~Queue() {}
 
 Texture::~Texture() {}
 
+RenderPass::~RenderPass() {}
+
 Device::~Device() {}
 
 llvm::Expected<llvm::SmallVector<std::unique_ptr<Device>>>

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -32,6 +32,9 @@
 #include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/JSON.h"
 #include "llvm/Support/raw_ostream.h"
+
+#include "../Util.h"
+
 #include <algorithm>
 #include <memory>
 
@@ -716,8 +719,9 @@ MTLCommandBuffer::createRenderEncoder(
                                    "RenderPassBeginDesc depth-stencil "
                                    "presence does not match its RenderPass.");
 
-  uint32_t Width = ~0u;
-  uint32_t Height = ~0u;
+  uint32_t Width = 0, Height = 0;
+  if (auto Err = findAndValidateRenderPassTextureSize(Desc, &Width, &Height))
+    return Err;
 
   MTL::RenderPassDescriptor *MTLDesc =
       MTL::RenderPassDescriptor::alloc()->init();
@@ -751,11 +755,6 @@ MTLCommandBuffer::createRenderEncoder(
     }
     MTLDesc->colorAttachments()->setObject(CADesc, I);
     CADesc->release();
-
-    if (Tex.Desc.Width < Width)
-      Width = Tex.Desc.Width;
-    if (Tex.Desc.Height < Height)
-      Height = Tex.Desc.Height;
   }
 
   if (Desc.DepthStencil) {
@@ -789,16 +788,6 @@ MTLCommandBuffer::createRenderEncoder(
       if (DS.StencilLoad == offloadtest::LoadAction::Clear)
         SADesc->setClearStencil(CV->Stencil);
     }
-
-    if (Tex.Desc.Width < Width)
-      Width = Tex.Desc.Width;
-    if (Tex.Desc.Height < Height)
-      Height = Tex.Desc.Height;
-  }
-
-  if (Width == ~0u && Height == ~0u) {
-    Width = 0;
-    Height = 0;
   }
 
   MTLDesc->setRenderTargetWidth(Width);

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -560,15 +560,6 @@ MTLCommandBuffer::createComputeEncoder() {
   return std::make_unique<MTLComputeEncoder>(CmdBuffer, NativeEncoder);
 }
 
-static MTL::PrimitiveType
-getMTLPrimitiveType(offloadtest::PrimitiveTopology Topology) {
-  switch (Topology) {
-  case offloadtest::PrimitiveTopology::TriangleList:
-    return MTL::PrimitiveTypeTriangle;
-  }
-  llvm_unreachable("All PrimitiveTopology cases handled");
-}
-
 static MTL::LoadAction getMTLLoadAction(offloadtest::LoadAction Action) {
   switch (Action) {
   case offloadtest::LoadAction::Load:
@@ -662,7 +653,6 @@ public:
   }
 
   llvm::Error drawInstanced(const offloadtest::PipelineState &PSO,
-                            offloadtest::PrimitiveTopology Topology,
                             uint32_t VertexCount, uint32_t InstanceCount,
                             uint32_t FirstVertex,
                             uint32_t FirstInstance) override {
@@ -685,7 +675,7 @@ public:
 
     // IRRuntimeDrawPrimitives also sets the DrawParams / DrawInfo argument
     // buffers that metal-irconverter consults for SV_VertexID and friends.
-    IRRuntimeDrawPrimitives(RenderEnc, getMTLPrimitiveType(Topology),
+    IRRuntimeDrawPrimitives(RenderEnc, MTL::PrimitiveTypeTriangle,
                             static_cast<NS::UInteger>(FirstVertex),
                             static_cast<NS::UInteger>(VertexCount),
                             static_cast<NS::UInteger>(InstanceCount),
@@ -1380,9 +1370,7 @@ class MTLDevice : public offloadtest::Device {
     if (IS.VB)
       Encoder.setVertexBuffer(0, IS.VB.get(), 0, P.Bindings.getVertexStride());
 
-    if (auto Err = Encoder.drawInstanced(*IS.Pipeline.get(),
-                                         PrimitiveTopology::TriangleList,
-                                         P.getVertexCount(),
+    if (auto Err = Encoder.drawInstanced(*IS.Pipeline.get(), P.getVertexCount(),
                                          /*InstanceCount=*/1))
       return Err;
     Encoder.endEncoding();

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -1794,8 +1794,8 @@ public:
       DepthStencilAttachmentFormatDesc DSAttachment = {};
       DSAttachment.Fmt = Format::D32FloatS8Uint;
       DSAttachment.DepthLoad = LoadAction::Clear;
-      DSAttachment.DepthStore = StoreAction::DontCare;
-      DSAttachment.StencilLoad = LoadAction::Clear;
+      DSAttachment.DepthStore = StoreAction::Store;
+      DSAttachment.StencilLoad = LoadAction::DontCare;
       DSAttachment.StencilStore = StoreAction::DontCare;
 
       RenderPassDesc PassDesc;

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -642,8 +642,7 @@ public:
 
   void setVertexBuffer(uint32_t Slot, offloadtest::Buffer *VB, size_t Offset,
                        uint32_t /*Stride*/) override {
-    // Stride lives in the render pipeline's vertex descriptor in Metal,
-    // not on the buffer binding.
+    // Stride is needed in DX12 at binding time, ignore parameter here.
     if (!VB) {
       RenderEnc->setVertexBuffer(nullptr, 0, Slot);
       return;
@@ -1681,8 +1680,6 @@ public:
     if (Error)
       return toError(Error);
 
-    // Bake the depth-stencil state and cull mode into the pipeline, mirroring
-    // the DX12 / Vulkan PSO model.
     MTL::DepthStencilDescriptor *DSDesc =
         MTL::DepthStencilDescriptor::alloc()->init();
     DSDesc->setDepthCompareFunction(MTL::CompareFunctionLess);

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -234,6 +234,13 @@ public:
   MTL::ComputePipelineState *ComputePipeline = nullptr;
   MTL::RenderPipelineState *RenderPipeline = nullptr;
 
+  // Rasterization pipeline only state.
+  // These are part of the pipeline in DX and VK, but dynamic state in Metal.
+  // To have a shared API we store these here and set the state when the
+  // pipeline is used.
+  MTL::DepthStencilState *DepthStencilState = nullptr;
+  MTL::CullMode CullMode = MTL::CullModeNone;
+
   MTLPipelineState(llvm::StringRef Name, IRRootSignaturePtr RootSig,
                    std::unique_ptr<MTLTopLevelArgumentBuffer> ArgBuffer,
                    IRShaderReflectionPtr Reflection,
@@ -244,16 +251,21 @@ public:
 
   MTLPipelineState(llvm::StringRef Name, IRRootSignaturePtr RootSig,
                    std::unique_ptr<MTLTopLevelArgumentBuffer> ArgBuffer,
-                   MTL::RenderPipelineState *RenderPipeline)
+                   MTL::RenderPipelineState *RenderPipeline,
+                   MTL::DepthStencilState *DepthStencilState,
+                   MTL::CullMode CullMode)
       : offloadtest::PipelineState(GPUAPI::Metal), Name(Name),
         RootSig(std::move(RootSig)), ArgBuffer(std::move(ArgBuffer)),
-        RenderPipeline(RenderPipeline) {}
+        RenderPipeline(RenderPipeline), DepthStencilState(DepthStencilState),
+        CullMode(CullMode) {}
 
   ~MTLPipelineState() override {
     if (ComputePipeline)
       ComputePipeline->release();
     if (RenderPipeline)
       RenderPipeline->release();
+    if (DepthStencilState)
+      DepthStencilState->release();
   }
 
   static bool classof(const offloadtest::PipelineState *B) {
@@ -359,6 +371,9 @@ public:
 
   llvm::Expected<std::unique_ptr<offloadtest::ComputeEncoder>>
   createComputeEncoder() override;
+
+  llvm::Expected<std::unique_ptr<offloadtest::RenderEncoder>>
+  createRenderEncoder(const offloadtest::RenderPassBeginDesc &Desc) override;
 
 private:
   MTLCommandBuffer() : CommandBuffer(GPUAPI::Metal) {}
@@ -544,6 +559,262 @@ MTLCommandBuffer::createComputeEncoder() {
       NS::String::string("ComputeEncoder", NS::UTF8StringEncoding));
   return std::make_unique<MTLComputeEncoder>(CmdBuffer, NativeEncoder);
 }
+
+static MTL::PrimitiveType
+getMTLPrimitiveType(offloadtest::PrimitiveTopology Topology) {
+  switch (Topology) {
+  case offloadtest::PrimitiveTopology::TriangleList:
+    return MTL::PrimitiveTypeTriangle;
+  }
+  llvm_unreachable("All PrimitiveTopology cases handled");
+}
+
+static MTL::LoadAction getMTLLoadAction(offloadtest::LoadAction Action) {
+  switch (Action) {
+  case offloadtest::LoadAction::Load:
+    return MTL::LoadActionLoad;
+  case offloadtest::LoadAction::Clear:
+    return MTL::LoadActionClear;
+  case offloadtest::LoadAction::DontCare:
+    return MTL::LoadActionDontCare;
+  }
+  llvm_unreachable("All LoadAction cases handled");
+}
+
+static MTL::StoreAction getMTLStoreAction(offloadtest::StoreAction Action) {
+  switch (Action) {
+  case offloadtest::StoreAction::Store:
+    return MTL::StoreActionStore;
+  case offloadtest::StoreAction::DontCare:
+    return MTL::StoreActionDontCare;
+  }
+  llvm_unreachable("All StoreAction cases handled");
+}
+
+class MTLRenderEncoder : public offloadtest::RenderEncoder {
+  MTL::RenderCommandEncoder *RenderEnc = nullptr;
+
+  // Encoder contract: viewport and scissor must both be set before
+  // drawInstanced().
+  bool ViewportSet = false;
+  bool ScissorSet = false;
+
+public:
+  MTLRenderEncoder(MTL::RenderCommandEncoder *Enc)
+      : RenderEncoder(GPUAPI::Metal), RenderEnc(Enc) {}
+
+  ~MTLRenderEncoder() override { endEncoding(); }
+
+  static bool classof(const CommandEncoder *E) {
+    return E->getAPI() == GPUAPI::Metal;
+  }
+
+  /// Access the underlying Metal encoder for state that the abstract
+  /// RenderEncoder API does not yet cover (depth-stencil state, cull
+  /// mode, etc.). Returns nullptr after endEncoding().
+  MTL::RenderCommandEncoder *getNative() const { return RenderEnc; }
+
+  void pushDebugGroup(llvm::StringRef Label) override {
+    if (RenderEnc)
+      RenderEnc->pushDebugGroup(
+          NS::String::string(Label.data(), NS::UTF8StringEncoding));
+  }
+
+  void popDebugGroup() override {
+    if (RenderEnc)
+      RenderEnc->popDebugGroup();
+  }
+
+  void insertDebugSignpost(llvm::StringRef Label) override {
+    if (RenderEnc)
+      RenderEnc->insertDebugSignpost(
+          NS::String::string(Label.data(), NS::UTF8StringEncoding));
+  }
+
+  void setViewport(const offloadtest::Viewport &VP) override {
+    RenderEnc->setViewport(MTL::Viewport{
+        static_cast<double>(VP.X), static_cast<double>(VP.Y),
+        static_cast<double>(VP.Width), static_cast<double>(VP.Height),
+        static_cast<double>(VP.MinDepth), static_cast<double>(VP.MaxDepth)});
+    ViewportSet = true;
+  }
+
+  void setScissor(const offloadtest::ScissorRect &Rect) override {
+    MTL::ScissorRect MTLRect;
+    MTLRect.x = static_cast<NS::UInteger>(Rect.X);
+    MTLRect.y = static_cast<NS::UInteger>(Rect.Y);
+    MTLRect.width = Rect.Width;
+    MTLRect.height = Rect.Height;
+    RenderEnc->setScissorRect(MTLRect);
+    ScissorSet = true;
+  }
+
+  void setVertexBuffer(uint32_t Slot, offloadtest::Buffer *VB, size_t Offset,
+                       uint32_t /*Stride*/) override {
+    // Stride lives in the render pipeline's vertex descriptor in Metal,
+    // not on the buffer binding.
+    if (!VB) {
+      RenderEnc->setVertexBuffer(nullptr, 0, Slot);
+      return;
+    }
+    auto &MTLVB = llvm::cast<MTLBuffer>(*VB);
+    RenderEnc->setVertexBuffer(MTLVB.Buf, Offset, Slot);
+  }
+
+  llvm::Error drawInstanced(const offloadtest::PipelineState &PSO,
+                            offloadtest::PrimitiveTopology Topology,
+                            uint32_t VertexCount, uint32_t InstanceCount,
+                            uint32_t FirstVertex,
+                            uint32_t FirstInstance) override {
+    if (!ViewportSet)
+      return llvm::createStringError(std::errc::invalid_argument,
+                                     "Viewport must be set before drawing.");
+    if (!ScissorSet)
+      return llvm::createStringError(std::errc::invalid_argument,
+                                     "Scissor must be set before drawing.");
+
+    const auto &MTLPSO = llvm::cast<MTLPipelineState>(PSO);
+    if (!MTLPSO.RenderPipeline)
+      return llvm::createStringError(
+          std::errc::invalid_argument,
+          "PipelineState bound to drawInstanced() is not a render pipeline.");
+    RenderEnc->setRenderPipelineState(MTLPSO.RenderPipeline);
+    if (MTLPSO.DepthStencilState)
+      RenderEnc->setDepthStencilState(MTLPSO.DepthStencilState);
+    RenderEnc->setCullMode(MTLPSO.CullMode);
+
+    // IRRuntimeDrawPrimitives also sets the DrawParams / DrawInfo argument
+    // buffers that metal-irconverter consults for SV_VertexID and friends.
+    IRRuntimeDrawPrimitives(RenderEnc, getMTLPrimitiveType(Topology),
+                            static_cast<NS::UInteger>(FirstVertex),
+                            static_cast<NS::UInteger>(VertexCount),
+                            static_cast<NS::UInteger>(InstanceCount),
+                            static_cast<NS::UInteger>(FirstInstance));
+
+    return llvm::Error::success();
+  }
+
+  llvm::Error copyBufferToBuffer(offloadtest::Buffer & /*Src*/,
+                                 size_t /*SrcOffset*/,
+                                 offloadtest::Buffer & /*Dst*/,
+                                 size_t /*DstOffset*/,
+                                 size_t /*Size*/) override {
+    // A Metal render command encoder cannot record blit operations. The
+    // caller must end this encoder and use a separate compute or blit
+    // encoder for buffer copies.
+    return llvm::createStringError(
+        std::errc::not_supported,
+        "copyBufferToBuffer is not supported on a Metal render encoder; "
+        "end the encoder and use a separate compute or blit encoder.");
+  }
+
+  void endEncodingImpl() override {
+    if (RenderEnc) {
+      RenderEnc->popDebugGroup();
+      RenderEnc->endEncoding();
+      RenderEnc = nullptr;
+    }
+  }
+};
+
+llvm::Expected<std::unique_ptr<offloadtest::RenderEncoder>>
+MTLCommandBuffer::createRenderEncoder(
+    const offloadtest::RenderPassBeginDesc &Desc) {
+  if (!Desc.Pass)
+    return llvm::createStringError(
+        std::errc::invalid_argument,
+        "RenderPassBeginDesc is missing its RenderPass.");
+  auto &Pass = llvm::cast<MTLRenderPass>(*Desc.Pass);
+  const offloadtest::RenderPassDesc &PassDesc = Pass.Desc;
+
+  if (Desc.ColorAttachments.size() != PassDesc.ColorAttachments.size())
+    return llvm::createStringError(
+        std::errc::invalid_argument,
+        "RenderPassBeginDesc color attachment count does not match its "
+        "RenderPass.");
+  if (PassDesc.DepthStencil.has_value() != (Desc.DepthStencil != nullptr))
+    return llvm::createStringError(std::errc::invalid_argument,
+                                   "RenderPassBeginDesc depth-stencil "
+                                   "presence does not match its RenderPass.");
+
+  MTL::RenderPassDescriptor *MTLDesc =
+      MTL::RenderPassDescriptor::alloc()->init();
+  auto DescScope = llvm::scope_exit([&] { MTLDesc->release(); });
+
+  for (size_t I = 0; I < Desc.ColorAttachments.size(); ++I) {
+    if (!Desc.ColorAttachments[I])
+      return llvm::createStringError(
+          std::errc::invalid_argument,
+          "RenderPassBeginDesc has a null color attachment texture.");
+    auto &Tex = llvm::cast<MTLTexture>(*Desc.ColorAttachments[I]);
+    const offloadtest::ColorAttachmentFormatDesc &Color =
+        PassDesc.ColorAttachments[I];
+
+    auto *CADesc = MTL::RenderPassColorAttachmentDescriptor::alloc()->init();
+    CADesc->setTexture(Tex.Tex);
+    CADesc->setLoadAction(getMTLLoadAction(Color.Load));
+    CADesc->setStoreAction(getMTLStoreAction(Color.Store));
+    if (Color.Load == offloadtest::LoadAction::Clear) {
+      if (!Tex.getDesc().OptimizedClearValue) {
+        CADesc->release();
+        return llvm::createStringError(
+            std::errc::invalid_argument,
+            "LoadAction::Clear requires the render target to have been "
+            "created with an OptimizedClearValue.");
+      }
+      const auto *CV =
+          std::get_if<ClearColor>(&*Tex.getDesc().OptimizedClearValue);
+      assert(CV && "RenderTarget OptimizedClearValue must be a ClearColor");
+      CADesc->setClearColor(MTL::ClearColor(CV->R, CV->G, CV->B, CV->A));
+    }
+    MTLDesc->colorAttachments()->setObject(CADesc, I);
+    CADesc->release();
+  }
+
+  if (Desc.DepthStencil) {
+    auto &Tex = llvm::cast<MTLTexture>(*Desc.DepthStencil);
+    const offloadtest::DepthStencilAttachmentFormatDesc &DS =
+        *PassDesc.DepthStencil;
+
+    auto *DADesc = MTLDesc->depthAttachment();
+    DADesc->setTexture(Tex.Tex);
+    DADesc->setLoadAction(getMTLLoadAction(DS.DepthLoad));
+    DADesc->setStoreAction(getMTLStoreAction(DS.DepthStore));
+
+    auto *SADesc = MTLDesc->stencilAttachment();
+    SADesc->setTexture(Tex.Tex);
+    SADesc->setLoadAction(getMTLLoadAction(DS.StencilLoad));
+    SADesc->setStoreAction(getMTLStoreAction(DS.StencilStore));
+
+    if (DS.DepthLoad == offloadtest::LoadAction::Clear ||
+        DS.StencilLoad == offloadtest::LoadAction::Clear) {
+      if (!Tex.getDesc().OptimizedClearValue)
+        return llvm::createStringError(
+            std::errc::invalid_argument,
+            "LoadAction::Clear requires the depth-stencil texture to have "
+            "been created with an OptimizedClearValue.");
+      const auto *CV =
+          std::get_if<ClearDepthStencil>(&*Tex.getDesc().OptimizedClearValue);
+      assert(CV &&
+             "DepthStencil OptimizedClearValue must be a ClearDepthStencil");
+      if (DS.DepthLoad == offloadtest::LoadAction::Clear)
+        DADesc->setClearDepth(CV->Depth);
+      if (DS.StencilLoad == offloadtest::LoadAction::Clear)
+        SADesc->setClearStencil(CV->Stencil);
+    }
+  }
+
+  MTL::RenderCommandEncoder *NativeEncoder =
+      CmdBuffer->renderCommandEncoder(MTLDesc);
+  if (!NativeEncoder)
+    return llvm::createStringError(
+        std::errc::device_or_resource_busy,
+        "Failed to create Metal render command encoder.");
+  NativeEncoder->pushDebugGroup(
+      NS::String::string("RenderEncoder", NS::UTF8StringEncoding));
+  return std::make_unique<MTLRenderEncoder>(NativeEncoder);
+}
+
 class MTLDevice : public offloadtest::Device {
   Capabilities Caps;
   MTL::Device *Device;
@@ -570,11 +841,12 @@ class MTLDevice : public offloadtest::Device {
     NS::AutoreleasePool *Pool = nullptr;
     std::unique_ptr<MTLDescriptorHeap> DescHeap;
     std::unique_ptr<offloadtest::Buffer> VB;
-    std::unique_ptr<offloadtest::Texture> FrameBufferTexture;
+    std::unique_ptr<offloadtest::Texture> RenderTarget;
     std::unique_ptr<offloadtest::Buffer> FrameBufferReadback;
     std::unique_ptr<offloadtest::Texture> DepthStencil;
     std::unique_ptr<MTLCommandBuffer> CB;
     std::unique_ptr<PipelineState> Pipeline;
+    std::unique_ptr<offloadtest::RenderPass> RenderPass;
 
     llvm::SmallVector<DescriptorTable> DescTables;
     // TODO: Support RootResources?
@@ -1045,7 +1317,7 @@ class MTLDevice : public offloadtest::Device {
     if (!TexOrErr)
       return TexOrErr.takeError();
 
-    IS.FrameBufferTexture = std::move(*TexOrErr);
+    IS.RenderTarget = std::move(*TexOrErr);
 
     // Create a readback buffer for copying render target data to the CPU.
     BufferCreateDesc BufDesc = {};
@@ -1077,102 +1349,61 @@ class MTLDevice : public offloadtest::Device {
     if (auto Err = createDepthStencil(P, IS))
       return Err;
 
-    auto &FBTex = llvm::cast<MTLTexture>(*IS.FrameBufferTexture);
-    auto &DS = llvm::cast<MTLTexture>(*IS.DepthStencil);
-    auto &FBReadback = llvm::cast<MTLBuffer>(*IS.FrameBufferReadback);
+    const uint64_t Width = IS.RenderTarget->getDesc().Width;
+    const uint64_t Height = IS.RenderTarget->getDesc().Height;
 
-    MTL::RenderPassDescriptor *Desc =
-        MTL::RenderPassDescriptor::alloc()->init();
+    RenderPassBeginDesc BeginDesc = {};
+    BeginDesc.Pass = IS.RenderPass.get();
+    BeginDesc.ColorAttachments.push_back(IS.RenderTarget.get());
+    BeginDesc.DepthStencil = &IS.DepthStencil.get();
 
-    const uint64_t Width = FBTex.Desc.Width;
-    const uint64_t Height = FBTex.Desc.Height;
+    auto EncOrErr = IS.CB->createRenderEncoder(BeginDesc);
+    if (!EncOrErr)
+      return EncOrErr.takeError();
+    auto &Encoder = *EncOrErr.get();
 
-    // Color attachment.
-    auto *CADesc = MTL::RenderPassColorAttachmentDescriptor::alloc()->init();
-    CADesc->setTexture(FBTex.Tex);
-    CADesc->setLoadAction(MTL::LoadActionClear);
-    const auto *ColorCV =
-        std::get_if<ClearColor>(&*FBTex.Desc.OptimizedClearValue);
-    if (!ColorCV)
-      return llvm::createStringError(
-          std::errc::invalid_argument,
-          "Render target clear value must be a ClearColor.");
-
-    CADesc->setClearColor(
-        MTL::ClearColor(ColorCV->R, ColorCV->G, ColorCV->B, ColorCV->A));
-    CADesc->setStoreAction(MTL::StoreActionStore);
-    Desc->colorAttachments()->setObject(CADesc, 0);
-
-    // Depth/stencil attachment.
-    const auto *DepthCV =
-        std::get_if<ClearDepthStencil>(&*DS.Desc.OptimizedClearValue);
-    if (!DepthCV)
-      return llvm::createStringError(
-          std::errc::invalid_argument,
-          "Depth/stencil clear value must be a ClearDepthStencil.");
-
-    auto *DADesc = Desc->depthAttachment();
-    DADesc->setTexture(DS.Tex);
-    DADesc->setLoadAction(MTL::LoadActionClear);
-    DADesc->setClearDepth(DepthCV->Depth);
-    DADesc->setStoreAction(MTL::StoreActionDontCare);
-
-    auto *SADesc = Desc->stencilAttachment();
-    SADesc->setTexture(DS.Tex);
-    SADesc->setLoadAction(MTL::LoadActionClear);
-    SADesc->setClearStencil(DepthCV->Stencil);
-    SADesc->setStoreAction(MTL::StoreActionDontCare);
-
-    MTL::RenderCommandEncoder *CmdEncoder =
-        IS.CB->CmdBuffer->renderCommandEncoder(Desc);
-
-    const auto &PS = llvm::cast<MTLPipelineState>(IS.Pipeline.get());
-    CmdEncoder->setRenderPipelineState(PS->RenderPipeline);
-
-    // Configure depth stencil state: depth test enabled, write all, less.
-    MTL::DepthStencilDescriptor *DSDesc =
-        MTL::DepthStencilDescriptor::alloc()->init();
-    DSDesc->setDepthCompareFunction(MTL::CompareFunctionLess);
-    DSDesc->setDepthWriteEnabled(true);
-    MTL::DepthStencilState *DSState = Device->newDepthStencilState(DSDesc);
-    CmdEncoder->setDepthStencilState(DSState);
-    DSDesc->release();
-    DSState->release();
-
-    if (IS.DescHeap) {
-      IS.DescHeap->bind(CmdEncoder);
-      // NOTE: This code assumes 1 descriptor set (D3D12 backend also assumes
-      // this)
-      PS->ArgBuffer->setRootDescriptorTable(
-          0, IS.DescHeap->getGPUDescriptorHandleForHeapStart());
+    {
+      auto &MTLEncoder = llvm::cast<MTLRenderEncoder>(*Encoder);
+      auto *CmdEncoder = MTLEncoder.getNative();
+      if (IS.DescHeap) {
+        IS.DescHeap->bind(CmdEncoder);
+        // NOTE: This code assumes 1 descriptor set (D3D12 backend also assumes
+        // this)
+        PS->ArgBuffer->setRootDescriptorTable(
+            0, IS.DescHeap->getGPUDescriptorHandleForHeapStart());
+      }
+      PS->ArgBuffer->bind(CmdEncoder);
+      for (const auto &Table : IS.DescTables)
+        for (const auto &ResPair : Table.Resources)
+          for (const auto &ResSet : ResPair.second)
+            CmdEncoder->useResource(ResSet.Resource.get(),
+                                    MTL::ResourceUsageRead |
+                                        MTL::ResourceUsageWrite);
     }
-    PS->ArgBuffer->bind(CmdEncoder);
-    for (const auto &Table : IS.DescTables)
-      for (const auto &ResPair : Table.Resources)
-        for (const auto &ResSet : ResPair.second)
-          CmdEncoder->useResource(ResSet.Resource.get(),
-                                  MTL::ResourceUsageRead |
-                                      MTL::ResourceUsageWrite);
 
-    // Explicitly set viewport to texture dimensions.
-    CmdEncoder->setViewport(
-        MTL::Viewport{0.0, 0.0, (double)Width, (double)Height, 0.0, 1.0});
-    CmdEncoder->setCullMode(MTL::CullModeNone);
-    CmdEncoder->setFrontFacingWinding(MTL::WindingCounterClockwise);
+    Viewport VP;
+    VP.Width = static_cast<float>(Width);
+    VP.Height = static_cast<float>(Height);
+    Encoder.setViewport(VP);
+
+    ScissorRect Scissor;
+    Scissor.Width = static_cast<uint32_t>(Width);
+    Scissor.Height = static_cast<uint32_t>(Height);
+    Encoder.setScissor(Scissor);
 
     if (IS.VB)
-      // Bind vertex buffer at slot 0 to match the vertex descriptor which
-      // references buffer index 0.
-      CmdEncoder->setVertexBuffer(llvm::cast<MTLBuffer>(*IS.VB).Buf, 0, 0);
+      Encoder.setVertexBuffer(0, IS.VB.get(), 0, P.Bindings.getVertexStride());
 
-    // IRRuntimeDrawPrimitives also sets the DrawParams / DrawInfo argument
-    // buffers that metal-irconverter consults for SV_VertexID and friends.
-    IRRuntimeDrawPrimitives(CmdEncoder, MTL::PrimitiveTypeTriangle,
-                            NS::UInteger(0), P.getVertexCount());
-
-    CmdEncoder->endEncoding();
+    if (auto Err = Encoder.drawInstanced(*IS.Pipeline.get(),
+                                         PrimitiveTopology::TriangleList,
+                                         P.getVertexCount(),
+                                         /*InstanceCount=*/1))
+      return Err;
+    Encoder.endEncoding();
 
     // Blit the render target into the readback buffer for CPU access.
+    auto &FBTex = llvm::cast<MTLTexture>(*IS.RenderTarget);
+    auto &FBReadback = llvm::cast<MTLBuffer>(*IS.FrameBufferReadback);
     MTL::BlitCommandEncoder *Blit = IS.CB->CmdBuffer->blitCommandEncoder();
     const size_t ElemSize = getFormatSizeInBytes(FBTex.Desc.Fmt);
     const size_t RowBytes = Width * ElemSize;
@@ -1476,8 +1707,18 @@ public:
     if (Error)
       return toError(Error);
 
+    // Bake the depth-stencil state and cull mode into the pipeline, mirroring
+    // the DX12 / Vulkan PSO model.
+    MTL::DepthStencilDescriptor *DSDesc =
+        MTL::DepthStencilDescriptor::alloc()->init();
+    DSDesc->setDepthCompareFunction(MTL::CompareFunctionLess);
+    DSDesc->setDepthWriteEnabled(true);
+    MTL::DepthStencilState *DSState = Device->newDepthStencilState(DSDesc);
+    DSDesc->release();
+
     return std::make_unique<MTLPipelineState>(Name, std::move(RootSig),
-                                              std::move(ArgBuffer), PSO);
+                                              std::move(ArgBuffer), PSO,
+                                              DSState, MTL::CullModeNone);
   }
 
   llvm::Error executeProgram(Pipeline &P) override {
@@ -1568,6 +1809,27 @@ public:
       if (!PipelineStateOrErr)
         return PipelineStateOrErr.takeError();
       IS.Pipeline = std::move(*PipelineStateOrErr);
+
+      ColorAttachmentFormatDesc ColorAttachment = {};
+      ColorAttachment.Fmt = *FormatOrErr;
+      ColorAttachment.Load = LoadAction::Clear;
+      ColorAttachment.Store = StoreAction::Store;
+
+      DepthStencilAttachmentFormatDesc DSAttachment = {};
+      DSAttachment.Fmt = Format::D32FloatS8Uint;
+      DSAttachment.DepthLoad = LoadAction::Clear;
+      DSAttachment.DepthStore = StoreAction::DontCare;
+      DSAttachment.StencilLoad = LoadAction::Clear;
+      DSAttachment.StencilStore = StoreAction::DontCare;
+
+      RenderPassDesc PassDesc;
+      PassDesc.ColorAttachments.push_back(ColorAttachment);
+      PassDesc.DepthStencil = DSAttachment;
+
+      auto RenderPassOrErr = createRenderPass(PassDesc);
+      if (!RenderPassOrErr)
+        return RenderPassOrErr.takeError();
+      IS.RenderPass = std::move(*RenderPassOrErr);
 
       if (auto Err = createGraphicsCommands(P, IS))
         return Err;

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -593,6 +593,10 @@ class MTLRenderEncoder : public offloadtest::RenderEncoder {
 public:
   MTLRenderEncoder(MTL::RenderCommandEncoder *Enc)
       : RenderEncoder(GPUAPI::Metal), RenderEnc(Enc) {}
+  MTLRenderEncoder(const MTLRenderEncoder &CB) = delete;
+  MTLRenderEncoder(MTLRenderEncoder &&CB) = delete;
+  MTLRenderEncoder &operator=(MTLRenderEncoder &CB) = delete;
+  MTLRenderEncoder &operator=(const MTLRenderEncoder &&CB) = delete;
 
   ~MTLRenderEncoder() override { endEncoding(); }
 

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -716,6 +716,9 @@ MTLCommandBuffer::createRenderEncoder(
                                    "RenderPassBeginDesc depth-stencil "
                                    "presence does not match its RenderPass.");
 
+  uint32_t Width = ~0u;
+  uint32_t Height = ~0u;
+
   MTL::RenderPassDescriptor *MTLDesc =
       MTL::RenderPassDescriptor::alloc()->init();
   auto DescScope = llvm::scope_exit([&] { MTLDesc->release(); });
@@ -748,6 +751,11 @@ MTLCommandBuffer::createRenderEncoder(
     }
     MTLDesc->colorAttachments()->setObject(CADesc, I);
     CADesc->release();
+
+    if (Tex.Desc.Width < Width)
+      Width = Tex.Desc.Width;
+    if (Tex.Desc.Height < Height)
+      Height = Tex.Desc.Height;
   }
 
   if (Desc.DepthStencil) {
@@ -781,7 +789,20 @@ MTLCommandBuffer::createRenderEncoder(
       if (DS.StencilLoad == offloadtest::LoadAction::Clear)
         SADesc->setClearStencil(CV->Stencil);
     }
+
+    if (Tex.Desc.Width < Width)
+      Width = Tex.Desc.Width;
+    if (Tex.Desc.Height < Height)
+      Height = Tex.Desc.Height;
   }
+
+  if (Width == ~0u && Height == ~0u) {
+    Width = 0;
+    Height = 0;
+  }
+
+  MTLDesc->setRenderTargetWidth(Width);
+  MTLDesc->setRenderTargetHeight(Height);
 
   MTL::RenderCommandEncoder *NativeEncoder =
       CmdBuffer->renderCommandEncoder(MTLDesc);

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -694,20 +694,6 @@ public:
     return llvm::Error::success();
   }
 
-  llvm::Error copyBufferToBuffer(offloadtest::Buffer & /*Src*/,
-                                 size_t /*SrcOffset*/,
-                                 offloadtest::Buffer & /*Dst*/,
-                                 size_t /*DstOffset*/,
-                                 size_t /*Size*/) override {
-    // A Metal render command encoder cannot record blit operations. The
-    // caller must end this encoder and use a separate compute or blit
-    // encoder for buffer copies.
-    return llvm::createStringError(
-        std::errc::not_supported,
-        "copyBufferToBuffer is not supported on a Metal render encoder; "
-        "end the encoder and use a separate compute or blit encoder.");
-  }
-
   void endEncodingImpl() override {
     if (RenderEnc) {
       RenderEnc->popDebugGroup();

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -314,6 +314,8 @@ public:
       Tex->release();
   }
 
+  const TextureCreateDesc &getDesc() const override { return Desc; }
+
   static bool classof(const offloadtest::Texture *T) {
     return T->getAPI() == GPUAPI::Metal;
   }

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -647,12 +647,12 @@ public:
   void setVertexBuffer(uint32_t Slot, offloadtest::Buffer *VB, size_t Offset,
                        uint32_t /*Stride*/) override {
     // Stride is needed in DX12 at binding time, ignore parameter here.
-    if (!VB) {
+    if (VB) {
+      auto &MTLVB = llvm::cast<MTLBuffer>(*VB);
+      RenderEnc->setVertexBuffer(MTLVB.Buf, Offset, Slot);
+    } else {
       RenderEnc->setVertexBuffer(nullptr, 0, Slot);
-      return;
     }
-    auto &MTLVB = llvm::cast<MTLBuffer>(*VB);
-    RenderEnc->setVertexBuffer(MTLVB.Buf, Offset, Slot);
   }
 
   llvm::Error drawInstanced(const offloadtest::PipelineState &PSO,

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -319,6 +319,22 @@ public:
   }
 };
 
+/// Metal has no standalone render-pass object: render pass info lives on
+/// MTLRenderPassDescriptor and is consumed when a render command encoder
+/// is created. We therefore just stash the descriptor for the encoder to
+/// translate later.
+class MTLRenderPass final : public offloadtest::RenderPass {
+public:
+  offloadtest::RenderPassDesc Desc;
+
+  explicit MTLRenderPass(offloadtest::RenderPassDesc Desc)
+      : RenderPass(GPUAPI::Metal), Desc(std::move(Desc)) {}
+
+  static bool classof(const offloadtest::RenderPass *RP) {
+    return RP->getAPI() == GPUAPI::Metal;
+  }
+};
+
 class MTLCommandBuffer : public offloadtest::CommandBuffer {
 public:
   MTL::CommandBuffer *CmdBuffer = nullptr;
@@ -1261,6 +1277,11 @@ public:
   llvm::Expected<std::unique_ptr<offloadtest::CommandBuffer>>
   createCommandBuffer() override {
     return MTLCommandBuffer::create(GraphicsQueue.Queue);
+  }
+
+  llvm::Expected<std::unique_ptr<offloadtest::RenderPass>>
+  createRenderPass(const offloadtest::RenderPassDesc &Desc) override {
+    return std::make_unique<MTLRenderPass>(Desc);
   }
 
   llvm::Expected<std::unique_ptr<PipelineState>>

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -605,8 +605,8 @@ public:
   }
 
   /// Access the underlying Metal encoder for state that the abstract
-  /// RenderEncoder API does not yet cover (depth-stencil state, cull
-  /// mode, etc.). Returns nullptr after endEncoding().
+  /// RenderEncoder API does not yet cover.
+  /// Returns nullptr after endEncoding().
   MTL::RenderCommandEncoder *getNative() const { return RenderEnc; }
 
   void pushDebugGroup(llvm::StringRef Label) override {

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -1330,7 +1330,7 @@ class MTLDevice : public offloadtest::Device {
     RenderPassBeginDesc BeginDesc = {};
     BeginDesc.Pass = IS.RenderPass.get();
     BeginDesc.ColorAttachments.push_back(IS.RenderTarget.get());
-    BeginDesc.DepthStencil = &IS.DepthStencil.get();
+    BeginDesc.DepthStencil = IS.DepthStencil.get();
 
     auto EncOrErr = IS.CB->createRenderEncoder(BeginDesc);
     if (!EncOrErr)
@@ -1338,7 +1338,8 @@ class MTLDevice : public offloadtest::Device {
     auto &Encoder = *EncOrErr.get();
 
     {
-      auto &MTLEncoder = llvm::cast<MTLRenderEncoder>(*Encoder);
+      auto &MTLEncoder = llvm::cast<MTLRenderEncoder>(Encoder);
+      const auto &PS = llvm::cast<MTLPipelineState>(IS.Pipeline.get());
       auto *CmdEncoder = MTLEncoder.getNative();
       if (IS.DescHeap) {
         IS.DescHeap->bind(CmdEncoder);

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -610,20 +610,20 @@ public:
   MTL::RenderCommandEncoder *getNative() const { return RenderEnc; }
 
   void pushDebugGroup(llvm::StringRef Label) override {
-    if (RenderEnc)
-      RenderEnc->pushDebugGroup(
-          NS::String::string(Label.data(), NS::UTF8StringEncoding));
+    assert(RenderEnc);
+    RenderEnc->pushDebugGroup(
+        NS::String::string(Label.data(), NS::UTF8StringEncoding));
   }
 
   void popDebugGroup() override {
-    if (RenderEnc)
-      RenderEnc->popDebugGroup();
+    assert(RenderEnc);
+    RenderEnc->popDebugGroup();
   }
 
   void insertDebugSignpost(llvm::StringRef Label) override {
-    if (RenderEnc)
-      RenderEnc->insertDebugSignpost(
-          NS::String::string(Label.data(), NS::UTF8StringEncoding));
+    assert(RenderEnc);
+    RenderEnc->insertDebugSignpost(
+        NS::String::string(Label.data(), NS::UTF8StringEncoding));
   }
 
   void setViewport(const offloadtest::Viewport &VP) override {

--- a/lib/API/Util.cpp
+++ b/lib/API/Util.cpp
@@ -1,0 +1,49 @@
+#include "Util.h"
+
+#include "API/Texture.h"
+
+llvm::Error offloadtest::findAndValidateRenderPassTextureSize(
+    const RenderPassBeginDesc &Desc, uint32_t *OutWidth, uint32_t *OutHeight) {
+  // Vulkan and Metal require us to pass a size for the render pass.
+  // DX12 doesn't require us to pass the size, but those require all render
+  // targets and depth stencil targets to have the same size.
+
+  bool AnyTexture = false;
+  uint32_t Width = 0, Height = 0;
+  for (const auto &Attachment : Desc.ColorAttachments) {
+    const TextureCreateDesc &TexDesc = Attachment->getDesc();
+
+    if (!AnyTexture) {
+      Width = TexDesc.Width;
+      Height = TexDesc.Height;
+      AnyTexture = true;
+    } else {
+      if (TexDesc.Width != Width || TexDesc.Height != Height)
+        return llvm::createStringError(
+            "All Render Targets and Depth Stencil Targets in a render pass "
+            "must have the same size.");
+    }
+  }
+
+  if (Desc.DepthStencil) {
+    const TextureCreateDesc &TexDesc = Desc.DepthStencil->getDesc();
+
+    if (!AnyTexture) {
+      Width = TexDesc.Width;
+      Height = TexDesc.Height;
+      AnyTexture = true;
+    } else {
+      if (TexDesc.Width != Width || TexDesc.Height != Height)
+        return llvm::createStringError(
+            "All Render Targets and Depth Stencil Targets in a render pass "
+            "must have the same size.");
+    }
+  }
+
+  if (OutWidth)
+    *OutWidth = Width;
+  if (OutHeight)
+    *OutHeight = Height;
+
+  return llvm::Error::success();
+}

--- a/lib/API/Util.h
+++ b/lib/API/Util.h
@@ -1,0 +1,30 @@
+//===- Util.h - Internal shared helper functions --------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Helper functions that are shared between the various backends, but which
+// should not be exposed to the uesr of the graphics layer.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef OFFLOADTEST_API_UTIL_H
+#define OFFLOADTEST_API_UTIL_H
+
+#include "API/API.h"
+#include "API/CommandBuffer.h"
+
+#include <cstdint>
+
+namespace offloadtest {
+
+llvm::Error findAndValidateRenderPassTextureSize(const RenderPassBeginDesc &,
+                                                 uint32_t *OutWidth,
+                                                 uint32_t *OutHeight);
+
+} // namespace offloadtest
+
+#endif // OFFLOADTEST_API_UTIL_H

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -642,7 +642,7 @@ public:
   }
 
   void pushDebugGroup(llvm::StringRef Label) {
-    if (CmdBeginDebugUtilsLabel)
+    if (!CmdBeginDebugUtilsLabel)
       return;
     VkDebugUtilsLabelEXT LabelInfo = {};
     LabelInfo.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT;

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -878,12 +878,12 @@ public:
     // Stride is needed in DX12 at binding time, ignore parameter here.
     if (!VB) {
       VkBuffer NullBuf = VK_NULL_HANDLE;
-      VkDeviceSize Zero = 0;
+      const VkDeviceSize Zero = 0;
       vkCmdBindVertexBuffers(CB.CmdBuffer, Slot, 1, &NullBuf, &Zero);
       return;
     }
     VkBuffer Handle = llvm::cast<VulkanBuffer>(*VB).Buffer;
-    VkDeviceSize VKOffset = Offset;
+    const VkDeviceSize VKOffset = Offset;
     vkCmdBindVertexBuffers(CB.CmdBuffer, Slot, 1, &Handle, &VKOffset);
   }
 
@@ -1478,7 +1478,7 @@ public:
     // Build a RenderPassDesc from the PSO's RT/DS formats.
     RenderPassDesc PassDesc;
     PassDesc.ColorAttachments.reserve(RTFormats.size());
-    for (Format F : RTFormats) {
+    for (const Format F : RTFormats) {
       ColorAttachmentFormatDesc CA = {};
       CA.Fmt = F;
       CA.Load = LoadAction::DontCare;
@@ -1506,7 +1506,7 @@ public:
         vkDestroyDescriptorSetLayout(Device, L, nullptr);
       return RenderPassOrErr.takeError();
     }
-    std::unique_ptr<offloadtest::RenderPass> RenderPass =
+    const std::unique_ptr<offloadtest::RenderPass> RenderPass =
         std::move(*RenderPassOrErr);
     VkRenderPass RenderPassHandle =
         llvm::cast<VulkanRenderPass>(*RenderPass).Handle;

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -638,18 +638,12 @@ public:
     PendingDstAccess = 0;
   }
 
-  /// Render passes and framebuffers built by render encoders for this
-  /// command buffer. The encoder records vkCmdBeginRenderPass against these,
-  /// so they must remain alive until the command buffer is submitted and
-  /// finishes execution. Destroyed alongside the command buffer.
-  llvm::SmallVector<VkRenderPass, 4> OwnedRenderPasses;
+  /// Keep-alive list for Framebuffers constructed by RencderEncoders.
   llvm::SmallVector<VkFramebuffer, 4> OwnedFramebuffers;
 
   ~VulkanCommandBuffer() override {
     for (VkFramebuffer FB : OwnedFramebuffers)
       vkDestroyFramebuffer(Device, FB, nullptr);
-    for (VkRenderPass RP : OwnedRenderPasses)
-      vkDestroyRenderPass(Device, RP, nullptr);
     if (CmdPool != VK_NULL_HANDLE)
       vkDestroyCommandPool(Device, CmdPool, nullptr);
   }
@@ -793,9 +787,6 @@ static VkAttachmentStoreOp getVkStoreOp(offloadtest::StoreAction Action) {
   llvm_unreachable("All StoreAction cases handled");
 }
 
-/// Vulkan render pass — owns a VkRenderPass built from the descriptor's
-/// formats and load/store actions. The handle outlives any encoder built
-/// against this pass and is destroyed with the RenderPass object.
 class VulkanRenderPass final : public offloadtest::RenderPass {
 public:
   VkDevice Dev;
@@ -884,8 +875,7 @@ public:
 
   void setVertexBuffer(uint32_t Slot, offloadtest::Buffer *VB, size_t Offset,
                        uint32_t /*Stride*/) override {
-    // Stride is part of the pipeline's input layout in Vulkan, not the
-    // buffer binding. The DX12 backend needs it; we don't.
+    // Stride is needed in DX12 at binding time, ignore parameter here.
     if (!VB) {
       VkBuffer NullBuf = VK_NULL_HANDLE;
       VkDeviceSize Zero = 0;
@@ -1973,11 +1963,6 @@ public:
 
   llvm::Expected<std::unique_ptr<offloadtest::RenderPass>>
   createRenderPass(const offloadtest::RenderPassDesc &Desc) override {
-    // Build a VkRenderPass from the descriptor's attachment formats and
-    // load/store actions. Initial layout for Load-action attachments is the
-    // standard attachment layout (caller's responsibility); for Clear /
-    // DontCare it's UNDEFINED. Final layout is always the standard
-    // attachment layout — caller does any post-pass transitions.
     llvm::SmallVector<VkAttachmentDescription, 9> Attachments;
     llvm::SmallVector<VkAttachmentReference, 8> ColorRefs;
 

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -930,19 +930,6 @@ public:
     return llvm::Error::success();
   }
 
-  llvm::Error copyBufferToBuffer(offloadtest::Buffer &Src, size_t SrcOffset,
-                                 offloadtest::Buffer &Dst, size_t DstOffset,
-                                 size_t Size) override {
-    auto &VKSrc = static_cast<VulkanBuffer &>(Src);
-    auto &VKDst = static_cast<VulkanBuffer &>(Dst);
-    VkBufferCopy Region = {};
-    Region.srcOffset = SrcOffset;
-    Region.dstOffset = DstOffset;
-    Region.size = Size;
-    vkCmdCopyBuffer(CB.CmdBuffer, VKSrc.Buffer, VKDst.Buffer, 1, &Region);
-    return llvm::Error::success();
-  }
-
   void endEncodingImpl() override {
     vkCmdEndRenderPass(CB.CmdBuffer);
     popDebugGroup();

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -933,8 +933,8 @@ VulkanCommandBuffer::createRenderEncoder(
 
   llvm::SmallVector<VkImageView, 9> Views;
   llvm::SmallVector<VkClearValue, 9> ClearValues;
-  uint32_t Width = 0;
-  uint32_t Height = 0;
+  uint32_t Width = ~0u;
+  uint32_t Height = ~0u;
 
   for (size_t I = 0; I < Desc.ColorAttachments.size(); ++I) {
     if (!Desc.ColorAttachments[I])
@@ -963,9 +963,9 @@ VulkanCommandBuffer::createRenderEncoder(
     }
     ClearValues.push_back(CV);
 
-    if (Tex.Desc.Width > Width)
+    if (Tex.Desc.Width < Width)
       Width = Tex.Desc.Width;
-    if (Tex.Desc.Height > Height)
+    if (Tex.Desc.Height < Height)
       Height = Tex.Desc.Height;
   }
 
@@ -994,9 +994,9 @@ VulkanCommandBuffer::createRenderEncoder(
     }
     ClearValues.push_back(CV);
 
-    if (Tex.Desc.Width > Width)
+    if (Tex.Desc.Width < Width)
       Width = Tex.Desc.Width;
-    if (Tex.Desc.Height > Height)
+    if (Tex.Desc.Height < Height)
       Height = Tex.Desc.Height;
   }
 

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -1971,6 +1971,11 @@ public:
       AD.storeOp = getVkStoreOp(Color.Store);
       AD.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
       AD.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+      // If we are loading, the layout MUST be defined and in color attachment
+      // optimal state.
+      // If we are NOT loading (clearing or don't care), we are discarding the
+      // original contents of the texture, and use an undefined layout. This
+      // allows us to use _any_ layout including unitialized textures.
       AD.initialLayout = Color.Load == LoadAction::Load
                              ? VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL
                              : VK_IMAGE_LAYOUT_UNDEFINED;

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -20,6 +20,8 @@
 #include "llvm/Support/Error.h"
 #include "llvm/Support/FormatVariadic.h"
 
+#include "../Util.h"
+
 #include <algorithm>
 #include <cmath>
 #include <map>
@@ -922,7 +924,6 @@ VulkanCommandBuffer::createRenderEncoder(
         "RenderPassBeginDesc is missing its RenderPass.");
   auto &VKPass = llvm::cast<VulkanRenderPass>(*Desc.Pass);
   const offloadtest::RenderPassDesc &PassDesc = VKPass.Desc;
-
   if (Desc.ColorAttachments.size() != PassDesc.ColorAttachments.size())
     return llvm::createStringError(
         std::errc::invalid_argument,
@@ -933,10 +934,12 @@ VulkanCommandBuffer::createRenderEncoder(
                                    "RenderPassBeginDesc depth-stencil "
                                    "presence does not match its RenderPass.");
 
+  uint32_t Width = 0, Height = 0;
+  if (auto Err = findAndValidateRenderPassTextureSize(Desc, &Width, &Height))
+    return Err;
+
   llvm::SmallVector<VkImageView, 9> Views;
   llvm::SmallVector<VkClearValue, 9> ClearValues;
-  uint32_t Width = ~0u;
-  uint32_t Height = ~0u;
 
   for (size_t I = 0; I < Desc.ColorAttachments.size(); ++I) {
     if (!Desc.ColorAttachments[I])
@@ -964,11 +967,6 @@ VulkanCommandBuffer::createRenderEncoder(
       CV.color = {{ColorCV->R, ColorCV->G, ColorCV->B, ColorCV->A}};
     }
     ClearValues.push_back(CV);
-
-    if (Tex.Desc.Width < Width)
-      Width = Tex.Desc.Width;
-    if (Tex.Desc.Height < Height)
-      Height = Tex.Desc.Height;
   }
 
   if (Desc.DepthStencil) {
@@ -995,11 +993,6 @@ VulkanCommandBuffer::createRenderEncoder(
       CV.depthStencil = {DepthCV->Depth, DepthCV->Stencil};
     }
     ClearValues.push_back(CV);
-
-    if (Tex.Desc.Width < Width)
-      Width = Tex.Desc.Width;
-    if (Tex.Desc.Height < Height)
-      Height = Tex.Desc.Height;
   }
 
   VkFramebufferCreateInfo FBCI = {};

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -561,6 +561,9 @@ public:
   PFN_vkCmdEndDebugUtilsLabelEXT CmdEndDebugUtilsLabel = nullptr;
   PFN_vkCmdInsertDebugUtilsLabelEXT CmdInsertDebugUtilsLabel = nullptr;
 
+  /// Keep-alive list for Framebuffers constructed by RencderEncoders.
+  llvm::SmallVector<VkFramebuffer, 4> OwnedFramebuffers;
+
   static llvm::Expected<std::unique_ptr<VulkanCommandBuffer>>
   create(VkDevice Device, uint32_t QueueFamilyIdx,
          PFN_vkCmdBeginDebugUtilsLabelEXT CmdBeginDebugUtilsLabel,
@@ -638,8 +641,28 @@ public:
     PendingDstAccess = 0;
   }
 
-  /// Keep-alive list for Framebuffers constructed by RencderEncoders.
-  llvm::SmallVector<VkFramebuffer, 4> OwnedFramebuffers;
+  void pushDebugGroup(llvm::StringRef Label) {
+    if (CmdBeginDebugUtilsLabel)
+      return;
+    VkDebugUtilsLabelEXT LabelInfo = {};
+    LabelInfo.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT;
+    LabelInfo.pLabelName = Label.data();
+    CmdBeginDebugUtilsLabel(CmdBuffer, &LabelInfo);
+  }
+
+  void popDebugGroup() {
+    if (CmdEndDebugUtilsLabel)
+      CmdEndDebugUtilsLabel(CmdBuffer);
+  }
+
+  void insertDebugSignpost(llvm::StringRef Label) {
+    if (!CmdInsertDebugUtilsLabel)
+      return;
+    VkDebugUtilsLabelEXT LabelInfo = {};
+    LabelInfo.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT;
+    LabelInfo.pLabelName = Label.data();
+    CmdInsertDebugUtilsLabel(CmdBuffer, &LabelInfo);
+  }
 
   ~VulkanCommandBuffer() override {
     for (VkFramebuffer FB : OwnedFramebuffers)
@@ -681,26 +704,11 @@ public:
   }
 
   void pushDebugGroup(llvm::StringRef Label) override {
-    if (!CB.CmdBeginDebugUtilsLabel)
-      return;
-    VkDebugUtilsLabelEXT LabelInfo = {};
-    LabelInfo.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT;
-    LabelInfo.pLabelName = Label.data();
-    CB.CmdBeginDebugUtilsLabel(CB.CmdBuffer, &LabelInfo);
+    CB.pushDebugGroup(Label);
   }
-
-  void popDebugGroup() override {
-    if (CB.CmdEndDebugUtilsLabel)
-      CB.CmdEndDebugUtilsLabel(CB.CmdBuffer);
-  }
-
+  void popDebugGroup() override { CB.popDebugGroup(); }
   void insertDebugSignpost(llvm::StringRef Label) override {
-    if (!CB.CmdInsertDebugUtilsLabel)
-      return;
-    VkDebugUtilsLabelEXT LabelInfo = {};
-    LabelInfo.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT;
-    LabelInfo.pLabelName = Label.data();
-    CB.CmdInsertDebugUtilsLabel(CB.CmdBuffer, &LabelInfo);
+    CB.insertDebugSignpost(Label);
   }
 
   llvm::Error dispatch(uint32_t GroupCountX, uint32_t GroupCountY,
@@ -830,26 +838,11 @@ public:
   }
 
   void pushDebugGroup(llvm::StringRef Label) override {
-    if (!CB.CmdBeginDebugUtilsLabel)
-      return;
-    VkDebugUtilsLabelEXT LabelInfo = {};
-    LabelInfo.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT;
-    LabelInfo.pLabelName = Label.data();
-    CB.CmdBeginDebugUtilsLabel(CB.CmdBuffer, &LabelInfo);
+    CB.pushDebugGroup(Label);
   }
-
-  void popDebugGroup() override {
-    if (CB.CmdEndDebugUtilsLabel)
-      CB.CmdEndDebugUtilsLabel(CB.CmdBuffer);
-  }
-
+  void popDebugGroup() override { CB.popDebugGroup(); }
   void insertDebugSignpost(llvm::StringRef Label) override {
-    if (!CB.CmdInsertDebugUtilsLabel)
-      return;
-    VkDebugUtilsLabelEXT LabelInfo = {};
-    LabelInfo.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT;
-    LabelInfo.pLabelName = Label.data();
-    CB.CmdInsertDebugUtilsLabel(CB.CmdBuffer, &LabelInfo);
+    CB.insertDebugSignpost(Label);
   }
 
   void setViewport(const offloadtest::Viewport &VP) override {

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -1495,7 +1495,7 @@ public:
     // NOTE: After pipeline creation this render pass can be dropped. Later
     // render passes just need to be compatible with this render pass, or in
     // other words: the format, sample count and number of targets (rt and ds),
-    // need to match.
+    // need to match, but Load/Store ops (and initial/final layout) are ignored.
     auto RenderPassOrErr = createRenderPass(PassDesc);
     if (!RenderPassOrErr) {
       vkDestroyPipelineLayout(Device, PipelineLayout, nullptr);

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -825,7 +825,9 @@ class VulkanRenderEncoder : public offloadtest::RenderEncoder {
 
 public:
   VulkanRenderEncoder(VulkanCommandBuffer &CB)
-      : RenderEncoder(GPUAPI::Vulkan), CB(CB) {}
+      : RenderEncoder(GPUAPI::Vulkan), CB(CB) {
+    pushDebugGroup("RenderEncoder");
+  }
   VulkanRenderEncoder(const VulkanRenderEncoder &CB) = delete;
   VulkanRenderEncoder(VulkanRenderEncoder &&CB) = delete;
   VulkanRenderEncoder &operator=(VulkanRenderEncoder &CB) = delete;
@@ -1031,9 +1033,7 @@ VulkanCommandBuffer::createRenderEncoder(
 
   vkCmdBeginRenderPass(CmdBuffer, &BeginInfo, VK_SUBPASS_CONTENTS_INLINE);
 
-  auto Enc = std::make_unique<VulkanRenderEncoder>(*this);
-  Enc->pushDebugGroup("RenderEncoder");
-  return Enc;
+  return std::make_unique<VulkanRenderEncoder>(*this);
 }
 
 class VulkanDevice : public offloadtest::Device {

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -736,19 +736,15 @@ public:
   VkPipeline Pipeline;
   VkPipelineLayout Layout;
   llvm::SmallVector<VkDescriptorSetLayout> SetLayouts;
-  VkRenderPass RenderPass;
 
   VulkanPipelineState(llvm::StringRef Name, VkDevice Dev, VkPipeline Pipeline,
                       VkPipelineLayout Layout,
-                      llvm::SmallVector<VkDescriptorSetLayout> SetLayouts,
-                      VkRenderPass RenderPass)
+                      llvm::SmallVector<VkDescriptorSetLayout> SetLayouts)
       : offloadtest::PipelineState(GPUAPI::Vulkan), Name(Name.str()), Dev(Dev),
-        Pipeline(Pipeline), Layout(Layout), SetLayouts(std::move(SetLayouts)),
-        RenderPass(RenderPass) {}
+        Pipeline(Pipeline), Layout(Layout), SetLayouts(std::move(SetLayouts)) {}
 
   ~VulkanPipelineState() override {
     vkDestroyPipeline(Dev, Pipeline, nullptr);
-    vkDestroyRenderPass(Dev, RenderPass, nullptr);
     vkDestroyPipelineLayout(Dev, Layout, nullptr);
     for (VkDescriptorSetLayout L : SetLayouts)
       vkDestroyDescriptorSetLayout(Dev, L, nullptr);
@@ -758,6 +754,53 @@ public:
     return B->getAPI() == GPUAPI::Vulkan;
   }
 };
+
+static VkAttachmentLoadOp getVkLoadOp(offloadtest::LoadAction Action) {
+  switch (Action) {
+  case offloadtest::LoadAction::Load:
+    return VK_ATTACHMENT_LOAD_OP_LOAD;
+  case offloadtest::LoadAction::Clear:
+    return VK_ATTACHMENT_LOAD_OP_CLEAR;
+  case offloadtest::LoadAction::DontCare:
+    return VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+  }
+  llvm_unreachable("All LoadAction cases handled");
+}
+
+static VkAttachmentStoreOp getVkStoreOp(offloadtest::StoreAction Action) {
+  switch (Action) {
+  case offloadtest::StoreAction::Store:
+    return VK_ATTACHMENT_STORE_OP_STORE;
+  case offloadtest::StoreAction::DontCare:
+    return VK_ATTACHMENT_STORE_OP_DONT_CARE;
+  }
+  llvm_unreachable("All StoreAction cases handled");
+}
+
+/// Vulkan render pass — owns a VkRenderPass built from the descriptor's
+/// formats and load/store actions. The handle outlives any encoder built
+/// against this pass and is destroyed with the RenderPass object.
+class VulkanRenderPass final : public offloadtest::RenderPass {
+public:
+  VkDevice Dev;
+  VkRenderPass Handle;
+  offloadtest::RenderPassDesc Desc;
+
+  VulkanRenderPass(VkDevice Dev, VkRenderPass Handle,
+                   offloadtest::RenderPassDesc Desc)
+      : RenderPass(GPUAPI::Vulkan), Dev(Dev), Handle(Handle),
+        Desc(std::move(Desc)) {}
+
+  ~VulkanRenderPass() override {
+    if (Handle != VK_NULL_HANDLE)
+      vkDestroyRenderPass(Dev, Handle, nullptr);
+  }
+
+  static bool classof(const offloadtest::RenderPass *RP) {
+    return RP->getAPI() == GPUAPI::Vulkan;
+  }
+};
+
 class VulkanDevice : public offloadtest::Device {
 private:
   std::shared_ptr<VulkanInstance> Instance;
@@ -845,6 +888,7 @@ private:
 
     // FrameBuffer associated data for offscreen rendering.
     VkFramebuffer FrameBuffer = VK_NULL_HANDLE;
+    std::unique_ptr<offloadtest::RenderPass> RenderPass;
     std::unique_ptr<offloadtest::Texture> RenderTarget;
     std::unique_ptr<offloadtest::Buffer> RTReadback;
     std::unique_ptr<offloadtest::Texture> DepthStencil;
@@ -1175,8 +1219,7 @@ public:
     vkDestroyShaderModule(Device, CSModule, nullptr);
 
     return std::make_unique<VulkanPipelineState>(
-        Name, Device, Pipeline, PipelineLayout, std::move(SetLayouts),
-        VK_NULL_HANDLE);
+        Name, Device, Pipeline, PipelineLayout, std::move(SetLayouts));
   }
 
   llvm::Expected<std::unique_ptr<PipelineState>>
@@ -1194,20 +1237,45 @@ public:
                                         PipelineLayout))
       return Err;
 
-    auto RenderPassOrErr = createRenderPass(RTFormats, DSFormat);
+    // Build a RenderPassDesc from the PSO's RT/DS formats.
+    RenderPassDesc PassDesc;
+    PassDesc.ColorAttachments.reserve(RTFormats.size());
+    for (Format F : RTFormats) {
+      ColorAttachmentFormatDesc CA = {};
+      CA.Fmt = F;
+      CA.Load = LoadAction::DontCare;
+      CA.Store = StoreAction::DontCare;
+      PassDesc.ColorAttachments.push_back(CA);
+    }
+    if (DSFormat) {
+      DepthStencilAttachmentFormatDesc DS = {};
+      DS.Fmt = *DSFormat;
+      DS.DepthLoad = LoadAction::DontCare;
+      DS.DepthStore = StoreAction::DontCare;
+      DS.StencilLoad = LoadAction::DontCare;
+      DS.StencilStore = StoreAction::DontCare;
+      PassDesc.DepthStencil = DS;
+    }
+
+    // NOTE: After pipeline creation this render pass can be dropped. Later
+    // render passes just need to be compatible with this render pass, or in
+    // other words: the format, sample count and number of targets (rt and ds),
+    // need to match.
+    auto RenderPassOrErr = createRenderPass(PassDesc);
     if (!RenderPassOrErr) {
       vkDestroyPipelineLayout(Device, PipelineLayout, nullptr);
       for (auto *L : SetLayouts)
         vkDestroyDescriptorSetLayout(Device, L, nullptr);
       return RenderPassOrErr.takeError();
     }
-    VkRenderPass RenderPass = *RenderPassOrErr;
-    llvm::outs() << "Render pass created.\n";
+    std::unique_ptr<offloadtest::RenderPass> RenderPass =
+        std::move(*RenderPassOrErr);
+    VkRenderPass RenderPassHandle =
+        llvm::cast<VulkanRenderPass>(*RenderPass).Handle;
 
     std::vector<VkShaderModule> ShaderModules;
     auto VSModOrErr = createShaderModule(VS.Shader, "vertex");
     if (!VSModOrErr) {
-      vkDestroyRenderPass(Device, RenderPass, nullptr);
       vkDestroyPipelineLayout(Device, PipelineLayout, nullptr);
       for (auto *L : SetLayouts)
         vkDestroyDescriptorSetLayout(Device, L, nullptr);
@@ -1219,7 +1287,6 @@ public:
     if (!PSModOrErr) {
       for (auto *M : ShaderModules)
         vkDestroyShaderModule(Device, M, nullptr);
-      vkDestroyRenderPass(Device, RenderPass, nullptr);
       vkDestroyPipelineLayout(Device, PipelineLayout, nullptr);
       for (auto *L : SetLayouts)
         vkDestroyDescriptorSetLayout(Device, L, nullptr);
@@ -1246,7 +1313,6 @@ public:
                 parseSpecializationConstant(SpecConst, Entry, VSSpecData)) {
           for (auto *M : ShaderModules)
             vkDestroyShaderModule(Device, M, nullptr);
-          vkDestroyRenderPass(Device, RenderPass, nullptr);
           vkDestroyPipelineLayout(Device, PipelineLayout, nullptr);
           for (auto *L : SetLayouts)
             vkDestroyDescriptorSetLayout(Device, L, nullptr);
@@ -1279,7 +1345,6 @@ public:
                 parseSpecializationConstant(SpecConst, Entry, PSSpecData)) {
           for (auto *M : ShaderModules)
             vkDestroyShaderModule(Device, M, nullptr);
-          vkDestroyRenderPass(Device, RenderPass, nullptr);
           vkDestroyPipelineLayout(Device, PipelineLayout, nullptr);
           for (auto *L : SetLayouts)
             vkDestroyDescriptorSetLayout(Device, L, nullptr);
@@ -1399,7 +1464,7 @@ public:
     PipelineCI.pColorBlendState = &BlendCI;
     PipelineCI.pDynamicState = &DynamicCI;
     PipelineCI.layout = PipelineLayout;
-    PipelineCI.renderPass = RenderPass;
+    PipelineCI.renderPass = RenderPassHandle;
 
     VkPipeline Pipeline = VK_NULL_HANDLE;
     if (auto Err = VK::toError(vkCreateGraphicsPipelines(Device, VK_NULL_HANDLE,
@@ -1408,7 +1473,6 @@ public:
                                "Failed to create graphics pipeline.")) {
       for (auto *M : ShaderModules)
         vkDestroyShaderModule(Device, M, nullptr);
-      vkDestroyRenderPass(Device, RenderPass, nullptr);
       vkDestroyPipelineLayout(Device, PipelineLayout, nullptr);
       for (auto *L : SetLayouts)
         vkDestroyDescriptorSetLayout(Device, L, nullptr);
@@ -1420,8 +1484,7 @@ public:
       vkDestroyShaderModule(Device, M, nullptr);
 
     return std::make_unique<VulkanPipelineState>(
-        Name, Device, Pipeline, PipelineLayout, std::move(SetLayouts),
-        RenderPass);
+        Name, Device, Pipeline, PipelineLayout, std::move(SetLayouts));
   }
 
   llvm::Expected<std::unique_ptr<offloadtest::Fence>>
@@ -1658,6 +1721,82 @@ public:
     return VulkanCommandBuffer::create(
         Device, GraphicsQueue.QueueFamilyIdx, CmdBeginDebugUtilsLabel,
         CmdEndDebugUtilsLabel, CmdInsertDebugUtilsLabel);
+  }
+
+  llvm::Expected<std::unique_ptr<offloadtest::RenderPass>>
+  createRenderPass(const offloadtest::RenderPassDesc &Desc) override {
+    // Build a VkRenderPass from the descriptor's attachment formats and
+    // load/store actions. Initial layout for Load-action attachments is the
+    // standard attachment layout (caller's responsibility); for Clear /
+    // DontCare it's UNDEFINED. Final layout is always the standard
+    // attachment layout — caller does any post-pass transitions.
+    llvm::SmallVector<VkAttachmentDescription, 9> Attachments;
+    llvm::SmallVector<VkAttachmentReference, 8> ColorRefs;
+
+    for (const ColorAttachmentFormatDesc &Color : Desc.ColorAttachments) {
+      VkAttachmentDescription AD = {};
+      AD.format = getVulkanFormat(Color.Fmt);
+      AD.samples = VK_SAMPLE_COUNT_1_BIT;
+      AD.loadOp = getVkLoadOp(Color.Load);
+      AD.storeOp = getVkStoreOp(Color.Store);
+      AD.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+      AD.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+      AD.initialLayout = Color.Load == LoadAction::Load
+                             ? VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL
+                             : VK_IMAGE_LAYOUT_UNDEFINED;
+      AD.finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+      VkAttachmentReference Ref = {};
+      Ref.attachment = static_cast<uint32_t>(Attachments.size());
+      Ref.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+      Attachments.push_back(AD);
+      ColorRefs.push_back(Ref);
+    }
+
+    VkAttachmentReference DepthReference = {};
+    bool HasDS = false;
+    if (Desc.DepthStencil) {
+      const auto &DS = *Desc.DepthStencil;
+      VkAttachmentDescription AD = {};
+      AD.format = getVulkanFormat(DS.Fmt);
+      AD.samples = VK_SAMPLE_COUNT_1_BIT;
+      AD.loadOp = getVkLoadOp(DS.DepthLoad);
+      AD.storeOp = getVkStoreOp(DS.DepthStore);
+      AD.stencilLoadOp = getVkLoadOp(DS.StencilLoad);
+      AD.stencilStoreOp = getVkStoreOp(DS.StencilStore);
+      AD.initialLayout = (DS.DepthLoad == LoadAction::Load ||
+                          DS.StencilLoad == LoadAction::Load)
+                             ? VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL
+                             : VK_IMAGE_LAYOUT_UNDEFINED;
+      AD.finalLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+
+      DepthReference.attachment = static_cast<uint32_t>(Attachments.size());
+      DepthReference.layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+
+      Attachments.push_back(AD);
+      HasDS = true;
+    }
+
+    VkSubpassDescription Subpass = {};
+    Subpass.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+    Subpass.colorAttachmentCount = static_cast<uint32_t>(ColorRefs.size());
+    Subpass.pColorAttachments = ColorRefs.data();
+    Subpass.pDepthStencilAttachment = HasDS ? &DepthReference : nullptr;
+
+    VkRenderPassCreateInfo RPCI = {};
+    RPCI.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
+    RPCI.attachmentCount = static_cast<uint32_t>(Attachments.size());
+    RPCI.pAttachments = Attachments.data();
+    RPCI.subpassCount = 1;
+    RPCI.pSubpasses = &Subpass;
+
+    VkRenderPass Handle = VK_NULL_HANDLE;
+    if (auto Err =
+            VK::toError(vkCreateRenderPass(Device, &RPCI, nullptr, &Handle),
+                        "Failed to create render pass."))
+      return Err;
+    return std::make_unique<VulkanRenderPass>(Device, Handle, Desc);
   }
 
   llvm::Expected<BufferRef> createBuffer(VkBufferUsageFlags Usage,
@@ -2174,87 +2313,16 @@ public:
     return llvm::Error::success();
   }
 
-  llvm::Expected<VkRenderPass>
-  createRenderPass(llvm::ArrayRef<Format> RTFormats,
-                   std::optional<Format> DSFormat) {
-    // Only 8 render targets can be bound + 1 depth stencil target.
-    llvm::SmallVector<VkAttachmentDescription, 9> Attachments;
-    llvm::SmallVector<VkAttachmentReference, 8> ColorReferences;
-    for (size_t I = 0, N = RTFormats.size(); I < N; ++I) {
-      VkAttachmentDescription AttachmentDesc = {};
-      AttachmentDesc.format = getVulkanFormat(RTFormats[I]);
-      AttachmentDesc.samples = VK_SAMPLE_COUNT_1_BIT;
-      AttachmentDesc.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
-      AttachmentDesc.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
-      AttachmentDesc.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-      AttachmentDesc.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-      AttachmentDesc.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-      AttachmentDesc.finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
-      Attachments.push_back(AttachmentDesc);
-
-      VkAttachmentReference ColorReference = {};
-      ColorReference.attachment = I;
-      ColorReference.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
-      ColorReferences.push_back(ColorReference);
-    }
-
-    VkAttachmentReference DepthReference = {};
-    if (DSFormat.has_value()) {
-      VkAttachmentDescription AttachmentDesc = {};
-      AttachmentDesc.format = getVulkanFormat(*DSFormat);
-      AttachmentDesc.samples = VK_SAMPLE_COUNT_1_BIT;
-      AttachmentDesc.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
-      AttachmentDesc.storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-      AttachmentDesc.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-      AttachmentDesc.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-      AttachmentDesc.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-      AttachmentDesc.finalLayout =
-          VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
-      Attachments.push_back(AttachmentDesc);
-
-      DepthReference.attachment = Attachments.size() - 1;
-      DepthReference.layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
-    }
-
-    VkSubpassDescription SubpassDescription = {};
-    SubpassDescription.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
-    SubpassDescription.colorAttachmentCount = ColorReferences.size();
-    SubpassDescription.pColorAttachments = ColorReferences.data();
-    SubpassDescription.pDepthStencilAttachment =
-        DSFormat.has_value() ? &DepthReference : nullptr;
-    SubpassDescription.inputAttachmentCount = 0;
-    SubpassDescription.pInputAttachments = nullptr;
-    SubpassDescription.preserveAttachmentCount = 0;
-    SubpassDescription.pPreserveAttachments = nullptr;
-    SubpassDescription.pResolveAttachments = nullptr;
-
-    VkRenderPassCreateInfo RPCI = {};
-    RPCI.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
-    RPCI.attachmentCount = static_cast<uint32_t>(Attachments.size());
-    RPCI.pAttachments = Attachments.data();
-    RPCI.subpassCount = 1;
-    RPCI.pSubpasses = &SubpassDescription;
-    // RPCI.dependencyCount = static_cast<uint32_t>(Dependencies.size());
-    // RPCI.pDependencies = Dependencies.data();
-
-    VkRenderPass RenderPass = VK_NULL_HANDLE;
-    if (auto Err =
-            VK::toError(vkCreateRenderPass(Device, &RPCI, nullptr, &RenderPass),
-                        "Failed to create render pass."))
-      return Err;
-    return RenderPass;
-  }
-
   llvm::Error createFrameBuffer(InvocationState &IS) {
     auto &RT = llvm::cast<VulkanTexture>(*IS.RenderTarget);
     auto &DS = llvm::cast<VulkanTexture>(*IS.DepthStencil);
-    auto &PipelineState = llvm::cast<VulkanPipelineState>(*IS.Pipeline);
 
     std::array<VkImageView, 2> Views = {RT.View, DS.View};
 
     VkFramebufferCreateInfo FbufCreateInfo = {};
     FbufCreateInfo.sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
-    FbufCreateInfo.renderPass = PipelineState.RenderPass;
+    FbufCreateInfo.renderPass =
+        llvm::cast<VulkanRenderPass>(*IS.RenderPass).Handle;
     FbufCreateInfo.attachmentCount = Views.size();
     FbufCreateInfo.pAttachments = Views.data();
     FbufCreateInfo.width = RT.Desc.Width;
@@ -2640,7 +2708,6 @@ public:
     if (P.isTraditionalRaster()) {
       auto &RT = llvm::cast<VulkanTexture>(*IS.RenderTarget);
       auto &DS = llvm::cast<VulkanTexture>(*IS.DepthStencil);
-      auto &PipelineState = llvm::cast<VulkanPipelineState>(*IS.Pipeline);
 
       const auto *ColorCV =
           std::get_if<ClearColor>(&*RT.Desc.OptimizedClearValue);
@@ -2660,7 +2727,8 @@ public:
 
       VkRenderPassBeginInfo RenderPassBeginInfo = {};
       RenderPassBeginInfo.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
-      RenderPassBeginInfo.renderPass = PipelineState.RenderPass;
+      RenderPassBeginInfo.renderPass =
+          llvm::cast<VulkanRenderPass>(*IS.RenderPass).Handle;
       RenderPassBeginInfo.framebuffer = IS.FrameBuffer;
       RenderPassBeginInfo.renderArea.extent.width =
           P.Bindings.RTargetBufferPtr->OutputProps.Width;
@@ -2977,6 +3045,28 @@ public:
         return PipelineStateOrErr.takeError();
       State.Pipeline = std::move(*PipelineStateOrErr);
       llvm::outs() << "Graphics Pipeline created.\n";
+
+      ColorAttachmentFormatDesc ColorAttachment = {};
+      ColorAttachment.Fmt = *FormatOrErr;
+      ColorAttachment.Load = LoadAction::Clear;
+      ColorAttachment.Store = StoreAction::Store;
+
+      DepthStencilAttachmentFormatDesc DSAttachment = {};
+      DSAttachment.Fmt = Format::D32FloatS8Uint;
+      DSAttachment.DepthLoad = LoadAction::Clear;
+      DSAttachment.DepthStore = StoreAction::Store;
+      DSAttachment.StencilLoad = LoadAction::DontCare;
+      DSAttachment.StencilStore = StoreAction::DontCare;
+
+      RenderPassDesc PassDesc;
+      PassDesc.ColorAttachments.push_back(ColorAttachment);
+      PassDesc.DepthStencil = DSAttachment;
+
+      auto RenderPassOrErr = createRenderPass(PassDesc);
+      if (!RenderPassOrErr)
+        return RenderPassOrErr.takeError();
+      State.RenderPass = std::move(*RenderPassOrErr);
+      llvm::outs() << "Render pass created.\n";
 
       if (auto Err = createFrameBuffer(State))
         return Err;

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -457,6 +457,8 @@ public:
     vkFreeMemory(Dev, Memory, nullptr);
   }
 
+  const TextureCreateDesc &getDesc() const override { return Desc; }
+
   static bool classof(const offloadtest::Texture *T) {
     return T->getAPI() == GPUAPI::Vulkan;
   }

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -771,15 +771,6 @@ public:
   }
 };
 
-static VkPrimitiveTopology
-getVkTopology(offloadtest::PrimitiveTopology Topology) {
-  switch (Topology) {
-  case offloadtest::PrimitiveTopology::TriangleList:
-    return VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
-  }
-  llvm_unreachable("All PrimitiveTopology cases handled");
-}
-
 static VkAttachmentLoadOp getVkLoadOp(offloadtest::LoadAction Action) {
   switch (Action) {
   case offloadtest::LoadAction::Load:
@@ -907,7 +898,6 @@ public:
   }
 
   llvm::Error drawInstanced(const offloadtest::PipelineState &PSO,
-                            offloadtest::PrimitiveTopology Topology,
                             uint32_t VertexCount, uint32_t InstanceCount,
                             uint32_t FirstVertex,
                             uint32_t FirstInstance) override {
@@ -917,10 +907,6 @@ public:
     if (!ScissorSet)
       return llvm::createStringError(std::errc::invalid_argument,
                                      "Scissor must be set before drawing.");
-    // Topology is fixed at PSO creation in Vulkan; the encoder argument is
-    // accepted for API parity with DX12. A future change can switch to
-    // dynamic topology via VK_EXT_extended_dynamic_state.
-    (void)getVkTopology(Topology);
 
     const auto &VKPSO = llvm::cast<VulkanPipelineState>(PSO);
     vkCmdBindPipeline(CB.CmdBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS,
@@ -3028,10 +3014,9 @@ public:
         Encoder.setVertexBuffer(0, IS.VB.get(), 0,
                                 P.Bindings.getVertexStride());
 
-      if (auto Err = Encoder.drawInstanced(*IS.Pipeline.get(),
-                                           PrimitiveTopology::TriangleList,
-                                           P.getVertexCount(),
-                                           /*InstanceCount=*/1))
+      if (auto Err =
+              Encoder.drawInstanced(*IS.Pipeline.get(), P.getVertexCount(),
+                                    /*InstanceCount=*/1))
         return Err;
       Encoder.endEncoding();
 

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -875,15 +875,15 @@ public:
   void setVertexBuffer(uint32_t Slot, offloadtest::Buffer *VB, size_t Offset,
                        uint32_t /*Stride*/) override {
     // Stride is needed in DX12 at binding time, ignore parameter here.
-    if (!VB) {
+    if (VB) {
+      VkBuffer Handle = llvm::cast<VulkanBuffer>(*VB).Buffer;
+      const VkDeviceSize VKOffset = Offset;
+      vkCmdBindVertexBuffers(CB.CmdBuffer, Slot, 1, &Handle, &VKOffset);
+    } else {
       VkBuffer NullBuf = VK_NULL_HANDLE;
       const VkDeviceSize Zero = 0;
       vkCmdBindVertexBuffers(CB.CmdBuffer, Slot, 1, &NullBuf, &Zero);
-      return;
     }
-    VkBuffer Handle = llvm::cast<VulkanBuffer>(*VB).Buffer;
-    const VkDeviceSize VKOffset = Offset;
-    vkCmdBindVertexBuffers(CB.CmdBuffer, Slot, 1, &Handle, &VKOffset);
   }
 
   llvm::Error drawInstanced(const offloadtest::PipelineState &PSO,

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -638,7 +638,18 @@ public:
     PendingDstAccess = 0;
   }
 
+  /// Render passes and framebuffers built by render encoders for this
+  /// command buffer. The encoder records vkCmdBeginRenderPass against these,
+  /// so they must remain alive until the command buffer is submitted and
+  /// finishes execution. Destroyed alongside the command buffer.
+  llvm::SmallVector<VkRenderPass, 4> OwnedRenderPasses;
+  llvm::SmallVector<VkFramebuffer, 4> OwnedFramebuffers;
+
   ~VulkanCommandBuffer() override {
+    for (VkFramebuffer FB : OwnedFramebuffers)
+      vkDestroyFramebuffer(Device, FB, nullptr);
+    for (VkRenderPass RP : OwnedRenderPasses)
+      vkDestroyRenderPass(Device, RP, nullptr);
     if (CmdPool != VK_NULL_HANDLE)
       vkDestroyCommandPool(Device, CmdPool, nullptr);
   }
@@ -649,6 +660,9 @@ public:
 
   llvm::Expected<std::unique_ptr<offloadtest::ComputeEncoder>>
   createComputeEncoder() override;
+
+  llvm::Expected<std::unique_ptr<offloadtest::RenderEncoder>>
+  createRenderEncoder(const offloadtest::RenderPassBeginDesc &Desc) override;
 
 private:
   VulkanCommandBuffer() : CommandBuffer(GPUAPI::Vulkan) {}
@@ -757,6 +771,15 @@ public:
   }
 };
 
+static VkPrimitiveTopology
+getVkTopology(offloadtest::PrimitiveTopology Topology) {
+  switch (Topology) {
+  case offloadtest::PrimitiveTopology::TriangleList:
+    return VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
+  }
+  llvm_unreachable("All PrimitiveTopology cases handled");
+}
+
 static VkAttachmentLoadOp getVkLoadOp(offloadtest::LoadAction Action) {
   switch (Action) {
   case offloadtest::LoadAction::Load:
@@ -802,6 +825,256 @@ public:
     return RP->getAPI() == GPUAPI::Vulkan;
   }
 };
+
+class VKRenderEncoder : public offloadtest::RenderEncoder {
+  VulkanCommandBuffer &CB;
+
+  // Encoder contract: viewport and scissor must both be set before draw().
+  bool ViewportSet = false;
+  bool ScissorSet = false;
+
+public:
+  VKRenderEncoder(VulkanCommandBuffer &CB)
+      : RenderEncoder(GPUAPI::Vulkan), CB(CB) {}
+
+  ~VKRenderEncoder() override { endEncoding(); }
+
+  static bool classof(const CommandEncoder *E) {
+    return E->getAPI() == GPUAPI::Vulkan;
+  }
+
+  void pushDebugGroup(llvm::StringRef Label) override {
+    if (!CB.CmdBeginDebugUtilsLabel)
+      return;
+    VkDebugUtilsLabelEXT LabelInfo = {};
+    LabelInfo.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT;
+    LabelInfo.pLabelName = Label.data();
+    CB.CmdBeginDebugUtilsLabel(CB.CmdBuffer, &LabelInfo);
+  }
+
+  void popDebugGroup() override {
+    if (CB.CmdEndDebugUtilsLabel)
+      CB.CmdEndDebugUtilsLabel(CB.CmdBuffer);
+  }
+
+  void insertDebugSignpost(llvm::StringRef Label) override {
+    if (!CB.CmdInsertDebugUtilsLabel)
+      return;
+    VkDebugUtilsLabelEXT LabelInfo = {};
+    LabelInfo.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT;
+    LabelInfo.pLabelName = Label.data();
+    CB.CmdInsertDebugUtilsLabel(CB.CmdBuffer, &LabelInfo);
+  }
+
+  void setViewport(const offloadtest::Viewport &VP) override {
+    // Negative viewport height (with Y origin at the bottom) flips clip->
+    // framebuffer Y the same way DX12 and Metal do, so a CCW-in-clip-space
+    // triangle is front-facing on every backend.
+    VkViewport VKVP = {};
+    VKVP.x = VP.X;
+    VKVP.y = VP.Y + VP.Height;
+    VKVP.width = VP.Width;
+    VKVP.height = -VP.Height;
+    VKVP.minDepth = VP.MinDepth;
+    VKVP.maxDepth = VP.MaxDepth;
+    vkCmdSetViewport(CB.CmdBuffer, 0, 1, &VKVP);
+    ViewportSet = true;
+  }
+
+  void setScissor(const offloadtest::ScissorRect &Rect) override {
+    VkRect2D VKRect = {};
+    VKRect.offset.x = Rect.X;
+    VKRect.offset.y = Rect.Y;
+    VKRect.extent.width = Rect.Width;
+    VKRect.extent.height = Rect.Height;
+    vkCmdSetScissor(CB.CmdBuffer, 0, 1, &VKRect);
+    ScissorSet = true;
+  }
+
+  void setVertexBuffer(uint32_t Slot, offloadtest::Buffer *VB, size_t Offset,
+                       uint32_t /*Stride*/) override {
+    // Stride is part of the pipeline's input layout in Vulkan, not the
+    // buffer binding. The DX12 backend needs it; we don't.
+    if (!VB) {
+      VkBuffer NullBuf = VK_NULL_HANDLE;
+      VkDeviceSize Zero = 0;
+      vkCmdBindVertexBuffers(CB.CmdBuffer, Slot, 1, &NullBuf, &Zero);
+      return;
+    }
+    VkBuffer Handle = llvm::cast<VulkanBuffer>(*VB).Buffer;
+    VkDeviceSize VKOffset = Offset;
+    vkCmdBindVertexBuffers(CB.CmdBuffer, Slot, 1, &Handle, &VKOffset);
+  }
+
+  llvm::Error drawInstanced(const offloadtest::PipelineState &PSO,
+                            offloadtest::PrimitiveTopology Topology,
+                            uint32_t VertexCount, uint32_t InstanceCount,
+                            uint32_t FirstVertex,
+                            uint32_t FirstInstance) override {
+    if (!ViewportSet)
+      return llvm::createStringError(std::errc::invalid_argument,
+                                     "Viewport must be set before drawing.");
+    if (!ScissorSet)
+      return llvm::createStringError(std::errc::invalid_argument,
+                                     "Scissor must be set before drawing.");
+    // Topology is fixed at PSO creation in Vulkan; the encoder argument is
+    // accepted for API parity with DX12. A future change can switch to
+    // dynamic topology via VK_EXT_extended_dynamic_state.
+    (void)getVkTopology(Topology);
+
+    const auto &VKPSO = llvm::cast<VulkanPipelineState>(PSO);
+    vkCmdBindPipeline(CB.CmdBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS,
+                      VKPSO.Pipeline);
+    vkCmdDraw(CB.CmdBuffer, VertexCount, InstanceCount, FirstVertex,
+              FirstInstance);
+    return llvm::Error::success();
+  }
+
+  llvm::Error copyBufferToBuffer(offloadtest::Buffer &Src, size_t SrcOffset,
+                                 offloadtest::Buffer &Dst, size_t DstOffset,
+                                 size_t Size) override {
+    auto &VKSrc = static_cast<VulkanBuffer &>(Src);
+    auto &VKDst = static_cast<VulkanBuffer &>(Dst);
+    VkBufferCopy Region = {};
+    Region.srcOffset = SrcOffset;
+    Region.dstOffset = DstOffset;
+    Region.size = Size;
+    vkCmdCopyBuffer(CB.CmdBuffer, VKSrc.Buffer, VKDst.Buffer, 1, &Region);
+    return llvm::Error::success();
+  }
+
+  void endEncodingImpl() override {
+    vkCmdEndRenderPass(CB.CmdBuffer);
+    popDebugGroup();
+  }
+};
+
+llvm::Expected<std::unique_ptr<offloadtest::RenderEncoder>>
+VulkanCommandBuffer::createRenderEncoder(
+    const offloadtest::RenderPassBeginDesc &Desc) {
+  // The pass carries the VkRenderPass and the format / load / store policy.
+  // The begin desc supplies the textures that get bound for this encoder.
+  if (!Desc.Pass)
+    return llvm::createStringError(
+        std::errc::invalid_argument,
+        "RenderPassBeginDesc is missing its RenderPass.");
+  auto &VKPass = llvm::cast<VulkanRenderPass>(*Desc.Pass);
+  const offloadtest::RenderPassDesc &PassDesc = VKPass.Desc;
+
+  if (Desc.ColorAttachments.size() != PassDesc.ColorAttachments.size())
+    return llvm::createStringError(
+        std::errc::invalid_argument,
+        "RenderPassBeginDesc color attachment count does not match its "
+        "RenderPass.");
+  if (PassDesc.DepthStencil.has_value() != (Desc.DepthStencil != nullptr))
+    return llvm::createStringError(std::errc::invalid_argument,
+                                   "RenderPassBeginDesc depth-stencil "
+                                   "presence does not match its RenderPass.");
+
+  llvm::SmallVector<VkImageView, 9> Views;
+  llvm::SmallVector<VkClearValue, 9> ClearValues;
+  uint32_t Width = 0;
+  uint32_t Height = 0;
+
+  for (size_t I = 0; I < Desc.ColorAttachments.size(); ++I) {
+    if (!Desc.ColorAttachments[I])
+      return llvm::createStringError(
+          std::errc::invalid_argument,
+          "RenderPassBeginDesc has a null color attachment texture.");
+    auto &Tex = llvm::cast<VulkanTexture>(*Desc.ColorAttachments[I]);
+    if (Tex.View == VK_NULL_HANDLE)
+      return llvm::createStringError(
+          std::errc::invalid_argument,
+          "Color attachment texture has no image view.");
+    Views.push_back(Tex.View);
+
+    VkClearValue CV = {};
+    if (PassDesc.ColorAttachments[I].Load == offloadtest::LoadAction::Clear) {
+      if (!Tex.Desc.OptimizedClearValue)
+        return llvm::createStringError(
+            std::errc::invalid_argument,
+            "LoadAction::Clear requires the render target to have been "
+            "created with an OptimizedClearValue.");
+      const auto *ColorCV =
+          std::get_if<ClearColor>(&*Tex.Desc.OptimizedClearValue);
+      assert(ColorCV &&
+             "RenderTarget OptimizedClearValue must be a ClearColor");
+      CV.color = {{ColorCV->R, ColorCV->G, ColorCV->B, ColorCV->A}};
+    }
+    ClearValues.push_back(CV);
+
+    if (Tex.Desc.Width > Width)
+      Width = Tex.Desc.Width;
+    if (Tex.Desc.Height > Height)
+      Height = Tex.Desc.Height;
+  }
+
+  if (Desc.DepthStencil) {
+    auto &Tex = llvm::cast<VulkanTexture>(*Desc.DepthStencil);
+    if (Tex.View == VK_NULL_HANDLE)
+      return llvm::createStringError(
+          std::errc::invalid_argument,
+          "Depth-stencil attachment texture has no image view.");
+    Views.push_back(Tex.View);
+
+    const auto &DS = *PassDesc.DepthStencil;
+    VkClearValue CV = {};
+    if (DS.DepthLoad == offloadtest::LoadAction::Clear ||
+        DS.StencilLoad == offloadtest::LoadAction::Clear) {
+      if (!Tex.Desc.OptimizedClearValue)
+        return llvm::createStringError(
+            std::errc::invalid_argument,
+            "LoadAction::Clear requires the depth-stencil texture to have "
+            "been created with an OptimizedClearValue.");
+      const auto *DepthCV =
+          std::get_if<ClearDepthStencil>(&*Tex.Desc.OptimizedClearValue);
+      assert(DepthCV &&
+             "DepthStencil OptimizedClearValue must be a ClearDepthStencil");
+      CV.depthStencil = {DepthCV->Depth, DepthCV->Stencil};
+    }
+    ClearValues.push_back(CV);
+
+    if (Tex.Desc.Width > Width)
+      Width = Tex.Desc.Width;
+    if (Tex.Desc.Height > Height)
+      Height = Tex.Desc.Height;
+  }
+
+  VkFramebufferCreateInfo FBCI = {};
+  FBCI.sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
+  FBCI.renderPass = VKPass.Handle;
+  FBCI.attachmentCount = static_cast<uint32_t>(Views.size());
+  FBCI.pAttachments = Views.data();
+  FBCI.width = Width;
+  FBCI.height = Height;
+  FBCI.layers = 1;
+
+  VkFramebuffer Framebuffer = VK_NULL_HANDLE;
+  if (auto Err =
+          VK::toError(vkCreateFramebuffer(Device, &FBCI, nullptr, &Framebuffer),
+                      "Failed to create framebuffer for RenderEncoder."))
+    return Err;
+
+  // The framebuffer must outlive this encoder and remain valid through GPU
+  // execution; the command buffer destroys it on teardown. The render pass
+  // is owned by the user-supplied VulkanRenderPass.
+  OwnedFramebuffers.push_back(Framebuffer);
+
+  VkRenderPassBeginInfo BeginInfo = {};
+  BeginInfo.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
+  BeginInfo.renderPass = VKPass.Handle;
+  BeginInfo.framebuffer = Framebuffer;
+  BeginInfo.renderArea.extent.width = Width;
+  BeginInfo.renderArea.extent.height = Height;
+  BeginInfo.clearValueCount = static_cast<uint32_t>(ClearValues.size());
+  BeginInfo.pClearValues = ClearValues.data();
+
+  vkCmdBeginRenderPass(CmdBuffer, &BeginInfo, VK_SUBPASS_CONTENTS_INLINE);
+
+  auto Enc = std::make_unique<VKRenderEncoder>(*this);
+  Enc->pushDebugGroup("RenderEncoder");
+  return Enc;
+}
 
 class VulkanDevice : public offloadtest::Device {
 private:
@@ -2707,63 +2980,6 @@ public:
     for (auto &R : IS.Resources)
       copyResourceDataToDevice(IS, R);
 
-    if (P.isTraditionalRaster()) {
-      auto &RT = llvm::cast<VulkanTexture>(*IS.RenderTarget);
-      auto &DS = llvm::cast<VulkanTexture>(*IS.DepthStencil);
-
-      const auto *ColorCV =
-          std::get_if<ClearColor>(&*RT.Desc.OptimizedClearValue);
-      if (!ColorCV)
-        return llvm::createStringError(
-            std::errc::invalid_argument,
-            "Render target clear value must be a ClearColor.");
-      const auto *DepthCV =
-          std::get_if<ClearDepthStencil>(&*DS.Desc.OptimizedClearValue);
-      if (!DepthCV)
-        return llvm::createStringError(
-            std::errc::invalid_argument,
-            "Depth/stencil clear value must be a ClearDepthStencil.");
-      VkClearValue ClearValues[2] = {};
-      ClearValues[0].color = {{ColorCV->R, ColorCV->G, ColorCV->B, ColorCV->A}};
-      ClearValues[1].depthStencil = {DepthCV->Depth, DepthCV->Stencil};
-
-      VkRenderPassBeginInfo RenderPassBeginInfo = {};
-      RenderPassBeginInfo.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
-      RenderPassBeginInfo.renderPass =
-          llvm::cast<VulkanRenderPass>(*IS.RenderPass).Handle;
-      RenderPassBeginInfo.framebuffer = IS.FrameBuffer;
-      RenderPassBeginInfo.renderArea.extent.width =
-          P.Bindings.RTargetBufferPtr->OutputProps.Width;
-      RenderPassBeginInfo.renderArea.extent.height =
-          P.Bindings.RTargetBufferPtr->OutputProps.Height;
-      RenderPassBeginInfo.clearValueCount = 2;
-      RenderPassBeginInfo.pClearValues = ClearValues;
-
-      vkCmdBeginRenderPass(IS.CB->CmdBuffer, &RenderPassBeginInfo,
-                           VK_SUBPASS_CONTENTS_INLINE);
-
-      // Negative viewport height (with Y origin at the bottom) flips clip->
-      // framebuffer Y the same way DX12 and Metal do, so a CCW-in-clip-space
-      // triangle is front-facing on every backend.
-      VkViewport Viewport = {};
-      Viewport.x = 0.0f;
-      Viewport.y =
-          static_cast<float>(P.Bindings.RTargetBufferPtr->OutputProps.Height);
-      Viewport.width =
-          static_cast<float>(P.Bindings.RTargetBufferPtr->OutputProps.Width);
-      Viewport.height =
-          -static_cast<float>(P.Bindings.RTargetBufferPtr->OutputProps.Height);
-      Viewport.minDepth = 0.0f;
-      Viewport.maxDepth = 1.0f;
-      vkCmdSetViewport(IS.CB->CmdBuffer, 0, 1, &Viewport);
-
-      VkRect2D Scissor = {};
-      Scissor.offset = {0, 0};
-      Scissor.extent.width = P.Bindings.RTargetBufferPtr->OutputProps.Width;
-      Scissor.extent.height = P.Bindings.RTargetBufferPtr->OutputProps.Height;
-      vkCmdSetScissor(IS.CB->CmdBuffer, 0, 1, &Scissor);
-    }
-
     const VkPipelineBindPoint BindPoint = P.isTraditionalRaster()
                                               ? VK_PIPELINE_BIND_POINT_GRAPHICS
                                               : VK_PIPELINE_BIND_POINT_COMPUTE;
@@ -2798,16 +3014,40 @@ public:
                    << P.DispatchParameters.DispatchGroupCount[0] << ", "
                    << P.DispatchParameters.DispatchGroupCount[1] << ", "
                    << P.DispatchParameters.DispatchGroupCount[2] << " }\n";
-    } else {
-      VkDeviceSize Offsets[1]{0};
-      if (IS.VB) {
-        VkBuffer VBHandle = llvm::cast<VulkanBuffer>(*IS.VB).Buffer;
-        vkCmdBindVertexBuffers(IS.CB->CmdBuffer, 0, 1, &VBHandle, Offsets);
-      }
-      // instanceCount must be >=1 to draw; previously was 0 which draws nothing
-      vkCmdDraw(IS.CB->CmdBuffer, P.getVertexCount(), 1, 0, 0);
-      llvm::outs() << "Drew " << P.getVertexCount() << " vertices.\n";
-      vkCmdEndRenderPass(IS.CB->CmdBuffer);
+    } else if (P.isTraditionalRaster()) {
+      RenderPassBeginDesc BeginDesc = {};
+      BeginDesc.Pass = IS.RenderPass.get();
+      BeginDesc.ColorAttachments.push_back(IS.RenderTarget.get());
+      BeginDesc.DepthStencil = IS.DepthStencil.get();
+
+      auto EncOrErr = IS.CB->createRenderEncoder(BeginDesc);
+      if (!EncOrErr)
+        return EncOrErr.takeError();
+      auto &Encoder = *EncOrErr.get();
+
+      Viewport VP;
+      VP.Width =
+          static_cast<float>(P.Bindings.RTargetBufferPtr->OutputProps.Width);
+      VP.Height =
+          static_cast<float>(P.Bindings.RTargetBufferPtr->OutputProps.Height);
+      Encoder.setViewport(VP);
+
+      ScissorRect Scissor;
+      Scissor.Width = static_cast<uint32_t>(VP.Width);
+      Scissor.Height = static_cast<uint32_t>(VP.Height);
+      Encoder.setScissor(Scissor);
+
+      if (IS.VB)
+        Encoder.setVertexBuffer(0, IS.VB.get(), 0,
+                                P.Bindings.getVertexStride());
+
+      if (auto Err = Encoder.drawInstanced(*IS.Pipeline.get(),
+                                           PrimitiveTopology::TriangleList,
+                                           P.getVertexCount(),
+                                           /*InstanceCount=*/1))
+        return Err;
+      Encoder.endEncoding();
+
       copyTextureToReadback(IS.CB->CmdBuffer,
                             llvm::cast<VulkanTexture>(*IS.RenderTarget),
                             llvm::cast<VulkanBuffer>(*IS.RTReadback),
@@ -3049,12 +3289,12 @@ public:
       llvm::outs() << "Graphics Pipeline created.\n";
 
       ColorAttachmentFormatDesc ColorAttachment = {};
-      ColorAttachment.Fmt = *FormatOrErr;
+      ColorAttachment.Fmt = State.RenderTarget->getDesc().Fmt;
       ColorAttachment.Load = LoadAction::Clear;
       ColorAttachment.Store = StoreAction::Store;
 
       DepthStencilAttachmentFormatDesc DSAttachment = {};
-      DSAttachment.Fmt = Format::D32FloatS8Uint;
+      DSAttachment.Fmt = State.DepthStencil->getDesc().Fmt;
       DSAttachment.DepthLoad = LoadAction::Clear;
       DSAttachment.DepthStore = StoreAction::Store;
       DSAttachment.StencilLoad = LoadAction::DontCare;

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -808,7 +808,7 @@ public:
   }
 };
 
-class VKRenderEncoder : public offloadtest::RenderEncoder {
+class VulkanRenderEncoder : public offloadtest::RenderEncoder {
   VulkanCommandBuffer &CB;
 
   // Encoder contract: viewport and scissor must both be set before draw().
@@ -816,10 +816,14 @@ class VKRenderEncoder : public offloadtest::RenderEncoder {
   bool ScissorSet = false;
 
 public:
-  VKRenderEncoder(VulkanCommandBuffer &CB)
+  VulkanRenderEncoder(VulkanCommandBuffer &CB)
       : RenderEncoder(GPUAPI::Vulkan), CB(CB) {}
+  VulkanRenderEncoder(const VulkanRenderEncoder &CB) = delete;
+  VulkanRenderEncoder(VulkanRenderEncoder &&CB) = delete;
+  VulkanRenderEncoder &operator=(VulkanRenderEncoder &CB) = delete;
+  VulkanRenderEncoder &operator=(const VulkanRenderEncoder &&CB) = delete;
 
-  ~VKRenderEncoder() override { endEncoding(); }
+  ~VulkanRenderEncoder() override { endEncoding(); }
 
   static bool classof(const CommandEncoder *E) {
     return E->getAPI() == GPUAPI::Vulkan;
@@ -1034,7 +1038,7 @@ VulkanCommandBuffer::createRenderEncoder(
 
   vkCmdBeginRenderPass(CmdBuffer, &BeginInfo, VK_SUBPASS_CONTENTS_INLINE);
 
-  auto Enc = std::make_unique<VKRenderEncoder>(*this);
+  auto Enc = std::make_unique<VulkanRenderEncoder>(*this);
   Enc->pushDebugGroup("RenderEncoder");
   return Enc;
 }


### PR DESCRIPTION
Previously the `ComputeEncoder` was introduced to record compute dispatch commands in an API-agnostic manner. This uses the same pattern for graphics commands. To keep changes minimal only `setVertexBuffer` and `drawInstanced` functions are added. 

The next step would be to introduce a `meshDispatch` function for mesh shader support. This `RenderEncoder` then allows us to implement Mesh Shader support once properly instead of implementing it for each backend and then having to refactor it later.

Due to how Vulkan is set-up with `RenderPass` objects we needed to add an API-agnostic type along with the creation functions for those. On DX12 and Metal these just save the input parameters which are then used to create the `RenderEncoder`.

A drive-by change is moving the `copyBufferToBuffer` function to the `ComputeEncoder` because Metal does not support copy operations on the `RenderEncoder`.