### PR TITLE
Add geometry shader support with point -> quad test

### DIFF
--- a/include/API/Device.h
+++ b/include/API/Device.h
@@ -27,6 +27,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/iterator_range.h"
 #include "llvm/Support/Error.h"
+#include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/MemoryBuffer.h"
 
 #include <cstdint>
@@ -79,6 +80,33 @@ struct ShaderContainer {
   std::string EntryPoint;
   const llvm::MemoryBuffer *Shader;
   llvm::SmallVector<SpecializationConstant> SpecializationConstants;
+};
+
+struct GraphicsPipelineCreateDesc {
+  llvm::SmallVector<InputLayoutDesc> InputLayout;
+  llvm::SmallVector<Format> RTFormats;
+  std::optional<Format> DSFormat;
+  PrimitiveTopology Topology;
+  ShaderContainer VS;
+  // TODO: Optional Hull & Domain Shaders
+  std::optional<ShaderContainer> GS;
+  ShaderContainer PS;
+
+  void setShader(Stages Stage, ShaderContainer &&SC) {
+    switch (Stage) {
+    case Stages::Vertex:
+      VS = std::move(SC);
+      break;
+    case Stages::Geometry:
+      GS = std::move(SC);
+      break;
+    case Stages::Pixel:
+      PS = std::move(SC);
+      break;
+    case Stages::Compute:
+      llvm_unreachable("Creating graphics pipeline for compute?");
+    }
+  }
 };
 
 class PipelineState {
@@ -160,11 +188,9 @@ public:
                    ShaderContainer CS) = 0;
 
   virtual llvm::Expected<std::unique_ptr<PipelineState>>
-  createPipelineVsPs(llvm::StringRef Name, const BindingsDesc &BindingsDesc,
-                     llvm::ArrayRef<InputLayoutDesc> InputLayout,
-                     llvm::ArrayRef<Format> RTFormats,
-                     std::optional<Format> DSFormat, ShaderContainer VS,
-                     ShaderContainer PS) = 0;
+  createTraditionalRasterPipeline(llvm::StringRef Name,
+                                  const BindingsDesc &BindingsDesc,
+                                  const GraphicsPipelineCreateDesc &Desc) = 0;
 
   virtual llvm::Expected<std::unique_ptr<Fence>>
   createFence(llvm::StringRef Name) = 0;

--- a/include/API/Device.h
+++ b/include/API/Device.h
@@ -82,7 +82,7 @@ struct ShaderContainer {
   llvm::SmallVector<SpecializationConstant> SpecializationConstants;
 };
 
-struct GraphicsPipelineCreateDesc {
+struct TraditionalRasterPipelineCreateDesc {
   llvm::SmallVector<InputLayoutDesc> InputLayout;
   llvm::SmallVector<Format> RTFormats;
   std::optional<Format> DSFormat;
@@ -190,9 +190,9 @@ public:
                    ShaderContainer CS) = 0;
 
   virtual llvm::Expected<std::unique_ptr<PipelineState>>
-  createTraditionalRasterPipeline(llvm::StringRef Name,
-                                  const BindingsDesc &BindingsDesc,
-                                  const GraphicsPipelineCreateDesc &Desc) = 0;
+  createTraditionalRasterPipeline(
+      llvm::StringRef Name, const BindingsDesc &BindingsDesc,
+      const TraditionalRasterPipelineCreateDesc &Desc) = 0;
 
   virtual llvm::Expected<std::unique_ptr<Fence>>
   createFence(llvm::StringRef Name) = 0;

--- a/include/API/Device.h
+++ b/include/API/Device.h
@@ -104,7 +104,9 @@ struct GraphicsPipelineCreateDesc {
       PS = std::move(SC);
       break;
     case Stages::Compute:
-      llvm_unreachable("Creating graphics pipeline for compute?");
+    case Stages::Amplification:
+    case Stages::Mesh:
+      llvm_unreachable("Not a traditional raster pipeline stage.");
     }
   }
 };

--- a/include/API/Enums.h
+++ b/include/API/Enums.h
@@ -44,6 +44,8 @@ enum class StoreAction {
   DontCare, ///< Contents may be discarded after the pass.
 };
 
+enum class PrimitiveTopology { TriangleList, PointList };
+
 } // namespace offloadtest
 
 #endif // OFFLOADTEST_API_ENUMS_H

