### PR TITLE
[Metal] Remove "UNSUPPORTED: Metal" from some tests

### DIFF
--- a/test/Feature/CBuffer/Matrix/MatrixElement/one_based_mat_element.f32.test
+++ b/test/Feature/CBuffer/Matrix/MatrixElement/one_based_mat_element.f32.test
@@ -178,10 +178,6 @@ DescriptorSets:
       VulkanBinding:
         Binding: 7
 
-# Note: Metal and Vulkan KosmicKrisp and MoltenVK
-# Are always empty
-# UNSUPPORTED: Darwin
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -fvk-use-dx-layout -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/CBuffer/Matrix/MatrixElement/one_based_mat_element_scalar.f32.test
+++ b/test/Feature/CBuffer/Matrix/MatrixElement/one_based_mat_element_scalar.f32.test
@@ -189,10 +189,6 @@ DescriptorSets:
       VulkanBinding:
         Binding: 7
 
-# Note: Metal and Vulkan KosmicKrisp and MoltenVK
-# Are always empty
-# UNSUPPORTED: Darwin
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -fvk-use-dx-layout -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/CBuffer/Matrix/MatrixElement/zero_based_mat_element.f32.test
+++ b/test/Feature/CBuffer/Matrix/MatrixElement/zero_based_mat_element.f32.test
@@ -178,10 +178,6 @@ DescriptorSets:
       VulkanBinding:
         Binding: 7
 
-# Note: Metal and Vulkan KosmicKrisp and MoltenVK
-# Are always empty
-# UNSUPPORTED: Darwin
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -fvk-use-dx-layout -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/CBuffer/Matrix/MatrixElement/zero_based_mat_element_scalar.f32.test
+++ b/test/Feature/CBuffer/Matrix/MatrixElement/zero_based_mat_element_scalar.f32.test
@@ -189,10 +189,6 @@ DescriptorSets:
       VulkanBinding:
         Binding: 7
 
-# Note: Metal and Vulkan KosmicKrisp and MoltenVK
-# Are always empty
-# UNSUPPORTED: Darwin
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -fvk-use-dx-layout -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/CBuffer/Matrix/MatrixSubscript/matrix_subscript.f32.test
+++ b/test/Feature/CBuffer/Matrix/MatrixSubscript/matrix_subscript.f32.test
@@ -189,10 +189,6 @@ DescriptorSets:
       VulkanBinding:
         Binding: 7
 
-# Note: Metal and Vulkan KosmicKrisp and MoltenVK
-# Are always empty
-# UNSUPPORTED: Darwin
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -fvk-use-dx-layout -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/CBuffer/Matrix/MatrixSubscript/row_major_flag_matrix_subscript.f32.test
+++ b/test/Feature/CBuffer/Matrix/MatrixSubscript/row_major_flag_matrix_subscript.f32.test
@@ -189,10 +189,6 @@ DescriptorSets:
       VulkanBinding:
         Binding: 7
 
-# Note: Metal and Vulkan KosmicKrisp and MoltenVK
-# Are always empty
-# UNSUPPORTED: Darwin
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -fvk-use-dx-layout -T cs_6_0 -Zpr -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/CBuffer/Matrix/MatrixSubscript/row_major_matrix_subscript.f32.test
+++ b/test/Feature/CBuffer/Matrix/MatrixSubscript/row_major_matrix_subscript.f32.test
@@ -189,10 +189,6 @@ DescriptorSets:
       VulkanBinding:
         Binding: 7
 
-# Note: Metal and Vulkan KosmicKrisp and MoltenVK
-# Are always empty
-# UNSUPPORTED: Darwin
-
 # Unimplemented https://github.com/llvm/llvm-project/issues/185049
 # XFAIL: Clang
 

--- a/test/Feature/CBuffer/Matrix/SingleSubscript/mat_cbuffer-swizzle.f32.test
+++ b/test/Feature/CBuffer/Matrix/SingleSubscript/mat_cbuffer-swizzle.f32.test
@@ -168,10 +168,6 @@ DescriptorSets:
       VulkanBinding:
         Binding: 7
 
-# Note: Metal and Vulkan KosmicKrisp and MoltenVK
-# Are always empty
-# UNSUPPORTED: Darwin
-
 # BUG https://github.com/llvm/llvm-project/issues/191070
 # XFAIL: Clang && Vulkan
 

--- a/test/Feature/CBuffer/Matrix/SingleSubscript/mat_cbuffer.f32.test
+++ b/test/Feature/CBuffer/Matrix/SingleSubscript/mat_cbuffer.f32.test
@@ -168,10 +168,6 @@ DescriptorSets:
       VulkanBinding:
         Binding: 7
 
-# Note: Metal and Vulkan KosmicKrisp and MoltenVK
-# Are always empty
-# UNSUPPORTED: Darwin
-
 # BUG https://github.com/llvm/llvm-project/issues/191070
 # XFAIL: Clang && Vulkan
 

--- a/test/Feature/CBuffer/Matrix/SingleSubscript/mat_cbuffer_threadgroup.f4x2.test
+++ b/test/Feature/CBuffer/Matrix/SingleSubscript/mat_cbuffer_threadgroup.f4x2.test
@@ -88,11 +88,6 @@ DescriptorSets:
       VulkanBinding:
         Binding: 3
 
