### PR TITLE
[Vulkan] XFAILs for VUID-StandaloneSpirv-Flat-04744 errors

### DIFF
--- a/test/Feature/Semantics/NestedStructSemantics.test
+++ b/test/Feature/Semantics/NestedStructSemantics.test
@@ -102,6 +102,9 @@ Results:
 # Semantics are not implemented in the DXIL backend.
 # XFAIL: Clang && !Vulkan
 
+# Bug https://github.com/llvm/llvm-project/issues/194293
+# XFAIL: Clang && Vulkan
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T vs_6_0 -Fo %t-vertex.o %t/vertex.hlsl
 # RUN: %dxc_target -T ps_6_0 -Fo %t-pixel.o %t/pixel.hlsl

--- a/test/Feature/Semantics/SemanticTypes.test
+++ b/test/Feature/Semantics/SemanticTypes.test
@@ -104,6 +104,9 @@ Results:
 # Semantics are not implemented in the DXIL backend.
 # XFAIL: Clang && !Vulkan
 
+# Bug https://github.com/llvm/llvm-project/issues/194293
+# XFAIL: Clang && Vulkan
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T vs_6_0 -Fo %t-vertex.o %t/vertex.hlsl
 # RUN: %dxc_target -T ps_6_0 -Fo %t-pixel.o %t/pixel.hlsl

--- a/test/Feature/Semantics/ShadowedSemantics.test
+++ b/test/Feature/Semantics/ShadowedSemantics.test
@@ -107,6 +107,9 @@ Results:
 # Semantics are not implemented in the DXIL backend.
 # XFAIL: Clang && !Vulkan
 
+# Bug https://github.com/llvm/llvm-project/issues/194293
+# XFAIL: Clang && Vulkan
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T vs_6_0 -Fo %t-vertex.o %t/vertex.hlsl
 # RUN: %dxc_target -T ps_6_0 -Fo %t-pixel.o %t/pixel.hlsl


### PR DESCRIPTION
These tests fail to pass spirv-val validation with an error like so:

> [VUID-StandaloneSpirv-Flat-04744] Fragment OpEntryPoint operand <n>
> with Input interfaces with integer or float type must have a Flat
> decoration for Entry Point id <m>.

We're tracking this issue in llvm/llvm-project#194293.