--- a/include/Support/Pipeline.h
+++ b/include/Support/Pipeline.h
@@ -32,6 +32,7 @@ enum class Stages {
 
   // Traditional Raster
   Vertex,
+  Geometry,
   Pixel,
 
   // Mesh Shader Raster
@@ -39,8 +40,8 @@ enum class Stages {
   Mesh
 };
 inline constexpr std::array AllStages = {
-    Stages::Compute,       Stages::Vertex, Stages::Pixel,
-    Stages::Amplification, Stages::Mesh,
+    Stages::Compute, Stages::Vertex,        Stages::Geometry,
+    Stages::Pixel,   Stages::Amplification, Stages::Mesh,
 };
 inline constexpr size_t NumStages = AllStages.size();
 
@@ -399,6 +400,7 @@ struct IOBindings {
 
   std::string RenderTarget;
   CPUBuffer *RTargetBufferPtr = nullptr;
+  PrimitiveTopology Topology = PrimitiveTopology::TriangleList;
 
   uint32_t getVertexStride() const {
     uint32_t Stride = 0;
@@ -728,9 +730,19 @@ template <> struct ScalarEnumerationTraits<offloadtest::Stages> {
 #define ENUM_CASE(Val) I.enumCase(V, #Val, offloadtest::Stages::Val)
     ENUM_CASE(Compute);
     ENUM_CASE(Vertex);
+    ENUM_CASE(Geometry);
     ENUM_CASE(Pixel);
     ENUM_CASE(Amplification);
     ENUM_CASE(Mesh);
+#undef ENUM_CASE
+  }
+};
+
+template <> struct ScalarEnumerationTraits<offloadtest::PrimitiveTopology> {
+  static void enumeration(IO &I, offloadtest::PrimitiveTopology &V) {
+#define ENUM_CASE(Val) I.enumCase(V, #Val, offloadtest::PrimitiveTopology::Val)
+    ENUM_CASE(TriangleList);
+    ENUM_CASE(PointList);
 #undef ENUM_CASE
   }
 };

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -716,14 +716,12 @@ class DXRenderEncoder : public offloadtest::RenderEncoder {
                                      "Scissor must be set before drawing.");
 
     const auto &DXPSO = llvm::cast<DXPipelineState>(PSO);
-    if (!DXPSO.Topology)
-      return llvm::createStringError(
-          std::errc::invalid_argument,
-          "Pipeline bound for drawing has no primitive topology (not a "
-          "graphics pipeline).");
     CB.CmdList->SetGraphicsRootSignature(DXPSO.RootSig.Get());
     CB.CmdList->SetPipelineState(DXPSO.PSO.Get());
-    CB.CmdList->IASetPrimitiveTopology(*DXPSO.Topology);
+    // Mesh-shader pipelines bypass the input assembler and carry no IA
+    // topology; only bind one when the pipeline actually has one.
+    if (DXPSO.Topology)
+      CB.CmdList->IASetPrimitiveTopology(*DXPSO.Topology);
     return llvm::Error::success();
   }
 
@@ -1126,7 +1124,7 @@ public:
   llvm::Expected<std::unique_ptr<PipelineState>>
   createTraditionalRasterPipeline(
       llvm::StringRef Name, const BindingsDesc &BndDesc,
-      const GraphicsPipelineCreateDesc &Desc) override {
+      const TraditionalRasterPipelineCreateDesc &Desc) override {
     assert(Desc.RTFormats.size() <= 8);
 
     ComPtr<ID3D12RootSignature> RootSig;
@@ -2489,7 +2487,7 @@ public:
           }
         }
 
