### PR TITLE
XFAIL test that uses groupshared on Vulkan

### DIFF
--- a/test/WaveOps/GroupMemoryBarrierWithGroupSync.test
+++ b/test/WaveOps/GroupMemoryBarrierWithGroupSync.test
@@ -81,6 +81,9 @@ DescriptorSets:
 # Bug: https://github.com/llvm/offload-test-suite/issues/955
 # XFAIL: Vulkan && Intel && Clang
 
+# Bug: https://github.com/llvm/llvm-project/issues/197557
+# XFAIL: Clang && Vulkan
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
This test is failing due to llvm/llvm-project#197557, which regressed any use of groupshared when targeting Vulkan.