### PR TITLE
[Metal] Add UInt64/Int64 handling to getMTLFormat

### DIFF
--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -110,6 +110,14 @@ static MTL::PixelFormat getMTLFormat(DataFormat Format, int Channels) {
     MTLFormats(32Sint) break;
   case DataFormat::Float32:
     MTLFormats(32Float) break;
+  case DataFormat::UInt64:
+  case DataFormat::Int64:
+    if (Channels == 1)
+      return MTL::PixelFormatRG32Uint;
+    if (Channels == 2)
+      return MTL::PixelFormatRGBA32Uint;
+    llvm_unreachable("Unsupported channel count for 64-bit format");
+
   default:
     llvm_unreachable("Unsupported Resource format specified");
   }

--- a/test/Feature/TypedBuffer/64bit-scalar.test
+++ b/test/Feature/TypedBuffer/64bit-scalar.test
@@ -122,8 +122,6 @@ DescriptorSets:
 ...
 #--- end
 
-# UNSUPPORTED: Metal
-
 # Bug https://github.com/llvm/offload-test-suite/issues/1110
 # XFAIL: Intel && Vulkan && DXC
 

--- a/test/Feature/TypedBuffer/64bit-vector.test
+++ b/test/Feature/TypedBuffer/64bit-vector.test
@@ -122,8 +122,6 @@ DescriptorSets:
 ...
 #--- end
 
-# UNSUPPORTED: Metal
-
 # This test is failing on Vulkan due to two separate issues.
 # Bug https://github.com/llvm/offload-test-suite/issues/1030
 # Bug https://github.com/llvm/offload-test-suite/issues/1037


### PR DESCRIPTION
This matches the DX implementation and was simply missing.