### PR TITLE
Add a Minimal Mesh Shader Test that runs on the DX12 backend.

### DIFF
--- a/include/API/Encoder.h
+++ b/include/API/Encoder.h
@@ -109,6 +109,10 @@ public:
                                     uint32_t InstanceCount,
                                     uint32_t FirstVertex = 0,
                                     uint32_t FirstInstance = 0) = 0;
+
+  virtual llvm::Error dispatchMesh(const PipelineState &PSO,
+                                   uint32_t GroupCountX, uint32_t GroupCountY,
+                                   uint32_t GroupCountZ) = 0;
 };
 
 } // namespace offloadtest

--- a/include/Support/Pipeline.h
+++ b/include/Support/Pipeline.h
@@ -26,15 +26,25 @@
 
 namespace offloadtest {
 
-enum class Stages { Compute, Vertex, Pixel };
+enum class Stages {
+  // Compute
+  Compute,
+
+  // Traditional Raster
+  Vertex,
+  Pixel,
+
+  // Mesh Shader
+  Amplification,
+  Mesh
+};
 inline constexpr std::array AllStages = {
-    Stages::Compute,
-    Stages::Vertex,
-    Stages::Pixel,
+    Stages::Compute,       Stages::Vertex, Stages::Pixel,
+    Stages::Amplification, Stages::Mesh,
 };
 inline constexpr size_t NumStages = AllStages.size();
 
-enum class ShaderPipelineKind { Compute, TraditionalRaster };
+enum class ShaderPipelineKind { Compute, TraditionalRaster, MeshShaderRaster };
 
 enum class Rule { BufferExact, BufferFloatULP, BufferFloatEpsilon };
 
@@ -503,6 +513,12 @@ struct Pipeline {
   bool isTraditionalRaster() const {
     return Kind == ShaderPipelineKind::TraditionalRaster;
   }
+  bool isMeshShaderRaster() const {
+    return Kind == ShaderPipelineKind::MeshShaderRaster;
+  }
+  bool isRaster() const {
+    return isTraditionalRaster() || isMeshShaderRaster();
+  }
 };
 } // namespace offloadtest
 
@@ -713,6 +729,8 @@ template <> struct ScalarEnumerationTraits<offloadtest::Stages> {
     ENUM_CASE(Compute);
     ENUM_CASE(Vertex);
     ENUM_CASE(Pixel);
+    ENUM_CASE(Amplification);
+    ENUM_CASE(Mesh);
 #undef ENUM_CASE
   }
 };

--- a/include/Support/Pipeline.h
+++ b/include/Support/Pipeline.h
@@ -34,7 +34,7 @@ enum class Stages {
   Vertex,
   Pixel,
 
-  // Mesh Shader
+  // Mesh Shader Raster
   Amplification,
   Mesh
 };

--- a/lib/API/DX/DXFeatures.cpp
+++ b/lib/API/DX/DXFeatures.cpp
@@ -34,6 +34,15 @@ static ArrayRef<EnumEntry<RootSignature>> getRootSignatures() {
   return ArrayRef(RootSignatureNames);
 }
 
