### PR TITLE
XFAIL 16 bit WaveActiveMin/Max on Apple M2

### DIFF
--- a/test/WaveOps/WaveActiveMax.fp16.test
+++ b/test/WaveOps/WaveActiveMax.fp16.test
@@ -306,6 +306,9 @@ DescriptorSets:
 # Bug https://github.com/llvm/llvm-project/issues/172577
 # XFAIL: Clang && Vulkan
 
+# Bug https://github.com/llvm/offload-test-suite/issues/1200
+# XFAIL: Metal && AppleM2
+
 # REQUIRES: Half
 
 # RUN: split-file %s %t

--- a/test/WaveOps/WaveActiveMin.fp16.test
+++ b/test/WaveOps/WaveActiveMin.fp16.test
@@ -306,6 +306,9 @@ DescriptorSets:
 # Bug https://github.com/llvm/llvm-project/issues/172577
 # XFAIL: Clang && Vulkan
 
+# Bug https://github.com/llvm/offload-test-suite/issues/1200
+# XFAIL: Metal && AppleM2
+
 # REQUIRES: Half
 
 # RUN: split-file %s %t


### PR DESCRIPTION
This needs further investigation, but should get the LLVM pre-checkin HLSL tests passing consistently. See llvm/offload-test-suite#1200.