### PR TITLE
XFAIL Texture2D GetDimensions test on Vulkan

### DIFF
--- a/test/Feature/Textures/Texture2D.GetDimensions.test.yaml
+++ b/test/Feature/Textures/Texture2D.GetDimensions.test.yaml
@@ -117,6 +117,9 @@ Results:
 # Unimplemented: Clang + DX: https://github.com/llvm/llvm-project/issues/101558
 # XFAIL: DirectX || Metal
 
+# Bug https://github.com/llvm/llvm-project/issues/197837
+# XFAIL: Clang && Vulkan
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/compute.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
We emit OpImageQuerySize when we need to emit OpImageQuerySizeLod, failing spirv-val. See llvm/llvm-project#197837.