### PR TITLE
Remove functions for cmd submission that were being called less than three times.

### DIFF
--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -1670,11 +1670,6 @@ public:
     IS.CB->CmdList->ResourceBarrier(1, &Barrier);
   }
 
-  llvm::Expected<offloadtest::SubmitResult>
-  executeCommandList(InvocationState &IS) {
-    return GraphicsQueue.submit(std::move(IS.CB));
-  }
-
   llvm::Error createComputeCommands(Pipeline &P, InvocationState &IS) {
     CD3DX12_GPU_DESCRIPTOR_HANDLE Handle;
     if (IS.DescHeap) {
@@ -2161,7 +2156,7 @@ public:
           "Pipeline was neither Compute nor Traditional Raster");
     }
 
-    auto SubmitResult = executeCommandList(State);
+    auto SubmitResult = GraphicsQueue.submit(std::move(State.CB));
     if (!SubmitResult)
       return SubmitResult.takeError();
     llvm::outs() << "Compute commands executed.\n";

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -1167,11 +1167,6 @@ class MTLDevice : public offloadtest::Device {
     return llvm::Error::success();
   }
 
-  llvm::Expected<offloadtest::SubmitResult>
-  executeCommands(InvocationState &IS) {
-    return GraphicsQueue.submit(std::move(IS.CB));
-  }
-
   llvm::Error copyBack(Pipeline &P, InvocationState &IS) {
     auto MemCpyBack = [](ResourcePair &Pair) -> llvm::Error {
       const Resource &R = *Pair.first;
@@ -1556,7 +1551,7 @@ public:
         return Err;
     }
 
-    auto SubmitResult = executeCommands(IS);
+    auto SubmitResult = GraphicsQueue.submit(std::move(IS.CB));
     if (!SubmitResult)
       return SubmitResult.takeError();
 

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -1947,11 +1947,6 @@ public:
     return llvm::Error::success();
   }
 
-  llvm::Expected<offloadtest::SubmitResult>
-  executeCommandBuffer(InvocationState &IS) {
-    return GraphicsQueue.submit(std::move(IS.CB));
-  }
-
   llvm::Error createDescriptorPool(Pipeline &P, InvocationState &IS) {
 
     constexpr VkDescriptorType DescriptorTypes[] = {
@@ -2995,7 +2990,7 @@ public:
     llvm::outs() << "Memory buffers created.\n";
     // No explicit wait: the next submit's GPU-side timeline semaphore
     // dependency ensures the copy completes before the dispatch runs.
-    auto CopyResult = executeCommandBuffer(State);
+    auto CopyResult = GraphicsQueue.submit(std::move(State.CB));
     if (!CopyResult)
       return CopyResult.takeError();
     llvm::outs() << "Executed copy command buffer.\n";
@@ -3015,7 +3010,7 @@ public:
     if (auto Err = createCommands(P, State))
       return Err;
     llvm::outs() << "Commands created.\n";
-    auto DispatchResult = executeCommandBuffer(State);
+    auto DispatchResult = GraphicsQueue.submit(std::move(State.CB));
     if (!DispatchResult)
       return DispatchResult.takeError();
     llvm::outs() << "Executed compute command buffer.\n";


### PR DESCRIPTION
The wrapper functions for submitting command buffers were being called less than three times. In this case the functions just obscure what is happening. Instead we should just inline the code.

This is just minor clean-up of code I found while working on something else.
