### PR TITLE
Promote AMD and NVIDIA DirectX targets to Tier 1

### DIFF
--- a/.github/workflows/pr-matrix.yaml
+++ b/.github/workflows/pr-matrix.yaml
@@ -20,8 +20,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        SKU: [windows-intel]
-        TestTarget: [check-hlsl-d3d12, check-hlsl-vk, check-hlsl-clang-d3d12, check-hlsl-clang-vk]
+        SKU: [windows-intel, windows-nvidia, windows-amd]
+        TestTarget: [check-hlsl-d3d12, check-hlsl-clang-d3d12]
+        include:
+          - SKU: windows-intel
+            TestTarget: check-hlsl-vk
+          - SKU: windows-intel
+            TestTarget: check-hlsl-clang-vk
 
     uses: ./.github/workflows/build-and-test-callable.yaml
     with:
@@ -58,7 +63,12 @@ jobs:
       fail-fast: false
       matrix:
         SKU: [windows-nvidia, windows-amd, windows-qc]
-        TestTarget: [check-hlsl-d3d12, check-hlsl-vk, check-hlsl-clang-d3d12, check-hlsl-clang-vk]
+        TestTarget: [check-hlsl-vk, check-hlsl-clang-vk]
+        include:
+          - SKU: windows-qc
+            TestTarget: check-hlsl-d3d12
+          - SKU: windows-qc
+            TestTarget: check-hlsl-clang-d3d12
 
     uses: ./.github/workflows/build-and-test-callable.yaml
     with:

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -13,6 +13,8 @@ When these configurations fail it should be high priority to correct them.
 Configurations:
 * Windows Intel GPU DirectX
 * Windows Intel GPU Vulkan
+* Windows AMD GPU DirectX
+* Windows NVIDIA GPU DirectX
 * Windows WARP LKG x64
 * Windows WARP LKG arm64
 
@@ -40,9 +42,7 @@ Experimental configurations should be promoted out to other tiers once they are
 robustly passing.
 
 Configurations:
-* Windows AMD GPU DirectX
 * Windows AMD GPU Vulkan
-* Windows NVIDIA GPU DirectX
 * Windows NVIDIA GPU Vulkan
 * Windows QC GPU DirectX
 * Windows QC GPU Vulkan


### PR DESCRIPTION
Move Windows AMD GPU DirectX and Windows NVIDIA GPU DirectX out of
experimental and into Tier 1 pre-merge testing. Both vendors now have
high pass rates (AMD 85.57%, NVIDIA 85.36%) and the DirectX targets
have been stable.

Remaining experimental configurations:
- Windows AMD GPU Vulkan
- Windows NVIDIA GPU Vulkan
- Windows QC GPU DirectX
- Windows QC GPU Vulkan

Assisted-by: Claude Opus 4.6