### PR TITLE
Update two XFAILs that no longer seem to be DXC specific

### DIFF
--- a/test/Feature/TypedBuffer/64bit-scalar.test
+++ b/test/Feature/TypedBuffer/64bit-scalar.test
@@ -123,7 +123,7 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/offload-test-suite/issues/1110
-# XFAIL: Intel && Vulkan && DXC
+# XFAIL: Intel && Vulkan
 
 # REQUIRES: Int64
 # RUN: split-file %s %t

--- a/test/Feature/TypedBuffer/GetDimensions.test
+++ b/test/Feature/TypedBuffer/GetDimensions.test
@@ -82,7 +82,7 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/offload-test-suite/issues/469
-# XFAIL: DXC && Vulkan && Intel
+# XFAIL: Vulkan && Intel
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl


### PR DESCRIPTION
As far as I can tell Clang's codegen has gotten similar enough to DXC's that these are failing in the same way for both compilers now.