+#define MESH_SHADER_TIER_ENUM(NewCase, Str, Value) {#Str, NewCase},
+static const EnumEntry<directx::MeshShaderTier> MeshShaderTierNames[]{
+#include "DXFeatures.def"
+};
+
+static ArrayRef<EnumEntry<MeshShaderTier>> getMeshShaderTiers() {
+  return ArrayRef(MeshShaderTierNames);
+}
+
 template <typename T>
 static std::string enumEntryToString(ArrayRef<EnumEntry<T>> EnumValues,
                                      T Value) {
@@ -51,4 +60,9 @@ std::string CapabilityPrinter<directx::ShaderModel>::toString(
 std::string CapabilityPrinter<directx::RootSignature>::toString(
     const directx::RootSignature &V) {
   return enumEntryToString(getRootSignatures(), V);
+}
+
+std::string CapabilityPrinter<directx::MeshShaderTier>::toString(
+    const directx::MeshShaderTier &V) {
+  return enumEntryToString(getMeshShaderTiers(), V);
 }

--- a/lib/API/DX/DXFeatures.def
+++ b/lib/API/DX/DXFeatures.def
@@ -22,9 +22,16 @@ ROOT_SIGNATURE_ENUM(RootSig_v1_2, 1.2, 0x3)
 #undef ROOT_SIGNATURE_ENUM
 #endif
 
+#ifdef MESH_SHADER_TIER_ENUM
+MESH_SHADER_TIER_ENUM(MeshShaderNotSupported, NotSupported, 0)
+MESH_SHADER_TIER_ENUM(MeshShaderTier1, Tier1,10)
+#undef MESH_SHADER_TIER_ENUM
+#endif
+
 #ifdef D3D_FEATURE_ENUM
 D3D_FEATURE_ENUM(directx::ShaderModel, HighestShaderModel)
 D3D_FEATURE_ENUM(directx::RootSignature, HighestRootSignatureVersion)
+D3D_FEATURE_ENUM(directx::MeshShaderTier, MeshShaderTier)
 #undef D3D_FEATURE_ENUM
 #endif
 

--- a/lib/API/DX/DXFeatures.h
+++ b/lib/API/DX/DXFeatures.h
@@ -32,6 +32,11 @@ enum RootSignature {
 #include "DXFeatures.def"
 };
 
+#define MESH_SHADER_TIER_ENUM(NewCase, Str, Value) NewCase = Value,
+enum MeshShaderTier {
+#include "DXFeatures.def"
+};
+
 } // namespace directx
 
 template <> struct CapabilityPrinter<directx::ShaderModel> {
@@ -40,6 +45,10 @@ template <> struct CapabilityPrinter<directx::ShaderModel> {
 
 template <> struct CapabilityPrinter<directx::RootSignature> {
   static std::string toString(const directx::RootSignature &V);
+};
+
+template <> struct CapabilityPrinter<directx::MeshShaderTier> {
+  static std::string toString(const directx::MeshShaderTier &V);
 };
 
 } // namespace offloadtest

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -57,16 +57,18 @@
 using namespace offloadtest;
 using Microsoft::WRL::ComPtr;
 
+using ID3D12DeviceX = ID3D12Device2;
+
 template <> char CapabilityValueEnum<directx::ShaderModel>::ID = 0;
 template <> char CapabilityValueEnum<directx::RootSignature>::ID = 0;
 template <> char CapabilityValueEnum<directx::MeshShaderTier>::ID = 0;
 
 static std::mutex SignalHandlerMutex;
-static llvm::SmallVector<ID3D12Device *> SignalHandlerDevices;
+static llvm::SmallVector<ID3D12DeviceX *> SignalHandlerDevices;
 
 static void dumpD3DInfoQueues(void *) {
   const std::lock_guard<std::mutex> Lock(SignalHandlerMutex);
-  for (ID3D12Device *Device : SignalHandlerDevices) {
+  for (ID3D12DeviceX *Device : SignalHandlerDevices) {
     ComPtr<ID3D12InfoQueue> InfoQueue;
     HRESULT HR = Device->QueryInterface(InfoQueue.GetAddressOf());
     if (FAILED(HR)) {
@@ -405,7 +407,7 @@ public:
   int Event;
 #endif
 
-  static llvm::Expected<std::unique_ptr<DXFence>> create(ID3D12Device *Device,
+  static llvm::Expected<std::unique_ptr<DXFence>> create(ID3D12DeviceX *Device,
                                                          llvm::StringRef Name) {
     ComPtr<ID3D12Fence> Fence;
     if (auto Err = HR::toError(
@@ -488,7 +490,7 @@ public:
   ~DXQueue() override {}
 
   static llvm::Expected<DXQueue>
-  createGraphicsQueue(ComPtr<ID3D12Device> Device) {
+  createGraphicsQueue(ComPtr<ID3D12DeviceX> Device) {
     const D3D12_COMMAND_QUEUE_DESC Desc = {D3D12_COMMAND_LIST_TYPE_DIRECT, 0,
                                            D3D12_COMMAND_QUEUE_FLAG_NONE, 0};
     ComPtr<ID3D12CommandQueue> CmdQueue;
@@ -515,7 +517,7 @@ public:
   bool PendingUAVBarrier = false;
 
   static llvm::Expected<std::unique_ptr<DXCommandBuffer>>
-  create(ComPtr<ID3D12Device> Device) {
+  create(ComPtr<ID3D12DeviceX> Device) {
     auto CB = std::unique_ptr<DXCommandBuffer>(new DXCommandBuffer());
     if (auto Err = HR::toError(
             Device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT,
@@ -565,7 +567,7 @@ struct DescriptorAllocator {
   uint32_t Capacity;
 
   static llvm::Expected<DescriptorAllocator>
-  create(ID3D12Device *Device, D3D12_DESCRIPTOR_HEAP_TYPE Type,
+  create(ID3D12DeviceX *Device, D3D12_DESCRIPTOR_HEAP_TYPE Type,
          uint32_t Capacity) {
     ComPtr<ID3D12DescriptorHeap> Heap;
     const D3D12_DESCRIPTOR_HEAP_DESC HeapDesc = {
@@ -877,7 +879,7 @@ DXCommandBuffer::createRenderEncoder(
 class DXDevice : public offloadtest::Device {
 private:
   ComPtr<IDXCoreAdapter> Adapter;
-  ComPtr<ID3D12Device> Device;
+  ComPtr<ID3D12DeviceX> Device;
   DXQueue GraphicsQueue;
   Capabilities Caps;
   DescriptorAllocator RTVAllocator;
@@ -920,7 +922,7 @@ private:
   };
 
 public:
-  DXDevice(ComPtr<IDXCoreAdapter> A, ComPtr<ID3D12Device> D, DXQueue Q,
+  DXDevice(ComPtr<IDXCoreAdapter> A, ComPtr<ID3D12DeviceX> D, DXQueue Q,
            DescriptorAllocator RTVAllocator, DescriptorAllocator DSVAllocator,
            std::string Desc)
       : Adapter(A), Device(D), GraphicsQueue(std::move(Q)),
@@ -1223,14 +1225,9 @@ public:
     const D3D12_PIPELINE_STATE_STREAM_DESC StreamDesc = {sizeof(Stream),
                                                          &Stream};
 
-    ComPtr<ID3D12Device2> Device2;
-    if (auto Err =
-            HR::toError(Device.As(&Device2), "Failed to query ID3D12Device2."))
-      return Err;
-
     ComPtr<ID3D12PipelineState> PSO;
     if (auto Err = HR::toError(
-            Device2->CreatePipelineState(&StreamDesc, IID_PPV_ARGS(&PSO)),
+            Device->CreatePipelineState(&StreamDesc, IID_PPV_ARGS(&PSO)),
             "Failed to create mesh shader PSO."))
       return Err;
 
@@ -1356,7 +1353,7 @@ public:
 
   static llvm::Expected<std::unique_ptr<offloadtest::Device>>
   create(ComPtr<IDXCoreAdapter> Adapter, const DeviceConfig &Config) {
-    ComPtr<ID3D12Device> Device;
+    ComPtr<ID3D12DeviceX> Device;
     if (auto Err =
             HR::toError(D3D12CreateDevice(Adapter.Get(), D3D_FEATURE_LEVEL_11_0,
                                           IID_PPV_ARGS(&Device)),
@@ -1430,7 +1427,7 @@ public:
 #include "DXFeatures.def"
   }
 
-  static llvm::Error configureInfoQueue(ID3D12Device *Device) {
+  static llvm::Error configureInfoQueue(ID3D12DeviceX *Device) {
 #ifdef _WIN32
     ComPtr<ID3D12InfoQueue> InfoQueue;
     if (auto Err = HR::toError(Device->QueryInterface(InfoQueue.GetAddressOf()),

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -1165,8 +1165,8 @@ public:
                                        /*IsGraphics=*/true, RootSig))
       return Err;
 
-    D3D12_SHADER_BYTECODE MSBytecode = {MS.Shader->getBuffer().data(),
-                                        MS.Shader->getBuffer().size()};
+    const D3D12_SHADER_BYTECODE MSBytecode = {MS.Shader->getBuffer().data(),
+                                              MS.Shader->getBuffer().size()};
     if (MSBytecode.BytecodeLength == 0)
       return llvm::createStringError(
           std::errc::invalid_argument,

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -59,6 +59,7 @@ using Microsoft::WRL::ComPtr;
 
 template <> char CapabilityValueEnum<directx::ShaderModel>::ID = 0;
 template <> char CapabilityValueEnum<directx::RootSignature>::ID = 0;
+template <> char CapabilityValueEnum<directx::MeshShaderTier>::ID = 0;
 
 static std::mutex SignalHandlerMutex;
 static llvm::SmallVector<ID3D12Device *> SignalHandlerDevices;

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -1143,6 +1143,90 @@ public:
     return std::make_unique<DXPipelineState>(Name, RootSig, PSO);
   }
 
+  llvm::Expected<std::unique_ptr<PipelineState>>
+  createPipelineAsMsPs(llvm::StringRef Name, const BindingsDesc &BindingsDesc,
+                       llvm::ArrayRef<Format> RTFormats,
+                       std::optional<Format> DSFormat,
+                       std::optional<ShaderContainer> AS, ShaderContainer MS,
+                       std::optional<ShaderContainer> PS) /*override*/ {
+    assert(RTFormats.size() <= 8);
+
+    ComPtr<ID3D12RootSignature> RootSig;
+    if (auto Err = createRootSignature(Name, BindingsDesc, MS,
+                                       /*IsGraphics=*/true, RootSig))
+      return Err;
+
+    D3D12_SHADER_BYTECODE MSBytecode = {MS.Shader->getBuffer().data(),
+                                        MS.Shader->getBuffer().size()};
+    if (MSBytecode.BytecodeLength == 0)
+      return llvm::createStringError(
+          std::errc::invalid_argument,
+          "Mesh shader pipeline requires a mesh shader.");
+
+    // The amplification (task) shader is optional.
+    D3D12_SHADER_BYTECODE ASBytecode = {};
+    if (AS) {
+      assert((*AS).Shader->getBufferSize() > 0 &&
+             "The passed task/amplification shader was empty.");
+      ASBytecode = {(*AS).Shader->getBuffer().data(),
+                    (*AS).Shader->getBuffer().size()};
+    }
+
+    // The pixel shader is optional
+    D3D12_SHADER_BYTECODE PSBytecode = {};
+    if (PS) {
+      assert((*PS).Shader->getBufferSize() > 0 &&
+             "The passed pixel shader was empty.");
+      PSBytecode = {(*PS).Shader->getBuffer().data(),
+                    (*PS).Shader->getBuffer().size()};
+    }
+
+    D3D12_RT_FORMAT_ARRAY RTArray = {};
+    RTArray.NumRenderTargets = static_cast<UINT>(RTFormats.size());
+    for (size_t I = 0; I < RTFormats.size(); ++I)
+      RTArray.RTFormats[I] = getDXGIFormat(RTFormats[I]);
+
+    CD3DX12_DEPTH_STENCIL_DESC1 DepthStencil(D3D12_DEFAULT);
+    DepthStencil.DepthEnable = true;
+    DepthStencil.DepthWriteMask = D3D12_DEPTH_WRITE_MASK_ALL;
+    DepthStencil.DepthFunc = D3D12_COMPARISON_FUNC_LESS;
+    DepthStencil.StencilEnable = false;
+
+    DXGI_SAMPLE_DESC SampleDesc = {};
+    SampleDesc.Count = 1;
+
+    CD3DX12_PIPELINE_MESH_STATE_STREAM Stream;
+    Stream.pRootSignature = RootSig.Get();
+    Stream.AS = ASBytecode;
+    Stream.MS = MSBytecode;
+    Stream.PS = PSBytecode;
+    Stream.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
+    Stream.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
+    Stream.DepthStencilState = DepthStencil;
+    Stream.SampleMask = UINT_MAX;
+    Stream.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+    Stream.RTVFormats = RTArray;
+    if (DSFormat)
+      Stream.DSVFormat = getDXGIFormat(*DSFormat);
+    Stream.SampleDesc = SampleDesc;
+
+    const D3D12_PIPELINE_STATE_STREAM_DESC StreamDesc = {sizeof(Stream),
+                                                         &Stream};
+
+    ComPtr<ID3D12Device2> Device2;
+    if (auto Err =
+            HR::toError(Device.As(&Device2), "Failed to query ID3D12Device2."))
+      return Err;
+
+    ComPtr<ID3D12PipelineState> PSO;
+    if (auto Err = HR::toError(
+            Device2->CreatePipelineState(&StreamDesc, IID_PPV_ARGS(&PSO)),
+            "Failed to create mesh shader PSO."))
+      return Err;
+
+    return std::make_unique<DXPipelineState>(Name, RootSig, PSO);
+  }
+
   llvm::Expected<std::unique_ptr<offloadtest::Fence>>
   createFence(llvm::StringRef Name) override {
     return DXFence::create(Device.Get(), Name);
@@ -2272,6 +2356,19 @@ public:
       BindingsDesc.DescriptorSetDescs.push_back(Layout);
     }
 
+    if (P.isRaster()) {
+      // Create render target, depth/stencil, readback and vertex buffer and
+      // PSO.
+      if (auto Err = createRenderTarget(P, State))
+        return Err;
+      llvm::outs() << "Render target created.\n";
+      // TODO: Always created for graphics pipelines. Consider making this
+      // conditional on the pipeline definition.
+      if (auto Err = createDepthStencil(P, State))
+        return Err;
+      llvm::outs() << "Depth stencil created.\n";
+    }
+
     if (P.isCompute()) {
       // This is an arbitrary distinction that we could alter in the future.
       if (P.Shaders.size() != 1 || P.Shaders[0].Stage != Stages::Compute)
@@ -2294,17 +2391,6 @@ public:
       llvm::outs() << "Compute command list created.\n";
 
     } else if (P.isTraditionalRaster()) {
-      // Create render target, depth/stencil, readback and vertex buffer and
-      // PSO.
-      if (auto Err = createRenderTarget(P, State))
-        return Err;
-      llvm::outs() << "Render target created.\n";
-      // TODO: Always created for graphics pipelines. Consider making this
-      // conditional on the pipeline definition.
-      if (auto Err = createDepthStencil(P, State))
-        return Err;
-      llvm::outs() << "Depth stencil created.\n";
-
       ShaderContainer VS = {};
       ShaderContainer PS = {};
       for (auto &Shader : P.Shaders) {
@@ -2340,12 +2426,12 @@ public:
       RTFormats.push_back(*FormatOrErr);
 
       auto PipelineStateOrErr = createPipelineVsPs(
-          "Graphics Pipeline State", BindingsDesc, InputLayout, RTFormats,
-          Format::D32FloatS8Uint, VS, PS);
+          "Traditional Raster Pipeline State", BindingsDesc, InputLayout,
+          RTFormats, Format::D32FloatS8Uint, VS, PS);
       if (!PipelineStateOrErr)
         return PipelineStateOrErr.takeError();
       State.Pipeline = std::move(*PipelineStateOrErr);
-      llvm::outs() << "Graphics Pipeline created.\n";
+      llvm::outs() << "Traditional Raster Pipeline created.\n";
 
       // Begin a render pass: bind RT/DSV and clear depth-stencil. Color
       // load action is Load — the existing inline code didn't clear color.
@@ -2374,6 +2460,43 @@ public:
       if (auto Err = createGraphicsCommands(P, State))
         return Err;
       llvm::outs() << "Graphics command list created complete.\n";
+    } else if (P.isMeshShaderRaster()) {
+      std::optional<ShaderContainer> AS = {};
+      ShaderContainer MS = {};
+      std::optional<ShaderContainer> PS = {};
+      for (auto &Shader : P.Shaders) {
+        if (Shader.Stage == Stages::Amplification) {
+          ShaderContainer Container;
+          Container.EntryPoint = Shader.Entry;
+          Container.Shader = Shader.Shader.get();
+          AS = Container;
+        } else if (Shader.Stage == Stages::Mesh) {
+          MS.EntryPoint = Shader.Entry;
+          MS.Shader = Shader.Shader.get();
+        } else if (Shader.Stage == Stages::Pixel) {
+          ShaderContainer Container;
+          Container.EntryPoint = Shader.Entry;
+          Container.Shader = Shader.Shader.get();
+          PS = Container;
+        }
+      }
+
+      auto FormatOrErr = toFormat(P.Bindings.RTargetBufferPtr->Format,
+                                  P.Bindings.RTargetBufferPtr->Channels);
+      if (!FormatOrErr)
+        return FormatOrErr.takeError();
+
+      llvm::SmallVector<Format> RTFormats;
+      RTFormats.push_back(*FormatOrErr);
+
+      auto PipelineStateOrErr =
+          createPipelineAsMsPs("Mesh Shader Pipeline State", BindingsDesc,
+                               RTFormats, Format::D32FloatS8Uint, AS, MS, PS);
+
+      if (!PipelineStateOrErr)
+        return PipelineStateOrErr.takeError();
+      State.Pipeline = std::move(*PipelineStateOrErr);
+      llvm::outs() << "Mesh Shader Pipeline created.\n";
     } else {
       return llvm::createStringError(
           "Pipeline was neither Compute nor Traditional Raster");

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -1157,7 +1157,7 @@ public:
                        llvm::ArrayRef<Format> RTFormats,
                        std::optional<Format> DSFormat,
                        std::optional<ShaderContainer> AS, ShaderContainer MS,
-                       std::optional<ShaderContainer> PS) /*override*/ {
+                       std::optional<ShaderContainer> PS) {
     assert(RTFormats.size() <= 8);
 
     ComPtr<ID3D12RootSignature> RootSig;
@@ -2377,8 +2377,7 @@ public:
     }
 
     if (P.isRaster()) {
-      // Create render target, depth/stencil, readback and vertex buffer and
-      // PSO.
+      // Create render target and depth/stencil
       if (auto Err = createRenderTarget(P, State))
         return Err;
       llvm::outs() << "Render target created.\n";

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -58,6 +58,7 @@ using namespace offloadtest;
 using Microsoft::WRL::ComPtr;
 
 using ID3D12DeviceX = ID3D12Device2;
+using ID3D12GraphicsCommandListX = ID3D12GraphicsCommandList6;
 
 template <> char CapabilityValueEnum<directx::ShaderModel>::ID = 0;
 template <> char CapabilityValueEnum<directx::RootSignature>::ID = 0;
@@ -512,7 +513,7 @@ public:
 class DXCommandBuffer : public offloadtest::CommandBuffer {
 public:
   ComPtr<ID3D12CommandAllocator> Allocator;
-  ComPtr<ID3D12GraphicsCommandList6> CmdList;
+  ComPtr<ID3D12GraphicsCommandListX> CmdList;
   /// Whether a UAV barrier is pending from a prior compute command.
   bool PendingUAVBarrier = false;
 

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -509,7 +509,7 @@ public:
 class DXCommandBuffer : public offloadtest::CommandBuffer {
 public:
   ComPtr<ID3D12CommandAllocator> Allocator;
-  ComPtr<ID3D12GraphicsCommandList> CmdList;
+  ComPtr<ID3D12GraphicsCommandList6> CmdList;
   /// Whether a UAV barrier is pending from a prior compute command.
   bool PendingUAVBarrier = false;
 
@@ -754,6 +754,15 @@ public:
       return Err;
     CB.CmdList->DrawInstanced(VertexCount, InstanceCount, FirstVertex,
                               FirstInstance);
+    return llvm::Error::success();
+  }
+
+  llvm::Error dispatchMesh(const offloadtest::PipelineState &PSO,
+                           uint32_t GroupCountX, uint32_t GroupCountY,
+                           uint32_t GroupCountZ) override {
+    if (auto Err = bindCommonDrawState(PSO))
+      return Err;
+    CB.CmdList->DispatchMesh(GroupCountX, GroupCountY, GroupCountZ);
     return llvm::Error::success();
   }
 
@@ -2255,12 +2264,23 @@ public:
     Scissor.Height = static_cast<uint32_t>(VP.Height);
     Encoder.setScissor(Scissor);
 
-    if (IS.VB)
-      Encoder.setVertexBuffer(0, IS.VB.get(), 0, P.Bindings.getVertexStride());
+    if (P.isTraditionalRaster()) {
+      if (IS.VB)
+        Encoder.setVertexBuffer(0, IS.VB.get(), 0,
+                                P.Bindings.getVertexStride());
 
-    if (auto Err = Encoder.drawInstanced(*IS.Pipeline.get(), P.getVertexCount(),
-                                         /*InstanceCount=*/1))
-      return Err;
+      if (auto Err =
+              Encoder.drawInstanced(*IS.Pipeline.get(), P.getVertexCount(),
+                                    /*InstanceCount=*/1))
+        return Err;
+    } else {
+      if (auto Err = Encoder.dispatchMesh(
+              *IS.Pipeline.get(), P.DispatchParameters.DispatchGroupCount[0],
+              P.DispatchParameters.DispatchGroupCount[1],
+              P.DispatchParameters.DispatchGroupCount[2]))
+        return Err;
+    }
+
     Encoder.endEncoding();
 
     // Transition the render target to copy source and copy to the readback
@@ -2390,49 +2410,7 @@ public:
         return Err;
       llvm::outs() << "Compute command list created.\n";
 
-    } else if (P.isTraditionalRaster()) {
-      ShaderContainer VS = {};
-      ShaderContainer PS = {};
-      for (auto &Shader : P.Shaders) {
-        if (Shader.Stage == Stages::Vertex) {
-          VS.EntryPoint = Shader.Entry;
-          VS.Shader = Shader.Shader.get();
-        } else if (Shader.Stage == Stages::Pixel) {
-          PS.EntryPoint = Shader.Entry;
-          PS.Shader = Shader.Shader.get();
-        }
-      }
-
-      // Create the input layout based on the vertex attributes.
-      llvm::SmallVector<InputLayoutDesc> InputLayout;
-      for (auto &Attr : P.Bindings.VertexAttributes) {
-        auto FormatOrErr = toFormat(Attr.Format, Attr.Channels);
-        if (!FormatOrErr)
-          return FormatOrErr.takeError();
-
-        InputLayoutDesc Desc = {};
-        Desc.Name = Attr.Name;
-        Desc.Fmt = *FormatOrErr;
-        Desc.OffsetInBytes = Attr.Offset;
-        InputLayout.push_back(Desc);
-      }
-
-      auto FormatOrErr = toFormat(P.Bindings.RTargetBufferPtr->Format,
-                                  P.Bindings.RTargetBufferPtr->Channels);
-      if (!FormatOrErr)
-        return FormatOrErr.takeError();
-
-      llvm::SmallVector<Format> RTFormats;
-      RTFormats.push_back(*FormatOrErr);
-
-      auto PipelineStateOrErr = createPipelineVsPs(
-          "Traditional Raster Pipeline State", BindingsDesc, InputLayout,
-          RTFormats, Format::D32FloatS8Uint, VS, PS);
-      if (!PipelineStateOrErr)
-        return PipelineStateOrErr.takeError();
-      State.Pipeline = std::move(*PipelineStateOrErr);
-      llvm::outs() << "Traditional Raster Pipeline created.\n";
-
+    } else if (P.isRaster()) {
       // Begin a render pass: bind RT/DSV and clear depth-stencil. Color
       // load action is Load — the existing inline code didn't clear color.
       ColorAttachmentFormatDesc ColorAttachment = {};
@@ -2457,49 +2435,93 @@ public:
       State.RenderPass = std::move(*RenderPassOrErr);
       llvm::outs() << "Render pass created.\n";
 
+      if (P.isTraditionalRaster()) {
+        ShaderContainer VS = {};
+        ShaderContainer PS = {};
+        for (auto &Shader : P.Shaders) {
+          if (Shader.Stage == Stages::Vertex) {
+            VS.EntryPoint = Shader.Entry;
+            VS.Shader = Shader.Shader.get();
+          } else if (Shader.Stage == Stages::Pixel) {
+            PS.EntryPoint = Shader.Entry;
+            PS.Shader = Shader.Shader.get();
+          }
+        }
+
+        // Create the input layout based on the vertex attributes.
+        llvm::SmallVector<InputLayoutDesc> InputLayout;
+        for (auto &Attr : P.Bindings.VertexAttributes) {
+          auto FormatOrErr = toFormat(Attr.Format, Attr.Channels);
+          if (!FormatOrErr)
+            return FormatOrErr.takeError();
+
+          InputLayoutDesc Desc = {};
+          Desc.Name = Attr.Name;
+          Desc.Fmt = *FormatOrErr;
+          Desc.OffsetInBytes = Attr.Offset;
+          InputLayout.push_back(Desc);
+        }
+
+        auto FormatOrErr = toFormat(P.Bindings.RTargetBufferPtr->Format,
+                                    P.Bindings.RTargetBufferPtr->Channels);
+        if (!FormatOrErr)
+          return FormatOrErr.takeError();
+
+        llvm::SmallVector<Format> RTFormats;
+        RTFormats.push_back(*FormatOrErr);
+
+        auto PipelineStateOrErr = createPipelineVsPs(
+            "Traditional Raster Pipeline State", BindingsDesc, InputLayout,
+            RTFormats, Format::D32FloatS8Uint, VS, PS);
+        if (!PipelineStateOrErr)
+          return PipelineStateOrErr.takeError();
+        State.Pipeline = std::move(*PipelineStateOrErr);
+        llvm::outs() << "Traditional Raster Pipeline created.\n";
+
+      } else if (P.isMeshShaderRaster()) {
+        std::optional<ShaderContainer> AS = {};
+        ShaderContainer MS = {};
+        std::optional<ShaderContainer> PS = {};
+        for (auto &Shader : P.Shaders) {
+          if (Shader.Stage == Stages::Amplification) {
+            ShaderContainer Container;
+            Container.EntryPoint = Shader.Entry;
+            Container.Shader = Shader.Shader.get();
+            AS = Container;
+          } else if (Shader.Stage == Stages::Mesh) {
+            MS.EntryPoint = Shader.Entry;
+            MS.Shader = Shader.Shader.get();
+          } else if (Shader.Stage == Stages::Pixel) {
+            ShaderContainer Container;
+            Container.EntryPoint = Shader.Entry;
+            Container.Shader = Shader.Shader.get();
+            PS = Container;
+          }
+        }
+
+        auto FormatOrErr = toFormat(P.Bindings.RTargetBufferPtr->Format,
+                                    P.Bindings.RTargetBufferPtr->Channels);
+        if (!FormatOrErr)
+          return FormatOrErr.takeError();
+
+        llvm::SmallVector<Format> RTFormats;
+        RTFormats.push_back(*FormatOrErr);
+
+        auto PipelineStateOrErr =
+            createPipelineAsMsPs("Mesh Shader Pipeline State", BindingsDesc,
+                                 RTFormats, Format::D32FloatS8Uint, AS, MS, PS);
+
+        if (!PipelineStateOrErr)
+          return PipelineStateOrErr.takeError();
+        State.Pipeline = std::move(*PipelineStateOrErr);
+        llvm::outs() << "Mesh Shader Pipeline created.\n";
+      }
+
       if (auto Err = createGraphicsCommands(P, State))
         return Err;
       llvm::outs() << "Graphics command list created complete.\n";
-    } else if (P.isMeshShaderRaster()) {
-      std::optional<ShaderContainer> AS = {};
-      ShaderContainer MS = {};
-      std::optional<ShaderContainer> PS = {};
-      for (auto &Shader : P.Shaders) {
-        if (Shader.Stage == Stages::Amplification) {
-          ShaderContainer Container;
-          Container.EntryPoint = Shader.Entry;
-          Container.Shader = Shader.Shader.get();
-          AS = Container;
-        } else if (Shader.Stage == Stages::Mesh) {
-          MS.EntryPoint = Shader.Entry;
-          MS.Shader = Shader.Shader.get();
-        } else if (Shader.Stage == Stages::Pixel) {
-          ShaderContainer Container;
-          Container.EntryPoint = Shader.Entry;
-          Container.Shader = Shader.Shader.get();
-          PS = Container;
-        }
-      }
-
-      auto FormatOrErr = toFormat(P.Bindings.RTargetBufferPtr->Format,
-                                  P.Bindings.RTargetBufferPtr->Channels);
-      if (!FormatOrErr)
-        return FormatOrErr.takeError();
-
-      llvm::SmallVector<Format> RTFormats;
-      RTFormats.push_back(*FormatOrErr);
-
-      auto PipelineStateOrErr =
-          createPipelineAsMsPs("Mesh Shader Pipeline State", BindingsDesc,
-                               RTFormats, Format::D32FloatS8Uint, AS, MS, PS);
-
-      if (!PipelineStateOrErr)
-        return PipelineStateOrErr.takeError();
-      State.Pipeline = std::move(*PipelineStateOrErr);
-      llvm::outs() << "Mesh Shader Pipeline created.\n";
     } else {
-      return llvm::createStringError(
-          "Pipeline was neither Compute nor Traditional Raster");
+      return llvm::createStringError("Pipeline was neither Compute nor Raster");
     }
 
     auto SubmitResult = GraphicsQueue.submit(std::move(State.CB));

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -697,6 +697,11 @@ public:
   llvm::Error dispatchMesh(const offloadtest::PipelineState &PSO,
                            uint32_t GroupCountX, uint32_t GroupCountY,
                            uint32_t GroupCountZ) override {
+    (void)PSO;
+    (void)GroupCountX;
+    (void)GroupCountY;
+    (void)GroupCountZ;
+
     return llvm::createStringError(
         "dispatchMesh is unimplemented in the Metal backend.");
   }

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -527,13 +527,6 @@ public:
     return llvm::Error::success();
   }
 
-  llvm::Error dispatchMesh(const offloadtest::PipelineState &PSO,
-                           uint32_t GroupCountX, uint32_t GroupCountY,
-                           uint32_t GroupCountZ) override {
-    return llvm::createStringError(
-        "dispatchMesh is unimplemented in the Metal backend.");
-  }
-
   llvm::Error copyBufferToBuffer(offloadtest::Buffer &Src, size_t SrcOffset,
                                  offloadtest::Buffer &Dst, size_t DstOffset,
                                  size_t Size) override {
@@ -699,6 +692,13 @@ public:
                             static_cast<NS::UInteger>(FirstInstance));
 
     return llvm::Error::success();
+  }
+
+  llvm::Error dispatchMesh(const offloadtest::PipelineState &PSO,
+                           uint32_t GroupCountX, uint32_t GroupCountY,
+                           uint32_t GroupCountZ) override {
+    return llvm::createStringError(
+        "dispatchMesh is unimplemented in the Metal backend.");
   }
 
   void endEncodingImpl() override {

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -1435,7 +1435,7 @@ class MTLDevice : public offloadtest::Device {
         if (auto Err = MemCpyBack(R))
           return Err;
 
-    if (P.isTraditionalRaster()) {
+    if (P.isRaster()) {
       auto &FBReadback = llvm::cast<MTLBuffer>(*IS.FrameBufferReadback);
       auto *RT = P.Bindings.RTargetBufferPtr;
       RT->copyFromTexture(FBReadback.Buf->contents(), RT->getImageRowBytes());

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -523,6 +523,13 @@ public:
     return llvm::Error::success();
   }
 
+  llvm::Error dispatchMesh(const offloadtest::PipelineState &PSO,
+                           uint32_t GroupCountX, uint32_t GroupCountY,
+                           uint32_t GroupCountZ) override {
+    return llvm::createStringError(
+        "dispatchMesh is unimplemented in the Metal backend.");
+  }
+
   llvm::Error copyBufferToBuffer(offloadtest::Buffer &Src, size_t SrcOffset,
                                  offloadtest::Buffer &Dst, size_t DstOffset,
                                  size_t Size) override {

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -135,6 +135,10 @@ static IRShaderStage getShaderStage(Stages Stage) {
     return IRShaderStageVertex;
   case Stages::Pixel:
     return IRShaderStageFragment;
+  case Stages::Amplification:
+    return IRShaderStageAmplification;
+  case Stages::Mesh:
+    return IRShaderStageMesh;
   }
   llvm_unreachable("All cases handled");
 }

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -909,6 +909,13 @@ public:
     return llvm::Error::success();
   }
 
+  llvm::Error dispatchMesh(const offloadtest::PipelineState &PSO,
+                           uint32_t GroupCountX, uint32_t GroupCountY,
+                           uint32_t GroupCountZ) override {
+    return llvm::createStringError(
+        "dispatchMesh is unimplemented in the Vulkan backend.");
+  }
+
   void endEncodingImpl() override {
     vkCmdEndRenderPass(CB.CmdBuffer);
     popDebugGroup();

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -914,6 +914,11 @@ public:
   llvm::Error dispatchMesh(const offloadtest::PipelineState &PSO,
                            uint32_t GroupCountX, uint32_t GroupCountY,
                            uint32_t GroupCountZ) override {
+    (void)PSO;
+    (void)GroupCountX;
+    (void)GroupCountY;
+    (void)GroupCountZ;
+
     return llvm::createStringError(
         "dispatchMesh is unimplemented in the Vulkan backend.");
   }

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -208,6 +208,8 @@ static VkShaderStageFlagBits getShaderStageFlag(Stages Stage) {
     return VK_SHADER_STAGE_VERTEX_BIT;
   case Stages::Pixel:
     return VK_SHADER_STAGE_FRAGMENT_BIT;
+  case Stages::Mesh:
+    return VK_SHADER_STAGE_MESH_BIT_EXT;
   }
   llvm_unreachable("All cases handled");
 }
@@ -2291,7 +2293,7 @@ public:
       }
     }
 
-    if (P.isTraditionalRaster()) {
+    if (P.isRaster()) {
       if (auto Err = createRenderTarget(P, IS))
         return Err;
       // TODO: Always created for graphics pipelines. Consider making this
@@ -3055,7 +3057,7 @@ public:
     }
 
     // Copy back the frame buffer data if this was a graphics pipeline.
-    if (P.isTraditionalRaster()) {
+    if (P.isRaster()) {
       auto &Readback = llvm::cast<VulkanBuffer>(*IS.RTReadback);
 
       VkMappedMemoryRange Range = {};

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -208,6 +208,8 @@ static VkShaderStageFlagBits getShaderStageFlag(Stages Stage) {
     return VK_SHADER_STAGE_VERTEX_BIT;
   case Stages::Pixel:
     return VK_SHADER_STAGE_FRAGMENT_BIT;
+  case Stages::Amplification:
+    return VK_SHADER_STAGE_TASK_BIT_EXT;
   case Stages::Mesh:
     return VK_SHADER_STAGE_MESH_BIT_EXT;
   }

--- a/lib/Support/Pipeline.cpp
+++ b/lib/Support/Pipeline.cpp
@@ -598,14 +598,24 @@ llvm::Error offloadtest::Pipeline::validatePipelineKind() {
   }
 
   if (HasShaderType[llvm::to_underlying(Stages::Vertex)]) {
+    if (HasShaderType[llvm::to_underlying(Stages::Amplification)] ||
+        HasShaderType[llvm::to_underlying(Stages::Mesh)])
+      return llvm::createStringError("Vertex and Mesh/Amplification Shaders "
+                                     "cannot be used in the same pipeline.");
+
     Kind = ShaderPipelineKind::TraditionalRaster;
+    return llvm::Error::success();
+  }
+
+  if (HasShaderType[llvm::to_underlying(Stages::Mesh)]) {
+    Kind = ShaderPipelineKind::MeshShaderRaster;
     return llvm::Error::success();
   }
 
   // As we add more pipeline types this error message should be updated with
   // more required shader types.
   return llvm::createStringError(
-      "The pipeline misses a Compute or Vertex Shader.");
+      "The pipeline misses a Compute, Vertex or Mesh Shader.");
 }
 
 llvm::Error offloadtest::Pipeline::validateDispatchParameters() {

--- a/lib/Support/Pipeline.cpp
+++ b/lib/Support/Pipeline.cpp
@@ -621,10 +621,11 @@ llvm::Error offloadtest::Pipeline::validatePipelineKind() {
 llvm::Error offloadtest::Pipeline::validateDispatchParameters() {
   switch (Kind) {
   case ShaderPipelineKind::Compute:
+  case ShaderPipelineKind::MeshShaderRaster:
     if (DispatchParameters.VertexCount)
       return llvm::createStringError(
-          "DispatchParameters.VertexCount set on a Compute pipeline. Only "
-          "allowed on a TraditionalRaster pipeline.");
+          "DispatchParameters.VertexCount set on a Compute or Mesh Shader "
+          "pipeline. Only allowed on a TraditionalRaster pipeline.");
     break;
   case ShaderPipelineKind::TraditionalRaster:
     if (DispatchParameters.DispatchGroupCount !=

--- a/test/Graphics/MeshShaders/SimpleTriangle.test
+++ b/test/Graphics/MeshShaders/SimpleTriangle.test
@@ -72,8 +72,8 @@ DescriptorSets: []
 ...
 #--- end
 
-# REQUIRES: MeshShader
-# UNSUPPORTED: Vulkan || Metal || Clang
+# Unimplemented https://github.com/llvm/llvm-project/issues/136966
+# XFAIL Clang
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T ms_6_5 -Fo %t-mesh.o %t/mesh.hlsl

--- a/test/Graphics/MeshShaders/SimpleTriangle.test
+++ b/test/Graphics/MeshShaders/SimpleTriangle.test
@@ -72,6 +72,7 @@ DescriptorSets: []
 ...
 #--- end
 
+# REQUIRES: MeshShader
 # UNSUPPORTED: Vulkan || Metal
 
 # RUN: split-file %s %t

--- a/test/Graphics/MeshShaders/SimpleTriangle.test
+++ b/test/Graphics/MeshShaders/SimpleTriangle.test
@@ -72,6 +72,8 @@ DescriptorSets: []
 ...
 #--- end
 
+REQUIRES: MeshShader
+
 # Unimplemented https://github.com/llvm/llvm-project/issues/136966
 # XFAIL Clang
 

--- a/test/Graphics/MeshShaders/SimpleTriangle.test
+++ b/test/Graphics/MeshShaders/SimpleTriangle.test
@@ -78,4 +78,4 @@ DescriptorSets: []
 # RUN: %dxc_target -T ms_6_5 -Fo %t-mesh.o %t/mesh.hlsl
 # RUN: %dxc_target -T ps_6_5 -Fo %t-pixel.o %t/pixel.hlsl
 # RUN: %offloader %t/pipeline.yaml %t-mesh.o %t-pixel.o -r Output -o %t/Output.png
-# RUN: imgdiff %t/Output.png %goldenimage_dir/hlsl/Graphics/MeshShaders/SimpleTriangle.png -rules %t/rules.yaml
+# RUN: imgdiff %t/Output.png %goldenimage_dir/hlsl/Graphics/SimpleTriangle.png -rules %t/rules.yaml

--- a/test/Graphics/MeshShaders/SimpleTriangle.test
+++ b/test/Graphics/MeshShaders/SimpleTriangle.test
@@ -75,7 +75,7 @@ DescriptorSets: []
 REQUIRES: MeshShader
 
 # Unimplemented https://github.com/llvm/llvm-project/issues/136966
-# XFAIL Clang
+# XFAIL: Clang
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T ms_6_5 -Fo %t-mesh.o %t/mesh.hlsl

--- a/test/Graphics/MeshShaders/SimpleTriangle.test
+++ b/test/Graphics/MeshShaders/SimpleTriangle.test
@@ -73,7 +73,7 @@ DescriptorSets: []
 #--- end
 
 # REQUIRES: MeshShader
-# UNSUPPORTED: Vulkan || Metal
+# UNSUPPORTED: Vulkan || Metal || Clang
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T ms_6_5 -Fo %t-mesh.o %t/mesh.hlsl

--- a/test/Graphics/MeshShaders/SimpleTriangle.test
+++ b/test/Graphics/MeshShaders/SimpleTriangle.test
@@ -1,0 +1,81 @@
+#--- mesh.hlsl
+struct PSInput
+{
+    float4 position : SV_POSITION;
+    float4 color : COLOR;
+};
+
+[outputtopology("triangle")]
+[numthreads(3, 1, 1)]
+void main(uint groupThreadID: SV_GroupThreadID, out vertices PSInput verts[3], out indices uint3 tris[1]) {
+    SetMeshOutputCounts(3, 1);
+
+    float4 position;
+    float4 color;
+    if (groupThreadID == 0) {
+        // position = float4(-1.0, -1.0, 0.0, 1.0);
+        position = float4(0.0, 0.25, 0.0, 1.0);
+        color = float4(1.0, 0.0, 0.0, 1.0);
+    } else if (groupThreadID == 1) {
+        // position = float4(0.0, 1.0, 0.0, 1.0);
+        position = float4(0.25, -0.25, 0.0, 1.0);
+        color = float4(0.0, 1.0, 0.0, 1.0);
+    } else /*if (groupThreadID == 2)*/ {
+        // position = float4(1.0, -1.0, 0.0, 1.0);
+        position = float4(-0.25, -0.25, 0.0, 1.0);
+        color = float4(0.0, 0.0, 1.0, 1.0);
+    }
+
+    verts[groupThreadID].position = position;
+    verts[groupThreadID].color = color;
+
+    if (groupThreadID == 0) {
+        tris[0] = uint3(0, 1, 2);
+    }
+}
+
+#--- pixel.hlsl
+struct PSInput
+{
+    float4 position : SV_POSITION;
+    float4 color : COLOR;
+};
+
+float4 main(PSInput input) : SV_TARGET
+{
+    return input.color;
+}
+#--- pipeline.yaml
+---
+Shaders:
+  - Stage: Mesh
+    Entry: main
+  - Stage: Pixel
+    Entry: main
+Buffers:
+  - Name: Output
+    Format: Float32
+    Channels: 4
+    FillSize: 1048576 # 256x256 @ 16 bytes per pixel
+    OutputProps:
+      Height: 256
+      Width: 256
+      Depth: 1
+Bindings:
+  RenderTarget: Output
+DescriptorSets: []
+...
+#--- rules.yaml
+---
+- Type: PixelPercent
+  Val: 0.2 # No more than 0.2% of pixels may be visibly different.
+...
+#--- end
+
+# UNSUPPORTED: Vulkan || Metal
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T ms_6_5 -Fo %t-mesh.o %t/mesh.hlsl
+# RUN: %dxc_target -T ps_6_5 -Fo %t-pixel.o %t/pixel.hlsl
+# RUN: %offloader %t/pipeline.yaml %t-mesh.o %t-pixel.o -r Output -o %t/Output.png
+# RUN: imgdiff %t/Output.png %goldenimage_dir/hlsl/Graphics/MeshShaders/SimpleTriangle.png -rules %t/rules.yaml

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -150,6 +150,8 @@ def setDeviceFeatures(config, device, compiler):
             config.available_features.add("Int64")
         if device["Features"].get("AtomicInt64OnGroupSharedSupported", False):
             config.available_features.add("Int64GroupSharedAtomics")
+        if device["Features"].get("MeshShaderTier", "NotSupported") != "NotSupported":
+            config.available_features.add("MeshShader")
         setWaveSizeFeaturesDirectX(config, device)
 
     if device["API"] == "Metal":


### PR DESCRIPTION
Fixes #1161

This PR introduces a new Mesh Shader SimpleTriangle test as well as render backend support for mesh shaders in DX12.

Perhaps we should rename the test to `VerticesFromThreadID` since this test also creates vertices based on the threadID.

To keep the PRs small only DX12 support is added here. In follow-up PRs we can add support for Vulkan and Metal as well.