### PR TITLE
Add InterlockedAnd tests

### DIFF
--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -1322,12 +1322,12 @@ public:
     DeviceInfo.pNext = Features.pNext;
 
 #ifdef VK_EXT_SHADER_IMAGE_ATOMIC_INT64_EXTENSION_NAME
-    llvm::SmallVector<const char *, 1> EnabledDeviceExtensions;
     if (HasShaderImageAtomicInt64Ext &&
         FeaturesImageAtomicInt64.shaderImageInt64Atomics)
       EnabledDeviceExtensions.push_back(
           VK_EXT_SHADER_IMAGE_ATOMIC_INT64_EXTENSION_NAME);
-    DeviceInfo.enabledExtensionCount = EnabledDeviceExtensions.size();
+    DeviceInfo.enabledExtensionCount =
+        static_cast<uint32_t>(EnabledDeviceExtensions.size());
     DeviceInfo.ppEnabledExtensionNames = EnabledDeviceExtensions.data();
 #endif
 

--- a/test/Feature/HLSLLib/InterlockedAnd.32.test
+++ b/test/Feature/HLSLLib/InterlockedAnd.32.test
@@ -1,0 +1,129 @@
+#--- source.hlsl
+
+// This test exercises InterlockedAnd against non-resource (groupshared)
+// destinations. A single threadgroup of 32 threads concurrently updates
+// shared counters, so the test actually exercises atomic behavior.
+//
+// Both the 2-argument and 3-argument overloads are covered for int and uint.
+//
+// Atomicity is verified by starting a counter at 0xFFFFFFFF and having each
+// of 32 threads atomically clear its own unique bit (AND with ~(1 << tid)).
+// If any read-modify-write were non-atomic, some thread's bit clear would
+// be lost and the final value would be non-zero. With true atomicity, the
+// counter must end at exactly 0.
+//
+// For the 3-argument form we additionally verify, per-thread, that the
+// returned "original value" still had this thread's bit set when the AND
+// was performed -- this must always be true under atomic semantics, since
+// no other thread ever clears that bit.
+
+RWStructuredBuffer<uint> OutOrigBitSet : register(u0);
+RWStructuredBuffer<uint> OutFinal : register(u1);
+
+groupshared uint CounterU;          // 3-arg form, unsigned: bit-clear test
+groupshared uint CounterUNoOrig;    // 2-arg form, unsigned: bit-clear test
+groupshared int  CounterI;          // 3-arg form, signed: bit-clear test on -1
+groupshared uint MaskedU;           // deterministic mask test (all threads
+                                    // AND with the same constant)
+
+groupshared uint OrigBitSet[32];    // per-thread: was my bit set in the
+                                    // original value I observed?
+
+[numthreads(32, 1, 1)]
+void main(uint3 GTID : SV_GroupThreadID) {
+  if (GTID.x == 0) {
+    CounterU = 0xFFFFFFFFu;
+    CounterUNoOrig = 0xFFFFFFFFu;
+    CounterI = -1;                  // 0xFFFFFFFF as int
+    MaskedU = 0xAAAAAAAAu;
+  }
+  OrigBitSet[GTID.x] = 0;
+  GroupMemoryBarrierWithGroupSync();
+
+  uint ThreadBit = 1u << GTID.x;
+  uint ThreadMask = ~ThreadBit;
+
+  // 3-argument form: capture original, then check our bit was set in it.
+  uint OrigU;
+  InterlockedAnd(CounterU, ThreadMask, OrigU);
+  OrigBitSet[GTID.x] = ((OrigU & ThreadBit) != 0u) ? 1u : 0u;
+
+  // 3-argument form, signed.
+  int OrigI;
+  InterlockedAnd(CounterI, (int)ThreadMask, OrigI);
+
+  // 2-argument form: no original captured.
+  InterlockedAnd(CounterUNoOrig, ThreadMask);
+
+  // 2-argument form: every thread ANDs with the same constant. Result
+  // is deterministic regardless of ordering: 0xAAAAAAAA & 0x0F0F0F0F.
+  InterlockedAnd(MaskedU, 0x0F0F0F0Fu);
+
+  GroupMemoryBarrierWithGroupSync();
+
+  OutOrigBitSet[GTID.x] = OrigBitSet[GTID.x];
+
+  if (GTID.x == 0) {
+    OutFinal[0] = CounterU;          // 0
+    OutFinal[1] = (uint)CounterI;    // 0
+    OutFinal[2] = CounterUNoOrig;    // 0
+    OutFinal[3] = MaskedU;           // 0xAAAAAAAA & 0x0F0F0F0F = 0x0A0A0A0A
+  }
+}
+
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+    DispatchSize: [1, 1, 1]
+Buffers:
+  - Name: OutOrigBitSet
+    Format: UInt32
+    Stride: 4
+    ZeroInitSize: 128
+  - Name: ExpectedOrigBitSet
+    Format: UInt32
+    Stride: 4
+    Data: [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ]
+  - Name: OutFinal
+    Format: UInt32
+    Stride: 4
+    ZeroInitSize: 16
+  - Name: ExpectedFinal
+    Format: UInt32
+    Stride: 4
+    Data: [ 0, 0, 0, 0x0A0A0A0A ]
+Results:
+  - Result: TestOrigBitSet
+    Rule: BufferExact
+    Actual: OutOrigBitSet
+    Expected: ExpectedOrigBitSet
+  - Result: TestFinal
+    Rule: BufferExact
+    Actual: OutFinal
+    Expected: ExpectedFinal
+DescriptorSets:
+  - Resources:
+    - Name: OutOrigBitSet
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: OutFinal
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+...
+#--- end
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/InterlockedAnd.32.test
+++ b/test/Feature/HLSLLib/InterlockedAnd.32.test
@@ -81,7 +81,7 @@ Buffers:
   - Name: OutOrigBitSet
     Format: UInt32
     Stride: 4