-        GraphicsPipelineCreateDesc PipelineDesc = {};
+        TraditionalRasterPipelineCreateDesc PipelineDesc = {};
         PipelineDesc.Topology = P.Bindings.Topology;
         PipelineDesc.DSFormat = Format::D32FloatS8Uint;
         for (auto &Shader : P.Shaders) {

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -157,6 +157,28 @@ static uint32_t getAlignedTexturePitch(uint32_t Width, uint32_t ElementSize) {
   return llvm::alignTo(Width * ElementSize, D3D12_TEXTURE_DATA_PITCH_ALIGNMENT);
 }
 
+static D3D12_PRIMITIVE_TOPOLOGY_TYPE
+getDXPrimitiveTopologyType(PrimitiveTopology Topology) {
+  switch (Topology) {
+  case PrimitiveTopology::TriangleList:
+    return D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+  case PrimitiveTopology::PointList:
+    return D3D12_PRIMITIVE_TOPOLOGY_TYPE_POINT;
+  }
+  llvm_unreachable("All PrimitiveTopology cases handled");
+}
+
+static D3D_PRIMITIVE_TOPOLOGY
+getDXPrimitiveTopology(PrimitiveTopology Topology) {
+  switch (Topology) {
+  case PrimitiveTopology::TriangleList:
+    return D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST;
+  case PrimitiveTopology::PointList:
+    return D3D_PRIMITIVE_TOPOLOGY_POINTLIST;
+  }
+  llvm_unreachable("All PrimitiveTopology cases handled");
+}
+
 static uint64_t getAlignedTextureBufferSize(const CPUBuffer &B) {
   const uint64_t AlignedPitch =
       getAlignedTexturePitch(B.OutputProps.Width, B.getElementSize());
@@ -379,11 +401,14 @@ public:
   std::string Name;
   ComPtr<ID3D12RootSignature> RootSig;
   ComPtr<ID3D12PipelineState> PSO;
+  // Only set for graphics pipelines.
+  std::optional<D3D_PRIMITIVE_TOPOLOGY> Topology;
 
   DXPipelineState(llvm::StringRef Name, ComPtr<ID3D12RootSignature> RootSig,
-                  ComPtr<ID3D12PipelineState> PSO)
+                  ComPtr<ID3D12PipelineState> PSO,
+                  std::optional<D3D_PRIMITIVE_TOPOLOGY> Topology)
       : offloadtest::PipelineState(GPUAPI::DirectX), Name(Name),
-        RootSig(RootSig), PSO(PSO) {}
+        RootSig(RootSig), PSO(PSO), Topology(Topology) {}
 
   static bool classof(const offloadtest::PipelineState *B) {
     return B->getAPI() == GPUAPI::DirectX;
@@ -691,9 +716,14 @@ class DXRenderEncoder : public offloadtest::RenderEncoder {
                                      "Scissor must be set before drawing.");
 
     const auto &DXPSO = llvm::cast<DXPipelineState>(PSO);
+    if (!DXPSO.Topology)
+      return llvm::createStringError(
+          std::errc::invalid_argument,
+          "Pipeline bound for drawing has no primitive topology (not a "
+          "graphics pipeline).");
     CB.CmdList->SetGraphicsRootSignature(DXPSO.RootSig.Get());
     CB.CmdList->SetPipelineState(DXPSO.PSO.Get());
-    CB.CmdList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+    CB.CmdList->IASetPrimitiveTopology(*DXPSO.Topology);
     return llvm::Error::success();
   }
 
@@ -974,17 +1004,17 @@ public:
   }
 
   llvm::Error createRootSignatureFromBindingsDesc(
-      llvm::StringRef, const BindingsDesc &BindingsDesc, bool IsGraphics,
+      llvm::StringRef, const BindingsDesc &BndDesc, bool IsGraphics,
       ComPtr<ID3D12RootSignature> &OutRootSignature) {
     uint32_t DescriptorCount = 0;
-    for (auto &D : BindingsDesc.DescriptorSetDescs)
+    for (auto &D : BndDesc.DescriptorSetDescs)
       DescriptorCount += D.ResourceBindings.size();
 
     std::vector<D3D12_ROOT_PARAMETER> RootParams;
     const std::unique_ptr<D3D12_DESCRIPTOR_RANGE[]> Ranges(
         new D3D12_DESCRIPTOR_RANGE[DescriptorCount]);
     uint32_t RangeIdx = 0;
-    for (const auto &Set : BindingsDesc.DescriptorSetDescs) {
+    for (const auto &Set : BndDesc.DescriptorSetDescs) {
       uint32_t DescriptorIdx = 0;
       const uint32_t StartRangeIdx = RangeIdx;
       for (const auto &Binding : Set.ResourceBindings) {
@@ -1049,7 +1079,7 @@ public:
   }
 
   llvm::Error
-  createRootSignature(llvm::StringRef Name, const BindingsDesc &BindingsDesc,
+  createRootSignature(llvm::StringRef Name, const BindingsDesc &BndDesc,
                       const ShaderContainer &Shader, bool IsGraphics,
                       ComPtr<ID3D12RootSignature> &OutRootSignature) {
     assert(OutRootSignature.Get() == nullptr);
@@ -1061,15 +1091,15 @@ public:
     if (OutRootSignature.Get() != nullptr)
       return llvm::Error::success();
 
-    return createRootSignatureFromBindingsDesc(Name, BindingsDesc, IsGraphics,
+    return createRootSignatureFromBindingsDesc(Name, BndDesc, IsGraphics,
                                                OutRootSignature);
   }
 
   llvm::Expected<std::unique_ptr<PipelineState>>
-  createPipelineCs(llvm::StringRef Name, const BindingsDesc &BindingsDesc,
+  createPipelineCs(llvm::StringRef Name, const BindingsDesc &BndDesc,
                    ShaderContainer CS) override {
     ComPtr<ID3D12RootSignature> RootSig;
-    if (auto Err = createRootSignature(Name, BindingsDesc, CS,
+    if (auto Err = createRootSignature(Name, BndDesc, CS,
                                        /*IsGraphics=*/false, RootSig))
       return Err;
 
@@ -1090,25 +1120,23 @@ public:
             "Failed to create PSO."))
       return Err;
 
-    return std::make_unique<DXPipelineState>(Name, RootSig, PSO);
+    return std::make_unique<DXPipelineState>(Name, RootSig, PSO, std::nullopt);
   }
 
   llvm::Expected<std::unique_ptr<PipelineState>>
-  createPipelineVsPs(llvm::StringRef Name, const BindingsDesc &BindingsDesc,
-                     llvm::ArrayRef<InputLayoutDesc> InputLayout,
-                     llvm::ArrayRef<Format> RTFormats,
-                     std::optional<Format> DSFormat, ShaderContainer VS,
-                     ShaderContainer PS) override {
-    assert(RTFormats.size() <= 8);
+  createTraditionalRasterPipeline(
+      llvm::StringRef Name, const BindingsDesc &BndDesc,
+      const GraphicsPipelineCreateDesc &Desc) override {
+    assert(Desc.RTFormats.size() <= 8);
 
     ComPtr<ID3D12RootSignature> RootSig;
-    if (auto Err = createRootSignature(Name, BindingsDesc, VS,
+    if (auto Err = createRootSignature(Name, BndDesc, Desc.VS,
                                        /*IsGraphics=*/true, RootSig))
       return Err;
 
     std::vector<D3D12_INPUT_ELEMENT_DESC> DXInputLayout;
-    DXInputLayout.reserve(InputLayout.size());
-    for (const InputLayoutDesc &Elem : InputLayout) {
+    DXInputLayout.reserve(Desc.InputLayout.size());
+    for (const InputLayoutDesc &Elem : Desc.InputLayout) {
       assert(!Elem.InstanceStepRate &&
              "Instance step rate is currently not supported.");
 
@@ -1125,12 +1153,17 @@ public:
     D3D12_GRAPHICS_PIPELINE_STATE_DESC PSODesc = {};
     PSODesc.InputLayout = {DXInputLayout.data(), (UINT)DXInputLayout.size()};
     PSODesc.pRootSignature = RootSig.Get();
-    PSODesc.VS = {VS.Shader->getBuffer().data(), VS.Shader->getBuffer().size()};
-    PSODesc.PS = {PS.Shader->getBuffer().data(), PS.Shader->getBuffer().size()};
+    PSODesc.VS = {Desc.VS.Shader->getBuffer().data(),
+                  Desc.VS.Shader->getBuffer().size()};
+    PSODesc.PS = {Desc.PS.Shader->getBuffer().data(),
+                  Desc.PS.Shader->getBuffer().size()};
     if (PSODesc.VS.BytecodeLength == 0 || PSODesc.PS.BytecodeLength == 0)
       return llvm::createStringError(std::errc::invalid_argument,
                                      "Graphics pipeline requires both a vertex "
                                      "shader and a pixel shader.");
+    if (Desc.GS)
+      PSODesc.GS = {Desc.GS->Shader->getBuffer().data(),
+                    Desc.GS->Shader->getBuffer().size()};
 
     PSODesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
     PSODesc.RasterizerState.CullMode = D3D12_CULL_MODE_NONE;
@@ -1141,12 +1174,12 @@ public:
     PSODesc.DepthStencilState.DepthFunc = D3D12_COMPARISON_FUNC_LESS;
     PSODesc.DepthStencilState.StencilEnable = false;
     PSODesc.SampleMask = UINT_MAX;
-    PSODesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
-    PSODesc.NumRenderTargets = static_cast<UINT>(RTFormats.size());
-    if (DSFormat)
-      PSODesc.DSVFormat = getDXGIFormat(*DSFormat);
-    for (size_t I = 0; I < RTFormats.size(); ++I)
-      PSODesc.RTVFormats[I] = getDXGIFormat(RTFormats[I]);
+    PSODesc.PrimitiveTopologyType = getDXPrimitiveTopologyType(Desc.Topology);
+    PSODesc.NumRenderTargets = static_cast<UINT>(Desc.RTFormats.size());
+    if (Desc.DSFormat)
+      PSODesc.DSVFormat = getDXGIFormat(*Desc.DSFormat);
+    for (size_t I = 0; I < Desc.RTFormats.size(); ++I)
+      PSODesc.RTVFormats[I] = getDXGIFormat(Desc.RTFormats[I]);
     PSODesc.SampleDesc.Count = 1;
 
     ComPtr<ID3D12PipelineState> PSO;
@@ -1155,11 +1188,12 @@ public:
             "Failed to create graphics PSO."))
       return Err;
 
-    return std::make_unique<DXPipelineState>(Name, RootSig, PSO);
+    return std::make_unique<DXPipelineState>(
+        Name, RootSig, PSO, getDXPrimitiveTopology(Desc.Topology));
   }
 
   llvm::Expected<std::unique_ptr<PipelineState>>
-  createPipelineAsMsPs(llvm::StringRef Name, const BindingsDesc &BindingsDesc,
+  createPipelineAsMsPs(llvm::StringRef Name, const BindingsDesc &BndDesc,
                        llvm::ArrayRef<Format> RTFormats,
                        std::optional<Format> DSFormat,
                        std::optional<ShaderContainer> AS, ShaderContainer MS,
@@ -1167,7 +1201,7 @@ public:
     assert(RTFormats.size() <= 8);
 
     ComPtr<ID3D12RootSignature> RootSig;
-    if (auto Err = createRootSignature(Name, BindingsDesc, MS,
+    if (auto Err = createRootSignature(Name, BndDesc, MS,
                                        /*IsGraphics=*/true, RootSig))
       return Err;
 
@@ -2366,7 +2400,7 @@ public:
       return Err;
     llvm::outs() << "Buffers created.\n";
 
-    BindingsDesc BindingsDesc = {};
+    BindingsDesc BndDesc = {};
     for (auto &S : P.Sets) {
       DescriptorSetLayoutDesc Layout;
       for (auto &R : S.Resources) {
@@ -2380,7 +2414,7 @@ public:
         Layout.ResourceBindings.push_back(ResourceBinding);
       }
 
-      BindingsDesc.DescriptorSetDescs.push_back(Layout);
+      BndDesc.DescriptorSetDescs.push_back(Layout);
     }
 
     if (P.isRaster()) {
@@ -2407,7 +2441,7 @@ public:
       CS.Shader = P.Shaders[0].Shader.get();
 
       auto PipelineStateOrErr =
-          createPipelineCs("Compute Pipeline State", BindingsDesc, CS);
+          createPipelineCs("Compute Pipeline State", BndDesc, CS);
       if (!PipelineStateOrErr)
         return PipelineStateOrErr.takeError();
       State.Pipeline = std::move(*PipelineStateOrErr);
@@ -2417,6 +2451,7 @@ public:
       llvm::outs() << "Compute command list created.\n";
 
     } else if (P.isRaster()) {
+
       // Begin a render pass: bind RT/DSV and clear depth-stencil. Color
       // load action is Load — the existing inline code didn't clear color.
       ColorAttachmentFormatDesc ColorAttachment = {};
@@ -2454,37 +2489,44 @@ public:
           }
         }
 
+        GraphicsPipelineCreateDesc PipelineDesc = {};
+        PipelineDesc.Topology = P.Bindings.Topology;
+        PipelineDesc.DSFormat = Format::D32FloatS8Uint;
+        for (auto &Shader : P.Shaders) {
+          ShaderContainer SC = {};
+          SC.EntryPoint = Shader.Entry;
+          SC.Shader = Shader.Shader.get();
+          PipelineDesc.setShader(Shader.Stage, std::move(SC));
+        }
+
         // Create the input layout based on the vertex attributes.
-        llvm::SmallVector<InputLayoutDesc> InputLayout;
         for (auto &Attr : P.Bindings.VertexAttributes) {
           auto FormatOrErr = toFormat(Attr.Format, Attr.Channels);
           if (!FormatOrErr)
             return FormatOrErr.takeError();
 
-          InputLayoutDesc Desc = {};
-          Desc.Name = Attr.Name;
-          Desc.Fmt = *FormatOrErr;
-          Desc.OffsetInBytes = Attr.Offset;
-          InputLayout.push_back(Desc);
+          InputLayoutDesc Layout = {};
+          Layout.Name = Attr.Name;
+          Layout.Fmt = *FormatOrErr;
+          Layout.OffsetInBytes = Attr.Offset;
+          PipelineDesc.InputLayout.push_back(Layout);
         }
 
         auto FormatOrErr = toFormat(P.Bindings.RTargetBufferPtr->Format,
                                     P.Bindings.RTargetBufferPtr->Channels);
         if (!FormatOrErr)
           return FormatOrErr.takeError();
+        PipelineDesc.RTFormats.push_back(*FormatOrErr);
 
-        llvm::SmallVector<Format> RTFormats;
-        RTFormats.push_back(*FormatOrErr);
-
-        auto PipelineStateOrErr = createPipelineVsPs(
-            "Traditional Raster Pipeline State", BindingsDesc, InputLayout,
-            RTFormats, Format::D32FloatS8Uint, VS, PS);
+        auto PipelineStateOrErr = createTraditionalRasterPipeline(
+            "Graphics Pipeline State", BndDesc, PipelineDesc);
         if (!PipelineStateOrErr)
           return PipelineStateOrErr.takeError();
         State.Pipeline = std::move(*PipelineStateOrErr);
         llvm::outs() << "Traditional Raster Pipeline created.\n";
 
       } else if (P.isMeshShaderRaster()) {
+
         std::optional<ShaderContainer> AS = {};
         ShaderContainer MS = {};
         std::optional<ShaderContainer> PS = {};
@@ -2514,7 +2556,7 @@ public:
         RTFormats.push_back(*FormatOrErr);
 
         auto PipelineStateOrErr =
-            createPipelineAsMsPs("Mesh Shader Pipeline State", BindingsDesc,
+            createPipelineAsMsPs("Mesh Shader Pipeline State", BndDesc,
                                  RTFormats, Format::D32FloatS8Uint, AS, MS, PS);
 
         if (!PipelineStateOrErr)

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -1268,7 +1268,7 @@ public:
             "Failed to create mesh shader PSO."))
       return Err;
 
-    return std::make_unique<DXPipelineState>(Name, RootSig, PSO);
+    return std::make_unique<DXPipelineState>(Name, RootSig, PSO, std::nullopt);
   }
 
   llvm::Expected<std::unique_ptr<offloadtest::Fence>>

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -1582,7 +1582,7 @@ public:
   llvm::Expected<std::unique_ptr<PipelineState>>
   createTraditionalRasterPipeline(
       llvm::StringRef Name, const BindingsDesc &BindingsDesc,
-      const GraphicsPipelineCreateDesc &Desc) override {
+      const TraditionalRasterPipelineCreateDesc &Desc) override {
     if (Desc.GS)
       return llvm::createStringError(
           std::errc::not_supported,
@@ -1812,7 +1812,7 @@ public:
       if (auto Err = createComputeCommands(P, IS))
         return Err;
     } else {
-      GraphicsPipelineCreateDesc PipelineDesc = {};
+      TraditionalRasterPipelineCreateDesc PipelineDesc = {};
       PipelineDesc.Topology = P.Bindings.Topology;
       PipelineDesc.DSFormat = Format::D32FloatS8Uint;
       for (auto &Shader : P.Shaders) {

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -133,6 +133,8 @@ static IRShaderStage getShaderStage(Stages Stage) {
     return IRShaderStageCompute;
   case Stages::Vertex:
     return IRShaderStageVertex;
+  case Stages::Geometry:
+    llvm_unreachable("Geometry shaders are not supported on Metal.");
   case Stages::Pixel:
     return IRShaderStageFragment;
   case Stages::Amplification:
@@ -1578,11 +1580,23 @@ public:
   }
 
   llvm::Expected<std::unique_ptr<PipelineState>>
-  createPipelineVsPs(llvm::StringRef Name, const BindingsDesc &BindingsDesc,
-                     llvm::ArrayRef<InputLayoutDesc> InputLayout,
-                     llvm::ArrayRef<Format> RTFormats,
-                     std::optional<Format> DSFormat, ShaderContainer VS,
-                     ShaderContainer PS) override {
+  createTraditionalRasterPipeline(
+      llvm::StringRef Name, const BindingsDesc &BindingsDesc,
+      const GraphicsPipelineCreateDesc &Desc) override {
+    if (Desc.GS)
+      return llvm::createStringError(
+          std::errc::not_supported,
+          "Geometry shaders are not supported on this backend.");
+    if (Desc.Topology != PrimitiveTopology::TriangleList)
+      return llvm::createStringError(
+          std::errc::not_supported,
+          "Only TriangleList topology is currently supported.");
+    const ShaderContainer &VS = Desc.VS;
+    const ShaderContainer &PS = Desc.PS;
+    const llvm::ArrayRef<InputLayoutDesc> InputLayout = Desc.InputLayout;
+    const llvm::ArrayRef<Format> RTFormats = Desc.RTFormats;
+    const std::optional<Format> DSFormat = Desc.DSFormat;
+
     IRRootSignaturePtr RootSig;
     std::unique_ptr<MTLTopLevelArgumentBuffer> ArgBuffer;
     if (auto Err = createRootSignature(BindingsDesc, /*IsGraphics=*/true,
@@ -1633,11 +1647,11 @@ public:
           PS.EntryPoint.c_str());
     auto PSFnScope = llvm::scope_exit([&] { PSFn->release(); });
 
-    MTL::RenderPipelineDescriptor *Desc =
+    MTL::RenderPipelineDescriptor *RPDesc =
         MTL::RenderPipelineDescriptor::alloc()->init();
-    auto DescScope = llvm::scope_exit([&] { Desc->release(); });
-    Desc->setVertexFunction(VSFn);
-    Desc->setFragmentFunction(PSFn);
+    auto RPDescScope = llvm::scope_exit([&] { RPDesc->release(); });
+    RPDesc->setVertexFunction(VSFn);
+    RPDesc->setFragmentFunction(PSFn);
 
     // Build vertex descriptor from InputLayout.
     if (!InputLayout.empty()) {
@@ -1712,7 +1726,7 @@ public:
       VtxDesc->layouts()->setObject(LDesc, kIRVertexBufferBindPoint);
       LDesc->release();
 
-      Desc->setVertexDescriptor(VtxDesc);
+      RPDesc->setVertexDescriptor(VtxDesc);
     }
 
     // Configure render target color attachments.
@@ -1720,20 +1734,20 @@ public:
       MTL::RenderPipelineColorAttachmentDescriptor *RPCA =
           MTL::RenderPipelineColorAttachmentDescriptor::alloc()->init();
       RPCA->setPixelFormat(getMetalPixelFormat(RTFormats[I]));
-      Desc->colorAttachments()->setObject(RPCA, I);
+      RPDesc->colorAttachments()->setObject(RPCA, I);
       RPCA->release();
     }
 
     // Configure depth/stencil attachment.
     if (DSFormat) {
       const MTL::PixelFormat DSPixelFormat = getMetalPixelFormat(*DSFormat);
-      Desc->setDepthAttachmentPixelFormat(DSPixelFormat);
+      RPDesc->setDepthAttachmentPixelFormat(DSPixelFormat);
       if (isStencilFormat(*DSFormat))
-        Desc->setStencilAttachmentPixelFormat(DSPixelFormat);
+        RPDesc->setStencilAttachmentPixelFormat(DSPixelFormat);
     }
 
     MTL::RenderPipelineState *PSO =
-        Device->newRenderPipelineState(Desc, &Error);
+        Device->newRenderPipelineState(RPDesc, &Error);
     if (Error)
       return toError(Error);
 
@@ -1798,42 +1812,36 @@ public:
       if (auto Err = createComputeCommands(P, IS))
         return Err;
     } else {
-      ShaderContainer VS = {};
-      ShaderContainer PS = {};
+      GraphicsPipelineCreateDesc PipelineDesc = {};
+      PipelineDesc.Topology = P.Bindings.Topology;
+      PipelineDesc.DSFormat = Format::D32FloatS8Uint;
       for (auto &Shader : P.Shaders) {
-        if (Shader.Stage == Stages::Vertex) {
-          VS.EntryPoint = Shader.Entry;
-          VS.Shader = Shader.Shader.get();
-        } else if (Shader.Stage == Stages::Pixel) {
-          PS.EntryPoint = Shader.Entry;
-          PS.Shader = Shader.Shader.get();
-        }
+        ShaderContainer SC = {};
+        SC.EntryPoint = Shader.Entry;
+        SC.Shader = Shader.Shader.get();
+        PipelineDesc.setShader(Shader.Stage, std::move(SC));
       }
 
-      llvm::SmallVector<InputLayoutDesc> InputLayout;
       for (auto &Attr : P.Bindings.VertexAttributes) {
         auto FormatOrErr = toFormat(Attr.Format, Attr.Channels);
         if (!FormatOrErr)
           return FormatOrErr.takeError();
 
-        InputLayoutDesc Desc = {};
-        Desc.Name = Attr.Name;
-        Desc.Fmt = *FormatOrErr;
-        Desc.OffsetInBytes = Attr.Offset;
-        InputLayout.push_back(Desc);
+        InputLayoutDesc Layout = {};
+        Layout.Name = Attr.Name;
+        Layout.Fmt = *FormatOrErr;
+        Layout.OffsetInBytes = Attr.Offset;
+        PipelineDesc.InputLayout.push_back(Layout);
       }
 
       auto FormatOrErr = toFormat(P.Bindings.RTargetBufferPtr->Format,
                                   P.Bindings.RTargetBufferPtr->Channels);
       if (!FormatOrErr)
         return FormatOrErr.takeError();
+      PipelineDesc.RTFormats.push_back(*FormatOrErr);
 
-      llvm::SmallVector<Format> RTFormats;
-      RTFormats.push_back(*FormatOrErr);
-
-      auto PipelineStateOrErr =
-          createPipelineVsPs("Graphics Pipeline State", Bindings, InputLayout,
-                             RTFormats, Format::D32FloatS8Uint, VS, PS);
+      auto PipelineStateOrErr = createTraditionalRasterPipeline(
+          "Graphics Pipeline State", Bindings, PipelineDesc);
       if (!PipelineStateOrErr)
         return PipelineStateOrErr.takeError();
       IS.Pipeline = std::move(*PipelineStateOrErr);

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -1458,7 +1458,7 @@ public:
   llvm::Expected<std::unique_ptr<PipelineState>>
   createTraditionalRasterPipeline(
       llvm::StringRef Name, const BindingsDesc &BindingsDesc,
-      const GraphicsPipelineCreateDesc &Desc) override {
+      const TraditionalRasterPipelineCreateDesc &Desc) override {
     const ShaderContainer &VS = Desc.VS;
     const ShaderContainer &PS = Desc.PS;
     const std::optional<ShaderContainer> &GS = Desc.GS;
@@ -3220,7 +3220,7 @@ public:
       State.Pipeline = std::move(*PipelineStateOrErr);
       llvm::outs() << "Compute Pipeline created.\n";
     } else if (P.isTraditionalRaster()) {
-      GraphicsPipelineCreateDesc PipelineDesc = {};
+      TraditionalRasterPipelineCreateDesc PipelineDesc = {};
       PipelineDesc.Topology = P.Bindings.Topology;
       PipelineDesc.DSFormat = Format::D32FloatS8Uint;
       for (auto &Shader : P.Shaders) {

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -206,6 +206,8 @@ static VkShaderStageFlagBits getShaderStageFlag(Stages Stage) {
     return VK_SHADER_STAGE_COMPUTE_BIT;
   case Stages::Vertex:
     return VK_SHADER_STAGE_VERTEX_BIT;
+  case Stages::Geometry:
+    return VK_SHADER_STAGE_GEOMETRY_BIT;
   case Stages::Pixel:
     return VK_SHADER_STAGE_FRAGMENT_BIT;
   case Stages::Amplification:
@@ -214,6 +216,16 @@ static VkShaderStageFlagBits getShaderStageFlag(Stages Stage) {
     return VK_SHADER_STAGE_MESH_BIT_EXT;
   }
   llvm_unreachable("All cases handled");
+}
+
+static VkPrimitiveTopology getVkPrimitiveTopology(PrimitiveTopology Topology) {
+  switch (Topology) {
+  case PrimitiveTopology::TriangleList:
+    return VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
+  case PrimitiveTopology::PointList:
+    return VK_PRIMITIVE_TOPOLOGY_POINT_LIST;
+  }
+  llvm_unreachable("All PrimitiveTopology cases handled");
 }
 
 static std::string getMessageSeverityString(
@@ -1444,11 +1456,15 @@ public:
   }
 
   llvm::Expected<std::unique_ptr<PipelineState>>
-  createPipelineVsPs(llvm::StringRef Name, const BindingsDesc &BindingsDesc,
-                     llvm::ArrayRef<InputLayoutDesc> InputLayout,
-                     llvm::ArrayRef<Format> RTFormats,
-                     std::optional<Format> DSFormat, ShaderContainer VS,
-                     ShaderContainer PS) override {
+  createTraditionalRasterPipeline(
+      llvm::StringRef Name, const BindingsDesc &BindingsDesc,
+      const GraphicsPipelineCreateDesc &Desc) override {
+    const ShaderContainer &VS = Desc.VS;
+    const ShaderContainer &PS = Desc.PS;
+    const std::optional<ShaderContainer> &GS = Desc.GS;
+    const llvm::ArrayRef<InputLayoutDesc> InputLayout = Desc.InputLayout;
+    const llvm::ArrayRef<Format> RTFormats = Desc.RTFormats;
+    const std::optional<Format> DSFormat = Desc.DSFormat;
 
     VkShaderStageFlags GraphicsFlags = VK_SHADER_STAGE_VERTEX_BIT;
     llvm::SmallVector<VkPipelineShaderStageCreateInfo, 5> ShaderStages;
@@ -1467,7 +1483,7 @@ public:
                                                   VSSpecInfo))
         return Err;
 
-      auto VSModOrErr = createShaderModule(VS.Shader, "mesh");
+      auto VSModOrErr = createShaderModule(VS.Shader, "vertex");
       if (!VSModOrErr)
         return VSModOrErr.takeError();
 
@@ -1478,6 +1494,31 @@ public:
       ShaderStage.pName = VS.EntryPoint.c_str();
       ShaderStage.pSpecializationInfo =
           VS.SpecializationConstants.empty() ? nullptr : &VSSpecInfo;
+      ShaderStages.push_back(ShaderStage);
+    }
+
+    llvm::SmallVector<VkSpecializationMapEntry> GSSpecEntries;
+    llvm::SmallVector<char> GSSpecData;
+    VkSpecializationInfo GSSpecInfo = {};
+    if (GS) {
+      if (auto Err = parseSpecializationConstants(GS->SpecializationConstants,
+                                                  GSSpecEntries, GSSpecData,
+                                                  GSSpecInfo))
+        return Err;
+
+      auto GSModOrErr = createShaderModule(GS->Shader, "geometry");
+      if (!GSModOrErr)
+        return GSModOrErr.takeError();
+
+      GraphicsFlags |= VK_SHADER_STAGE_GEOMETRY_BIT;
+
+      VkPipelineShaderStageCreateInfo ShaderStage = {};
+      ShaderStage.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+      ShaderStage.stage = VK_SHADER_STAGE_GEOMETRY_BIT;
+      ShaderStage.module = *GSModOrErr;
+      ShaderStage.pName = GS->EntryPoint.c_str();
+      ShaderStage.pSpecializationInfo =
+          GS->SpecializationConstants.empty() ? nullptr : &GSSpecInfo;
       ShaderStages.push_back(ShaderStage);
     }
 
@@ -1582,7 +1623,7 @@ public:
     VkPipelineInputAssemblyStateCreateInfo InputAssemblyCI = {};
     InputAssemblyCI.sType =
         VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
-    InputAssemblyCI.topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
+    InputAssemblyCI.topology = getVkPrimitiveTopology(Desc.Topology);
 
     VkPipelineViewportStateCreateInfo ViewportCI = {};
     ViewportCI.sType = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO;
@@ -3179,45 +3220,38 @@ public:
       State.Pipeline = std::move(*PipelineStateOrErr);
       llvm::outs() << "Compute Pipeline created.\n";
     } else if (P.isTraditionalRaster()) {
-      ShaderContainer VS = {};
-      ShaderContainer PS = {};
+      GraphicsPipelineCreateDesc PipelineDesc = {};
+      PipelineDesc.Topology = P.Bindings.Topology;
+      PipelineDesc.DSFormat = Format::D32FloatS8Uint;
       for (auto &Shader : P.Shaders) {
-        if (Shader.Stage == Stages::Vertex) {
-          VS.EntryPoint = Shader.Entry;
-          VS.Shader = Shader.Shader.get();
-          VS.SpecializationConstants = Shader.SpecializationConstants;
-        } else if (Shader.Stage == Stages::Pixel) {
-          PS.EntryPoint = Shader.Entry;
-          PS.Shader = Shader.Shader.get();
-          PS.SpecializationConstants = Shader.SpecializationConstants;
-        }
+        ShaderContainer SC = {};
+        SC.EntryPoint = Shader.Entry;
+        SC.Shader = Shader.Shader.get();
+        SC.SpecializationConstants = Shader.SpecializationConstants;
+        PipelineDesc.setShader(Shader.Stage, std::move(SC));
       }
 
       // Create the input layout based on the vertex attributes.
-      llvm::SmallVector<InputLayoutDesc> InputLayout;
       for (auto &Attr : P.Bindings.VertexAttributes) {
         auto FormatOrErr = toFormat(Attr.Format, Attr.Channels);
         if (!FormatOrErr)
           return FormatOrErr.takeError();
 
-        InputLayoutDesc Desc = {};
-        Desc.Name = Attr.Name;
-        Desc.Fmt = *FormatOrErr;
-        Desc.OffsetInBytes = Attr.Offset;
-        InputLayout.push_back(Desc);
+        InputLayoutDesc Layout = {};
+        Layout.Name = Attr.Name;
+        Layout.Fmt = *FormatOrErr;
+        Layout.OffsetInBytes = Attr.Offset;
+        PipelineDesc.InputLayout.push_back(Layout);
       }
 
       auto FormatOrErr = toFormat(P.Bindings.RTargetBufferPtr->Format,
                                   P.Bindings.RTargetBufferPtr->Channels);
       if (!FormatOrErr)
         return FormatOrErr.takeError();
+      PipelineDesc.RTFormats.push_back(*FormatOrErr);
 
-      llvm::SmallVector<Format> RTFormats;
-      RTFormats.push_back(*FormatOrErr);
-
-      auto PipelineStateOrErr = createPipelineVsPs(
-          "Graphics Pipeline State", BindingsDesc, InputLayout, RTFormats,
-          Format::D32FloatS8Uint, VS, PS);
+      auto PipelineStateOrErr = createTraditionalRasterPipeline(
+          "Graphics Pipeline State", BindingsDesc, PipelineDesc);
       if (!PipelineStateOrErr)
         return PipelineStateOrErr.takeError();
       State.Pipeline = std::move(*PipelineStateOrErr);

--- a/lib/Support/Pipeline.cpp
+++ b/lib/Support/Pipeline.cpp
@@ -425,6 +425,8 @@ void MappingTraits<offloadtest::IOBindings>::mapping(
   I.mapOptional("VertexBuffer", B.VertexBuffer);
   I.mapOptional("VertexAttributes", B.VertexAttributes);
   I.mapOptional("RenderTarget", B.RenderTarget);
+  I.mapOptional("Topology", B.Topology,
+                offloadtest::PrimitiveTopology::TriangleList);
 }
 
 void MappingTraits<offloadtest::PushConstantBlock>::mapping(

--- a/test/Graphics/gs_point_to_quad.test
+++ b/test/Graphics/gs_point_to_quad.test
@@ -1,0 +1,98 @@
+#--- vertex.hlsl
+struct VSOutput {
+  float4 position : SV_POSITION;
+};
+
+// Pass-through vertex shader: a single input point travels unchanged to the
+// geometry stage, which is responsible for expanding it into a quad.
+VSOutput main(float4 position : POSITION) {
+  VSOutput o;
+  o.position = position;
+  return o;
+}
+
+#--- geometry.hlsl
+struct GSInput {
+  float4 position : SV_POSITION;
+};
+
+struct GSOutput {
+  float4 position : SV_POSITION;
+};
+
+// Expand the single input point into a fullscreen quad (two triangles via a
+// triangle strip). The emitted clip-space positions cover the whole viewport
+// so every pixel of the 2x2 render target is rasterized.
+[maxvertexcount(4)]
+void main(point GSInput input[1], inout TriangleStream<GSOutput> stream) {
+  GSOutput v;
+  v.position = float4(-1.0, -1.0, 0.0, 1.0);
+  stream.Append(v);
+  v.position = float4(-1.0,  1.0, 0.0, 1.0);
+  stream.Append(v);
+  v.position = float4( 1.0, -1.0, 0.0, 1.0);
+  stream.Append(v);
+  v.position = float4( 1.0,  1.0, 0.0, 1.0);
+  stream.Append(v);
+}
+
+#--- pixel.hlsl
+struct PSInput {
+  float4 position : SV_POSITION;
+};
+
+float4 main(PSInput input) : SV_TARGET {
+  return float4(1.0, 0.0, 0.0, 1.0);
+}
+
+#--- pipeline.yaml
+---
+Shaders:
+  - Stage: Vertex
+    Entry: main
+  - Stage: Geometry
+    Entry: main
+  - Stage: Pixel
+    Entry: main
+Buffers:
+  - Name: VertexData
+    Format: Float32
+    Stride: 16 # 1 vertex, 16 bytes
+    Data: [ 0.0, 0.0, 0.0, 1.0 ]
+  - Name: Output
+    Format: Float32
+    Channels: 4
+    FillSize: 64 # 2x2 @ 16 bytes per pixel
+    OutputProps:
+      Height: 2
+      Width: 2
+      Depth: 1
+Bindings:
+  VertexBuffer: VertexData
+  VertexAttributes:
+    - Format: Float32
+      Channels: 4
+      Offset: 0
+      Name: POSITION
+  Topology: PointList
+  RenderTarget: Output
+DescriptorSets: []
+...
+#--- end
+
+# Metal has no native geometry shader stage (equivalents would require mesh or
+# tessellation shaders). Skip this test on that backend entirely.
+# UNSUPPORTED: Metal
+
+# Unimplemented https://github.com/llvm/llvm-project/issues/136963
+# XFAIL: Clang
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T vs_6_0 -Fo %t-vertex.o %t/vertex.hlsl
+# RUN: %dxc_target -T gs_6_0 -Fo %t-geometry.o %t/geometry.hlsl
+# RUN: %dxc_target -T ps_6_0 -Fo %t-pixel.o %t/pixel.hlsl
+# RUN: %offloader %t/pipeline.yaml %t-vertex.o %t-geometry.o %t-pixel.o | FileCheck %s
+
+# All 4 pixels of the 2x2 render target must be opaque red.
+# CHECK: Name: Output
+# CHECK: Data: [ 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1 ]


### PR DESCRIPTION
Add geometry shader support to the engine and introduce `PrimitiveTopology` type.
`PrimitiveTopology` defaults to `TriangleList` so that we don't have to specify it in all our existing rasterization tests.

Add a new test `Graphics/gs_point_to_quad.test` exercising a VS → GS → PS pipeline: 
- VS is a pass-through
- GS expands a single input point into a fullscreen quad
- PS writes red. 
- A 2x2 render target verifies that all four pixels are rasterized.

Add `GraphicsPipelineCreateDesc` to keep the pipeline creation function signature tidy.
`GS` and `PS` within `GraphicsPipelineCreateDesc` are optional, but for the time being the backends assert that a PS is set. We can lift that assert once we need a VS-only test.