### PR TITLE
[Docs] Fix typo in WARP.md (non-WRAP -> non-WARP)

### DIFF
--- a/docs/WARP.md
+++ b/docs/WARP.md
@@ -11,7 +11,7 @@ will generate test targets for `check-hlsl-warp-d3d12` and
 There are some useful CMake options to tweak the configuration to better utilize
 WARP:
 
-* **OFFLOADTEST_WARP_ONLY** - Skips generating non-WRAP test configurations
+* **OFFLOADTEST_WARP_ONLY** - Skips generating non-WARP test configurations
   and backends. This is useful if you're running Windows in a VM and only
   have a working WARP implementation.
 


### PR DESCRIPTION
Fixes a small typo in `docs/WARP.md`: `non-WRAP` -> `non-WARP` in the description of the `OFFLOADTEST_WARP_ONLY` CMake option.

---
Assisted by Claude Opus 4.7.