### PR TITLE
XFAILs for spirv-val failures related to resources in structs

### DIFF
--- a/test/Feature/ResourcesInStructs/array-of-structs-with-res.test
+++ b/test/Feature/ResourcesInStructs/array-of-structs-with-res.test
@@ -98,6 +98,9 @@ DescriptorSets:
 ...
 #--- end
 
+# Bug: https://github.com/llvm/llvm-project/issues/194435
+# XFAIL: Clang && Vulkan
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/ResourcesInStructs/res-array-of-matrix-in-struct.test
+++ b/test/Feature/ResourcesInStructs/res-array-of-matrix-in-struct.test
@@ -74,6 +74,9 @@ DescriptorSets:
 # Unimplemented https://github.com/microsoft/DirectXShaderCompiler/issues/8301
 # XFAIL: Vulkan && DXC
 
+# Bug: https://github.com/llvm/llvm-project/issues/194435
+# XFAIL: Clang && Vulkan
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/ResourcesInStructs/res-in-struct-mix.test
+++ b/test/Feature/ResourcesInStructs/res-in-struct-mix.test
@@ -117,6 +117,9 @@ DescriptorSets:
 ...
 #--- end
 
+# Bug: https://github.com/llvm/llvm-project/issues/194435
+# XFAIL: Clang && Vulkan
+
 # DXC + Vulkan does not support global structures containing buffers.
 # UNSUPPORTED: DXC && Vulkan
 

--- a/test/Feature/ResourcesInStructs/res-in-struct-simple-array.test
+++ b/test/Feature/ResourcesInStructs/res-in-struct-simple-array.test
@@ -69,6 +69,9 @@ DescriptorSets:
 ...
 #--- end
 
+# Bug: https://github.com/llvm/llvm-project/issues/194435
+# XFAIL: Clang && Vulkan
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/ResourcesInStructs/res-in-struct-simple-one.test
+++ b/test/Feature/ResourcesInStructs/res-in-struct-simple-one.test
@@ -62,6 +62,9 @@ DescriptorSets:
 ...
 #--- end
 
+# Bug: https://github.com/llvm/llvm-project/issues/194435
+# XFAIL: Clang && Vulkan
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
Add XFAILs for various tests failing due to llvm/llvm-project#194435