-
-# Note: Metal and Vulkan KosmicKrisp and MoltenVK 
-# Are always empty
-# UNSUPPORTED: Darwin
-
 # BUG https://github.com/llvm/offload-test-suite/issues/931
 # XFAIL: Clang && DirectX && AMD
 

--- a/test/Feature/ImplicitBindings/all-implicit.test
+++ b/test/Feature/ImplicitBindings/all-implicit.test
@@ -69,10 +69,6 @@ DescriptorSets:
 ...
 #--- end
 
-# CBuffer bindings seem to be broken under metal
-# https://github.com/llvm/offload-test-suite/issues/55
-# UNSUPPORTED: Metal
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 %if Vulkan %{ -fvk-use-dx-layout %} -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s

--- a/test/Feature/ImplicitBindings/simple-resources.test
+++ b/test/Feature/ImplicitBindings/simple-resources.test
@@ -71,10 +71,6 @@ DescriptorSets:
 # specify descriptor sets that are valid for both DirectX and Vulkan there.
 # UNSUPPORTED: DXC && Vulkan
 
-# CBuffer bindings seem to be broken under metal
-# https://github.com/llvm/offload-test-suite/issues/55
-# UNSUPPORTED: Metal
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s

--- a/test/Feature/ResourceArrays/array-local.test
+++ b/test/Feature/ResourceArrays/array-local.test
@@ -78,9 +78,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Resource arrays are not yet supported on Metal
-# UNSUPPORTED: Metal
-
 # Bug https://github.com/llvm/llvm-project/issues/154669
 # XFAIL: Clang && Vulkan
 

--- a/test/Feature/ResourceArrays/array-local2.test
+++ b/test/Feature/ResourceArrays/array-local2.test
@@ -77,13 +77,13 @@ DescriptorSets:
 # of a function argument if the type is resource or resource array.
 # Bug https://github.com/microsoft/DirectXShaderCompiler/issues/7678
 # XFAIL: DXC && DirectX
+# Metal also uses the DirectX path here, and has the same issue.
+# Bug https://github.com/microsoft/DirectXShaderCompiler/issues/7678
+# XFAIL: DXC && Metal
 
 # DXC-Vulkan support for arrays of RWStructuredBuffer are pretty broken.
 # Tracked by https://github.com/microsoft/DirectXShaderCompiler/issues/7727
 # XFAIL: DXC && Vulkan
-
-# Resource arrays are not yet supported on Metal
-# UNSUPPORTED: Metal
 
 # Bug https://github.com/llvm/llvm-project/issues/154669
 # XFAIL: Clang && Vulkan

--- a/test/Feature/ResourceArrays/multi-dim-array-global.test
+++ b/test/Feature/ResourceArrays/multi-dim-array-global.test
@@ -68,9 +68,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Resource arrays are not yet supported on Metal
-# UNSUPPORTED: Metal
-
 # Vulkan does not support multi-dimensional resource arrays
 # UNSUPPORTED: Vulkan
 

--- a/test/Feature/ResourceArrays/multi-dim-array-local.test
+++ b/test/Feature/ResourceArrays/multi-dim-array-local.test
@@ -78,9 +78,6 @@ DescriptorSets:
 # Vulkan does not support multi-dimensional resource arrays
 # UNSUPPORTED: Vulkan
 
-# Resource arrays are not yet supported on Metal
-# UNSUPPORTED: Metal
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/ResourceArrays/multi-dim-array-subset-nuri.test
+++ b/test/Feature/ResourceArrays/multi-dim-array-subset-nuri.test
@@ -71,9 +71,6 @@ DescriptorSets:
 # Vulkan does not support multi-dimensional resource arrays
 # UNSUPPORTED: Vulkan
 
-# Resource arrays are not yet supported on Metal
-# UNSUPPORTED: Metal
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/ResourceArrays/multi-dim-unbounded-array-nuri.test
+++ b/test/Feature/ResourceArrays/multi-dim-unbounded-array-nuri.test
@@ -60,9 +60,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Resource arrays are not yet supported on Metal
-# UNSUPPORTED: Metal
-
 # Vulkan does not support multi-dimensional resource arrays
 # UNSUPPORTED: Vulkan
 

--- a/test/Feature/ResourceArrays/unbounded-array-nuri.test
+++ b/test/Feature/ResourceArrays/unbounded-array-nuri.test
@@ -62,9 +62,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Resource arrays are not yet supported on Metal
-# UNSUPPORTED: Metal
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/ResourcesInStructs/res-in-struct-local-arg.test
+++ b/test/Feature/ResourcesInStructs/res-in-struct-local-arg.test
@@ -76,9 +76,6 @@ DescriptorSets:
 # Unimplemented https://github.com/llvm/wg-hlsl/issues/367
 # XFAIL: Clang
 
-# Unsupported on Metal - requires Vulkan feature robustBufferAccess
-# UNSUPPORTED: Metal
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
Most of these really should've been XFAIL rather than UNSUPPORTED, but in any case, after #1061 they're supported.

These all pass now except `Feature/ResourceArrays/array-local2.test`, which fails for the same reason the test fails on DirectX.