### PR TITLE
Update XFAIL that is CBuffer<T> specific

### DIFF
--- a/test/Feature/ResourceArrays/array-of-constant-buffers.test
+++ b/test/Feature/ResourceArrays/array-of-constant-buffers.test
@@ -67,9 +67,10 @@ DescriptorSets:
 ...
 #--- end
 
-# Resource arrays are not yet implemented in Clang:
-# Unimplemented https://github.com/llvm/llvm-project/issues/133835
-# XFAIL: Clang
+# CBuffer<T> not yet implemented for DirectX
+# Unimplemented https://github.com/llvm/llvm-project/issues/122791
+# XFAIL: Clang && DirectX
+# XFAIL: Clang && Metal
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl


### PR DESCRIPTION
This passes on Vulkan as of llvm/llvm-project#195153, but still fails elsewhere since CBuffer<T> support is incomplete.