### PR TITLE
Remove XFAIL for Feature/PushConstant/matrix.test

### DIFF
--- a/test/Feature/PushConstant/matrix.test
+++ b/test/Feature/PushConstant/matrix.test
@@ -41,7 +41,6 @@ DescriptorSets:
 ...
 #--- end
 # UNSUPPORTED: Metal || DirectX
-# XFAIL: Clang
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -fvk-use-dx-layout -T cs_6_0 -Fo %t.o %t/source.hlsl


### PR DESCRIPTION
This test is passing as of llvm/llvm-project#193073