### PR TITLE
Simplify bitpatterns for reversebits.64 and XFAIL on Vulkan

### DIFF
--- a/test/Feature/HLSLLib/reversebits.64.test
+++ b/test/Feature/HLSLLib/reversebits.64.test
@@ -6,9 +6,12 @@ RWStructuredBuffer<uint64_t4> Out : register(u1);
 [numthreads(1,1,1)]
 void main() {
   Out[0] = reversebits(In[0]);
-  uint64_t4 Tmp = {reversebits(In[1].xyz), reversebits(In[1].w)};
+  uint64_t4 Tmp = {reversebits(In[0].xyz), reversebits(In[0].w)};
   Out[1] = Tmp;
-  uint64_t4 Tmp2 = {reversebits(In[2].xy), reversebits(uint64_t2(0, 4294967296))};
+  uint64_t4 Tmp2 = {
+    reversebits(In[0].xy),
+    reversebits(uint64_t2(0x3333CCCCCCCC3333, 0x0123456789ABCDEF))
+  };
   Out[2] = Tmp2;
 }
 
@@ -23,7 +26,12 @@ Buffers:
   - Name: In
     Format: UInt64
     Stride: 32
-    Data: [ 0, 1, 8, 0x0000000100000000, 0x7FFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF, 0x5555555555555555, 0xF0F0F0F0F0F0F0F0, 0x0F880F880F880F88, 0xC003C003C003C003, 0, 0 ] # Last two are filler
+    Data: [
+      0x0000FFFF0000FFFF,
+      0xAAAAAAAAAAAAAAAA,
+      0x3333CCCCCCCC3333,
+      0x0123456789ABCDEF,
+    ]
   - Name: Out
     Format: UInt64
     Stride: 32
@@ -31,7 +39,22 @@ Buffers:
   - Name: ExpectedOut # The result we expect
     Format: UInt64
     Stride: 32
-    Data: [ 0, 9223372036854775808, 1152921504606846976, 0x0000000080000000, 0xFFFFFFFFFFFFFFFE, 0xFFFFFFFFFFFFFFFF, 0xAAAAAAAAAAAAAAAA, 0x0F0F0F0F0F0F0F0F, 0x11F011F011F011F0, 0xC003C003C003C003, 0, 2147483648 ]
+    Data: [
+      0xFFFF0000FFFF0000,
+      0x5555555555555555,
+      0xCCCC33333333CCCC,
+      0xF7B3D591E6A2C480,
+
+      0xFFFF0000FFFF0000,
+      0x5555555555555555,
+      0xCCCC33333333CCCC,
+      0xF7B3D591E6A2C480,
+
+      0xFFFF0000FFFF0000,
+      0x5555555555555555,
+      0xCCCC33333333CCCC,
+      0xF7B3D591E6A2C480,
+    ]
 Results:
   - Result: Test1
     Rule: BufferExact
@@ -55,6 +78,9 @@ DescriptorSets:
         Binding: 1
 ...
 #--- end
+
+# Bug https://github.com/llvm/llvm-project/issues/197810
+# XFAIL: Clang && Vulkan
 
 # REQUIRES: Int64
 # RUN: split-file %s %t


### PR DESCRIPTION
This XFAILs the test due to llvm/llvm-project#197810, but I've also updated the values to ones with more instantly recognizable bit patterns from my debugging to file that issue.