-    ZeroInitSize: 128
+    FillSize: 128
   - Name: ExpectedOrigBitSet
     Format: UInt32
     Stride: 4
@@ -90,7 +90,7 @@ Buffers:
   - Name: OutFinal
     Format: UInt32
     Stride: 4
-    ZeroInitSize: 16
+    FillSize: 16
   - Name: ExpectedFinal
     Format: UInt32
     Stride: 4

--- a/test/Feature/HLSLLib/InterlockedAnd.32.test
+++ b/test/Feature/HLSLLib/InterlockedAnd.32.test
@@ -77,7 +77,6 @@ void main(uint3 GTID : SV_GroupThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: OutOrigBitSet
     Format: UInt32

--- a/test/Feature/HLSLLib/InterlockedAnd.32.test
+++ b/test/Feature/HLSLLib/InterlockedAnd.32.test
@@ -123,6 +123,9 @@ DescriptorSets:
 ...
 #--- end
 
+# Unimplemented: https://github.com/llvm/llvm-project/issues/99125
+# XFAIL: Clang
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/InterlockedAnd.int64.test
+++ b/test/Feature/HLSLLib/InterlockedAnd.int64.test
@@ -128,6 +128,9 @@ DescriptorSets:
 ...
 #--- end
 
+# Unimplemented: https://github.com/llvm/llvm-project/issues/99125
+# XFAIL: Clang
+
 # REQUIRES: Int64
 # RUN: split-file %s %t
 # RUN: %dxc_target -HV 202x -T cs_6_6 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/InterlockedAnd.int64.test
+++ b/test/Feature/HLSLLib/InterlockedAnd.int64.test
@@ -84,7 +84,7 @@ Buffers:
   - Name: OutOrigBitSet
     Format: UInt32
     Stride: 4
-    ZeroInitSize: 256
+    FillSize: 256
   - Name: ExpectedOrigBitSet
     Format: UInt32
     Stride: 4
@@ -95,7 +95,7 @@ Buffers:
   - Name: OutFinal
     Format: UInt64
     Stride: 8
-    ZeroInitSize: 32
+    FillSize: 32
   - Name: ExpectedFinal
     Format: UInt64
     Stride: 8

--- a/test/Feature/HLSLLib/InterlockedAnd.int64.test
+++ b/test/Feature/HLSLLib/InterlockedAnd.int64.test
@@ -1,0 +1,135 @@
+#--- source.hlsl
+
+// This test exercises InterlockedAnd against non-resource (groupshared)
+// destinations using 64-bit integer types. A single threadgroup of 64
+// threads concurrently updates shared counters, so the test actually
+// exercises atomic behavior.
+//
+// Both the 2-argument and 3-argument overloads are covered for int64_t
+// and uint64_t.
+//
+// Atomicity is verified by starting a counter at 0xFFFFFFFFFFFFFFFF and
+// having each of 64 threads atomically clear its own unique bit
+// (AND with ~(1ull << tid)). If any read-modify-write were non-atomic,
+// some thread's bit clear would be lost and the final value would be
+// non-zero. With true atomicity, the counter must end at exactly 0.
+//
+// For the 3-argument form we additionally verify, per-thread, that the
+// returned "original value" still had this thread's bit set when the AND
+// was performed -- this must always be true under atomic semantics, since
+// no other thread ever clears that bit.
+
+RWStructuredBuffer<uint> OutOrigBitSet : register(u0);
+RWStructuredBuffer<uint64_t> OutFinal : register(u1);
+
+groupshared uint64_t CounterU;          // 3-arg form, unsigned: bit-clear test
+groupshared uint64_t CounterUNoOrig;    // 2-arg form, unsigned: bit-clear test
+groupshared int64_t  CounterI;          // 3-arg form, signed: bit-clear test on -1
+groupshared uint64_t MaskedU;           // deterministic mask test (all threads
+                                        // AND with the same constant)
+
+groupshared uint OrigBitSet[64];        // per-thread: was my bit set in the
+                                        // original value I observed?
+
+[numthreads(64, 1, 1)]
+void main(uint3 GTID : SV_GroupThreadID) {
+  if (GTID.x == 0) {
+    CounterU = 0xFFFFFFFFFFFFFFFFull;
+    CounterUNoOrig = 0xFFFFFFFFFFFFFFFFull;
+    CounterI = (int64_t)-1;             // all bits set
+    MaskedU = 0xAAAAAAAAAAAAAAAAull;
+  }
+  OrigBitSet[GTID.x] = 0;
+  GroupMemoryBarrierWithGroupSync();
+
+  uint64_t ThreadBit = 1ull << GTID.x;
+  uint64_t ThreadMask = ~ThreadBit;
+
+  // 3-argument form: capture original, then check our bit was set in it.
+  uint64_t OrigU;
+  InterlockedAnd(CounterU, ThreadMask, OrigU);
+  OrigBitSet[GTID.x] = ((OrigU & ThreadBit) != 0ull) ? 1u : 0u;
+
+  // 3-argument form, signed.
+  int64_t OrigI;
+  InterlockedAnd(CounterI, (int64_t)ThreadMask, OrigI);
+
+  // 2-argument form: no original captured.
+  InterlockedAnd(CounterUNoOrig, ThreadMask);
+
+  // 2-argument form: every thread ANDs with the same constant. Result
+  // is deterministic regardless of ordering. The mask exercises both the
+  // low and high 32-bit halves.
+  InterlockedAnd(MaskedU, 0x0F0F0F0F0F0F0F0Full);
+
+  GroupMemoryBarrierWithGroupSync();
+
+  OutOrigBitSet[GTID.x] = OrigBitSet[GTID.x];
+
+  if (GTID.x == 0) {
+    OutFinal[0] = CounterU;             // 0
+    OutFinal[1] = (uint64_t)CounterI;   // 0
+    OutFinal[2] = CounterUNoOrig;       // 0
+    OutFinal[3] = MaskedU;              // 0x0A0A0A0A0A0A0A0A
+  }
+}
+
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+    DispatchSize: [1, 1, 1]
+Buffers:
+  - Name: OutOrigBitSet
+    Format: UInt32
+    Stride: 4
+    ZeroInitSize: 256
+  - Name: ExpectedOrigBitSet
+    Format: UInt32
+    Stride: 4
+    Data: [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ]
+  - Name: OutFinal
+    Format: UInt64
+    Stride: 8
+    ZeroInitSize: 32
+  - Name: ExpectedFinal
+    Format: UInt64
+    Stride: 8
+    Data: [ 0, 0, 0, 0x0A0A0A0A0A0A0A0A ]
+Results:
+  - Result: TestOrigBitSet
+    Rule: BufferExact
+    Actual: OutOrigBitSet
+    Expected: ExpectedOrigBitSet
+  - Result: TestFinal
+    Rule: BufferExact
+    Actual: OutFinal
+    Expected: ExpectedFinal
+DescriptorSets:
+  - Resources:
+    - Name: OutOrigBitSet
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: OutFinal
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+...
+#--- end
+
+# REQUIRES: Int64
+# RUN: split-file %s %t
+# RUN: %dxc_target -HV 202x -T cs_6_6 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/InterlockedAnd.int64.test
+++ b/test/Feature/HLSLLib/InterlockedAnd.int64.test
@@ -80,7 +80,6 @@ void main(uint3 GTID : SV_GroupThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: OutOrigBitSet
     Format: UInt32

--- a/test/Feature/HLSLLib/InterlockedAnd.int64.test
+++ b/test/Feature/HLSLLib/InterlockedAnd.int64.test
@@ -131,7 +131,10 @@ DescriptorSets:
 # Unimplemented: https://github.com/llvm/llvm-project/issues/99125
 # XFAIL: Clang
 
-# REQUIRES: Int64
+# Bug: https://github.com/llvm/offload-test-suite/issues/1164
+# XFAIL: Metal && DXC
+
+# REQUIRES: Int64 && Int64GroupSharedAtomics && SM_6_6
 # RUN: split-file %s %t
 # RUN: %dxc_target -HV 202x -T cs_6_6 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/InterlockedAnd.resources.32.test
+++ b/test/Feature/HLSLLib/InterlockedAnd.resources.32.test
@@ -223,6 +223,9 @@ DescriptorSets:
 # Unimplemented: https://github.com/llvm/llvm-project/issues/99125
 # XFAIL: Clang
 
+# Bug: https://github.com/llvm/offload-test-suite/issues/1164
+# XFAIL: Metal && DXC
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/InterlockedAnd.resources.32.test
+++ b/test/Feature/HLSLLib/InterlockedAnd.resources.32.test
@@ -1,0 +1,228 @@
+#--- source.hlsl
+
+// This test exercises InterlockedAnd against the full set of HLSL-legal
+// non-groupshared (resource) destination types:
+//
+//   * RWStructuredBuffer<uint>[i]          (free function, 2-arg)
+//   * RWStructuredBuffer<int>[i]           (free function, 3-arg, signed)
+//   * RWBuffer<uint>[i]                    (free function on typed UAV)
+//   * RWTexture2D<uint>[coord]             (free function on typed UAV)
+//   * RWByteAddressBuffer::InterlockedAnd  (method, 2-arg and 3-arg)
+//
+// For each destination, 32 threads of a single threadgroup atomically AND
+// `~(1 << tid)` into a single accumulator slot whose initial value is
+// 0xFFFFFFFF. With correct atomic semantics every thread's bit-clear must
+// take effect, so each accumulator must end at exactly 0. If any
+// read-modify-write were lost, the corresponding bit would remain set.
+//
+// Per-thread sanity for the 3-argument forms: the returned "original"
+// value must have *this* thread's bit set, since no other thread ever
+// clears that bit. Failures here would indicate the wrong value was
+// returned for `original_value`.
+
+RWStructuredBuffer<uint> SBufU : register(u0);
+RWStructuredBuffer<int>  SBufI : register(u1);
+RWBuffer<uint>           TBufU : register(u2);
+RWTexture2D<uint>        Tex2D : register(u3);
+RWByteAddressBuffer      BABuf : register(u4);
+
+RWStructuredBuffer<uint> OutOrigBitSetSBufI : register(u5);
+RWStructuredBuffer<uint> OutOrigBitSetBABuf : register(u6);
+
+[numthreads(32, 1, 1)]
+void main(uint3 GTID : SV_GroupThreadID) {
+  if (GTID.x == 0) {
+    SBufU[0] = 0xFFFFFFFFu;
+    SBufI[0] = -1;                       // 0xFFFFFFFF as int
+    TBufU[0] = 0xFFFFFFFFu;
+    Tex2D[uint2(0, 0)] = 0xFFFFFFFFu;
+    BABuf.Store(0, 0xFFFFFFFFu);   // accumulator for 2-arg method form
+    BABuf.Store(4, 0xFFFFFFFFu);   // accumulator for 3-arg method form
+  }
+  OutOrigBitSetSBufI[GTID.x] = 0u;
+  OutOrigBitSetBABuf[GTID.x] = 0u;
+  DeviceMemoryBarrierWithGroupSync();
+
+  uint ThreadBit = 1u << GTID.x;
+  uint ThreadMask = ~ThreadBit;
+
+  // RWStructuredBuffer<uint>: 2-argument free function.
+  InterlockedAnd(SBufU[0], ThreadMask);
+
+  // RWStructuredBuffer<int>: 3-argument free function (signed).
+  int OrigI;
+  InterlockedAnd(SBufI[0], (int)ThreadMask, OrigI);
+  OutOrigBitSetSBufI[GTID.x] = (((uint)OrigI & ThreadBit) != 0u) ? 1u : 0u;
+
+  // RWBuffer<uint> (typed buffer UAV): 2-argument free function.
+  InterlockedAnd(TBufU[0], ThreadMask);
+
+  // RWTexture2D<uint>: 2-argument free function.
+  InterlockedAnd(Tex2D[uint2(0, 0)], ThreadMask);
+
+  // RWByteAddressBuffer method: 2-argument form.
+  BABuf.InterlockedAnd(0, ThreadMask);
+
+  // RWByteAddressBuffer method: 3-argument form.
+  uint OrigBA;
+  BABuf.InterlockedAnd(4, ThreadMask, OrigBA);
+  OutOrigBitSetBABuf[GTID.x] = ((OrigBA & ThreadBit) != 0u) ? 1u : 0u;
+}
+
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+Buffers:
+  - Name: SBufU
+    Format: UInt32
+    Stride: 4
+    FillSize: 4
+  - Name: ExpectedSBufU
+    Format: UInt32
+    Stride: 4
+    Data: [ 0 ]
+  - Name: SBufI
+    Format: Int32
+    Stride: 4
+    FillSize: 4
+  - Name: ExpectedSBufI
+    Format: Int32
+    Stride: 4
+    Data: [ 0 ]
+  - Name: TBufU
+    Format: UInt32
+    Channels: 1
+    FillSize: 4
+  - Name: ExpectedTBufU
+    Format: UInt32
+    Channels: 1
+    Data: [ 0 ]
+  - Name: Tex2D
+    Format: UInt32
+    Channels: 1
+    FillSize: 4
+    OutputProps:
+      Height: 1
+      Width: 1
+      Depth: 1
+  - Name: ExpectedTex2D
+    Format: UInt32
+    Channels: 1
+    Data: [ 0 ]
+    OutputProps:
+      Height: 1
+      Width: 1
+      Depth: 1
+  - Name: BABuf
+    Format: Hex32
+    Stride: 4
+    FillSize: 8
+  - Name: ExpectedBABuf
+    Format: Hex32
+    Stride: 4
+    Data: [ 0x00000000, 0x00000000 ]
+  - Name: OutOrigBitSetSBufI
+    Format: UInt32
+    Stride: 4
+    FillSize: 128
+  - Name: ExpectedOrigBitSet
+    Format: UInt32
+    Stride: 4
+    Data: [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ]
+  - Name: OutOrigBitSetBABuf
+    Format: UInt32
+    Stride: 4
+    FillSize: 128
+Results:
+  - Result: TestSBufU
+    Rule: BufferExact
+    Actual: SBufU
+    Expected: ExpectedSBufU
+  - Result: TestSBufI
+    Rule: BufferExact
+    Actual: SBufI
+    Expected: ExpectedSBufI
+  - Result: TestTBufU
+    Rule: BufferExact
+    Actual: TBufU
+    Expected: ExpectedTBufU
+  - Result: TestTex2D
+    Rule: BufferExact
+    Actual: Tex2D
+    Expected: ExpectedTex2D
+  - Result: TestBABuf
+    Rule: BufferExact
+    Actual: BABuf
+    Expected: ExpectedBABuf
+  - Result: TestOrigBitSetSBufI
+    Rule: BufferExact
+    Actual: OutOrigBitSetSBufI
+    Expected: ExpectedOrigBitSet
+  - Result: TestOrigBitSetBABuf
+    Rule: BufferExact
+    Actual: OutOrigBitSetBABuf
+    Expected: ExpectedOrigBitSet
+DescriptorSets:
+  - Resources:
+    - Name: SBufU
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: SBufI
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+    - Name: TBufU
+      Kind: RWBuffer
+      DirectXBinding:
+        Register: 2
+        Space: 0
+      VulkanBinding:
+        Binding: 2
+    - Name: Tex2D
+      Kind: RWTexture2D
+      DirectXBinding:
+        Register: 3
+        Space: 0
+      VulkanBinding:
+        Binding: 3
+    - Name: BABuf
+      Kind: RWByteAddressBuffer
+      DirectXBinding:
+        Register: 4
+        Space: 0
+      VulkanBinding:
+        Binding: 4
+    - Name: OutOrigBitSetSBufI
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 5
+        Space: 0
+      VulkanBinding:
+        Binding: 5
+    - Name: OutOrigBitSetBABuf
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 6
+        Space: 0
+      VulkanBinding:
+        Binding: 6
+...
+#--- end
+
+# Unimplemented: https://github.com/llvm/llvm-project/issues/99125
+# XFAIL: Clang
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/InterlockedAnd.resources.int64.test
+++ b/test/Feature/HLSLLib/InterlockedAnd.resources.int64.test
@@ -1,0 +1,178 @@
+#--- source.hlsl
+
+// This test exercises InterlockedAnd against the HLSL-legal 64-bit
+// non-groupshared (resource) destination types. 64-bit atomics on UAVs
+// were introduced in Shader Model 6.6.
+//
+//   * RWStructuredBuffer<uint64_t>[i]        (free function, 2-arg)
+//   * RWStructuredBuffer<int64_t>[i]         (free function, 3-arg, signed)
+//   * RWByteAddressBuffer::InterlockedAnd64  (method, 2-arg and 3-arg)
+//
+// 64-bit atomics on typed RWBuffer / RWTexture require the optional
+// "AtomicInt64OnTypedResource" capability and are intentionally not
+// covered here, to keep this test portable across implementations.
+//
+// For each destination, 64 threads of a single threadgroup atomically
+// AND `~(1ull << tid)` into a single accumulator slot whose initial value
+// is 0xFFFFFFFFFFFFFFFF. With correct atomic semantics every thread's
+// bit-clear must take effect, so each accumulator must end at exactly 0.
+// If any read-modify-write were lost, the corresponding bit would remain
+// set.
+//
+// Per-thread sanity for the 3-argument forms: the returned "original"
+// value must have *this* thread's bit set, since no other thread ever
+// clears that bit.
+
+RWStructuredBuffer<uint64_t> SBufU : register(u0);
+RWStructuredBuffer<int64_t>  SBufI : register(u1);
+RWByteAddressBuffer          BABuf : register(u2);
+
+RWStructuredBuffer<uint> OutOrigBitSetSBufI : register(u3);
+RWStructuredBuffer<uint> OutOrigBitSetBABuf : register(u4);
+
+[numthreads(64, 1, 1)]
+void main(uint3 GTID : SV_GroupThreadID) {
+  if (GTID.x == 0) {
+    SBufU[0] = 0xFFFFFFFFFFFFFFFFull;
+    SBufI[0] = (int64_t)-1;
+    BABuf.Store<uint64_t>(0, 0xFFFFFFFFFFFFFFFFull); // accumulator for 2-arg method form
+    BABuf.Store<uint64_t>(8, 0xFFFFFFFFFFFFFFFFull); // accumulator for 3-arg method form
+  }
+  OutOrigBitSetSBufI[GTID.x] = 0u;
+  OutOrigBitSetBABuf[GTID.x] = 0u;
+  DeviceMemoryBarrierWithGroupSync();
+
+  uint64_t ThreadBit  = 1ull << GTID.x;
+  uint64_t ThreadMask = ~ThreadBit;
+
+  // RWStructuredBuffer<uint64_t>: 2-argument free function.
+  InterlockedAnd(SBufU[0], ThreadMask);
+
+  // RWStructuredBuffer<int64_t>: 3-argument free function (signed).
+  int64_t OrigI;
+  InterlockedAnd(SBufI[0], (int64_t)ThreadMask, OrigI);
+  OutOrigBitSetSBufI[GTID.x] = (((uint64_t)OrigI & ThreadBit) != 0ull) ? 1u : 0u;
+
+  // RWByteAddressBuffer 64-bit method: 2-argument form.
+  BABuf.InterlockedAnd64(0, ThreadMask);
+
+  // RWByteAddressBuffer 64-bit method: 3-argument form.
+  uint64_t OrigBA;
+  BABuf.InterlockedAnd64(8, ThreadMask, OrigBA);
+  OutOrigBitSetBABuf[GTID.x] = ((OrigBA & ThreadBit) != 0ull) ? 1u : 0u;
+}
+
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+Buffers:
+  - Name: SBufU
+    Format: UInt64
+    Stride: 8
+    FillSize: 8
+  - Name: ExpectedSBufU
+    Format: UInt64
+    Stride: 8
+    Data: [ 0 ]
+  - Name: SBufI
+    Format: Int64
+    Stride: 8
+    FillSize: 8
+  - Name: ExpectedSBufI
+    Format: Int64
+    Stride: 8
+    Data: [ 0 ]
+  - Name: BABuf
+    Format: Hex64
+    Stride: 8
+    FillSize: 16
+  - Name: ExpectedBABuf
+    Format: Hex64
+    Stride: 8
+    Data: [ 0x0000000000000000, 0x0000000000000000 ]
+  - Name: OutOrigBitSetSBufI
+    Format: UInt32
+    Stride: 4
+    FillSize: 256
+  - Name: ExpectedOrigBitSet
+    Format: UInt32
+    Stride: 4
+    Data: [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ]
+  - Name: OutOrigBitSetBABuf
+    Format: UInt32
+    Stride: 4
+    FillSize: 256
+Results:
+  - Result: TestSBufU
+    Rule: BufferExact
+    Actual: SBufU
+    Expected: ExpectedSBufU
+  - Result: TestSBufI
+    Rule: BufferExact
+    Actual: SBufI
+    Expected: ExpectedSBufI
+  - Result: TestBABuf
+    Rule: BufferExact
+    Actual: BABuf
+    Expected: ExpectedBABuf
+  - Result: TestOrigBitSetSBufI
+    Rule: BufferExact
+    Actual: OutOrigBitSetSBufI
+    Expected: ExpectedOrigBitSet
+  - Result: TestOrigBitSetBABuf
+    Rule: BufferExact
+    Actual: OutOrigBitSetBABuf
+    Expected: ExpectedOrigBitSet
+DescriptorSets:
+  - Resources:
+    - Name: SBufU
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: SBufI
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+    - Name: BABuf
+      Kind: RWByteAddressBuffer
+      DirectXBinding:
+        Register: 2
+        Space: 0
+      VulkanBinding:
+        Binding: 2
+    - Name: OutOrigBitSetSBufI
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 3
+        Space: 0
+      VulkanBinding:
+        Binding: 3
+    - Name: OutOrigBitSetBABuf
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 4
+        Space: 0
+      VulkanBinding:
+        Binding: 4
+...
+#--- end
+
+# Unimplemented: https://github.com/llvm/llvm-project/issues/99125
+# XFAIL: Clang
+
+# REQUIRES: Int64
+# RUN: split-file %s %t
+# RUN: %dxc_target -HV 202x -T cs_6_6 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/InterlockedAnd.resources.int64.test
+++ b/test/Feature/HLSLLib/InterlockedAnd.resources.int64.test
@@ -172,7 +172,13 @@ DescriptorSets:
 # Unimplemented: https://github.com/llvm/llvm-project/issues/99125
 # XFAIL: Clang
 
-# REQUIRES: Int64
+# Bug: https://github.com/llvm/offload-test-suite/issues/1164
+# XFAIL: Metal && DXC
+
+# Unimplemented: https://github.com/microsoft/DirectXShaderCompiler/issues/8451
+# XFAIL: Vulkan && DXC
+
+# REQUIRES: Int64 && SM_6_6 && (!Vulkan || VulkanInt64BufferAtomics)
 # RUN: split-file %s %t
 # RUN: %dxc_target -HV 202x -T cs_6_6 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/InterlockedAnd.resources.typed.int64.test
+++ b/test/Feature/HLSLLib/InterlockedAnd.resources.typed.int64.test
@@ -1,0 +1,130 @@
+#--- source.hlsl
+
+// This test exercises InterlockedAnd on 64-bit typed RWBuffer resources.
+// 64-bit atomics on typed UAVs are an optional Shader Model 6.6 capability
+// (D3D12 cap AtomicInt64OnTypedResourceSupported, Vulkan feature
+// shaderBufferInt64Atomics), surfaced to lit as `Int64TypedResourceAtomics`.
+//
+//   * RWBuffer<uint64_t>[i]  (free function, 2-arg)
+//   * RWBuffer<int64_t>[i]   (free function, 3-arg, signed)
+//
+// 64-bit typed-image atomics (RWTexture<int64_t>) live behind an additional
+// Vulkan extension (VK_EXT_shader_image_atomic_int64) and are not covered
+// here.
+//
+// 64 threads of a single threadgroup atomically AND `~(1ull << tid)` into
+// a single accumulator slot whose initial value is 0xFFFFFFFFFFFFFFFF.
+// With correct atomic semantics every thread's bit-clear must take
+// effect, so each accumulator must end at exactly 0. If any
+// read-modify-write were lost, the corresponding bit would remain set.
+//
+// Per-thread sanity for the 3-argument form: the returned "original"
+// value must have *this* thread's bit set, since no other thread ever
+// clears that bit.
+
+RWBuffer<uint64_t> TBufU : register(u0);
+RWBuffer<int64_t>  TBufI : register(u1);
+
+RWStructuredBuffer<uint> OutOrigBitSet : register(u2);
+
+[numthreads(64, 1, 1)]
+void main(uint3 GTID : SV_GroupThreadID) {
+  if (GTID.x == 0) {
+    TBufU[0] = 0xFFFFFFFFFFFFFFFFull;
+    TBufI[0] = (int64_t)-1;
+  }
+  OutOrigBitSet[GTID.x] = 0u;
+  DeviceMemoryBarrierWithGroupSync();
+
+  uint64_t ThreadBit  = 1ull << GTID.x;
+  uint64_t ThreadMask = ~ThreadBit;
+
+  // RWBuffer<uint64_t>: 2-argument free function.
+  InterlockedAnd(TBufU[0], ThreadMask);
+
+  // RWBuffer<int64_t>: 3-argument free function (signed).
+  int64_t OrigI;
+  InterlockedAnd(TBufI[0], (int64_t)ThreadMask, OrigI);
+  OutOrigBitSet[GTID.x] = (((uint64_t)OrigI & ThreadBit) != 0ull) ? 1u : 0u;
+}
+
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+Buffers:
+  - Name: TBufU
+    Format: UInt64
+    Channels: 1
+    FillSize: 8
+  - Name: ExpectedTBufU
+    Format: UInt64
+    Channels: 1
+    Data: [ 0 ]
+  - Name: TBufI
+    Format: Int64
+    Channels: 1
+    FillSize: 8
+  - Name: ExpectedTBufI
+    Format: Int64
+    Channels: 1
+    Data: [ 0 ]
+  - Name: OutOrigBitSet
+    Format: UInt32
+    Stride: 4
+    FillSize: 256
+  - Name: ExpectedOrigBitSet
+    Format: UInt32
+    Stride: 4
+    Data: [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ]
+Results:
+  - Result: TestTBufU
+    Rule: BufferExact
+    Actual: TBufU
+    Expected: ExpectedTBufU
+  - Result: TestTBufI
+    Rule: BufferExact
+    Actual: TBufI
+    Expected: ExpectedTBufI
+  - Result: TestOrigBitSet
+    Rule: BufferExact
+    Actual: OutOrigBitSet
+    Expected: ExpectedOrigBitSet
+DescriptorSets:
+  - Resources:
+    - Name: TBufU
+      Kind: RWBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: TBufI
+      Kind: RWBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+    - Name: OutOrigBitSet
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 2
+        Space: 0
+      VulkanBinding:
+        Binding: 2
+...
+#--- end
+
+# Unimplemented: https://github.com/llvm/llvm-project/issues/99125
+# XFAIL: Clang
+
+# REQUIRES: Int64TypedResourceAtomics
+# RUN: split-file %s %t
+# RUN: %dxc_target -HV 202x -T cs_6_6 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/InterlockedAnd.resources.typed.int64.test
+++ b/test/Feature/HLSLLib/InterlockedAnd.resources.typed.int64.test
@@ -1,26 +1,32 @@
 #--- source.hlsl
 
 // This test exercises InterlockedAnd on 64-bit typed RWBuffer resources.
-// 64-bit atomics on typed UAVs are an optional Shader Model 6.6 capability
-// (D3D12 cap AtomicInt64OnTypedResourceSupported, Vulkan feature
-// shaderBufferInt64Atomics), surfaced to lit as `Int64TypedResourceAtomics`.
+// 64-bit atomics on typed UAVs are an optional Shader Model 6.6 capability:
+//
+//   * DirectX:  cap AtomicInt64OnTypedResourceSupported
+//   * Vulkan:   shaderImageInt64Atomics, from the (non-core) extension
+//               VK_EXT_shader_image_atomic_int64. RWBuffer<T> in HLSL maps
+//               to a SPIR-V image (not an SSBO), so RWBuffer atomics on
+//               Vulkan require this image-atomics extension, not
+//               shaderBufferInt64Atomics. The same Vulkan feature also
+//               covers RWTexture<int64_t> typed-image atomics; this test
+//               only exercises RWBuffer.
+//
+// Both are surfaced to lit as `Int64TypedResourceAtomics`.
 //
 //   * RWBuffer<uint64_t>[i]  (free function, 2-arg)
 //   * RWBuffer<int64_t>[i]   (free function, 3-arg, signed)
 //
-// 64-bit typed-image atomics (RWTexture<int64_t>) live behind an additional
-// Vulkan extension (VK_EXT_shader_image_atomic_int64) and are not covered
-// here.
-//
-// 64 threads of a single threadgroup atomically AND `~(1ull << tid)` into
-// a single accumulator slot whose initial value is 0xFFFFFFFFFFFFFFFF.
-// With correct atomic semantics every thread's bit-clear must take
-// effect, so each accumulator must end at exactly 0. If any
-// read-modify-write were lost, the corresponding bit would remain set.
+// 64 threads of a single threadgroup atomically AND their own unique bit
+// mask ~(1ull << tid) into a single accumulator slot that starts with 
+// all bits set. With correct atomic semantics, every bit must be set 
+// back to 0, so each accumulator must end at
+// exactly 0x0000000000000000. If any read-modify-write were lost, the
+// corresponding bit would remain clear.
 //
 // Per-thread sanity for the 3-argument form: the returned "original"
-// value must have *this* thread's bit set, since no other thread ever
-// clears that bit.
+// value must have *this* thread's bit clear, since no other thread ever
+// sets that bit.
 
 RWBuffer<uint64_t> TBufU : register(u0);
 RWBuffer<int64_t>  TBufI : register(u1);
@@ -59,6 +65,7 @@ Buffers:
     Format: UInt64
     Channels: 1
     FillSize: 8
+    FillValue: 137  # trash non-zero initialization data
   - Name: ExpectedTBufU
     Format: UInt64
     Channels: 1
@@ -67,6 +74,7 @@ Buffers:
     Format: Int64
     Channels: 1
     FillSize: 8
+    FillValue: 137  # trash non-zero initialization data
   - Name: ExpectedTBufI
     Format: Int64
     Channels: 1
@@ -124,7 +132,7 @@ DescriptorSets:
 # Unimplemented: https://github.com/llvm/llvm-project/issues/99125
 # XFAIL: Clang
 
-# REQUIRES: Int64TypedResourceAtomics
+# REQUIRES: Int64TypedResourceAtomics && SM_6_6
 # RUN: split-file %s %t
 # RUN: %dxc_target -HV 202x -T cs_6_6 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
This PR adds tests for `InterlockedAnd`
Adds 32 bit and 64 bit signed/unsigned integer tests
Fixes https://github.com/llvm/offload-test-suite/issues/849