### PR TITLE
[api-query] Report GPU driver version

### DIFF
--- a/include/API/Device.h
+++ b/include/API/Device.h
@@ -145,6 +145,7 @@ class Device {
 protected:
   std::string Description;
   std::string DriverName;
+  std::string DriverVersion;
 
 public:
   virtual const Capabilities &getCapabilities() = 0;
@@ -184,6 +185,7 @@ public:
 
   llvm::StringRef getDescription() const { return Description; }
   llvm::StringRef getDriverName() const { return DriverName; }
+  llvm::StringRef getDriverVersion() const { return DriverVersion; }
 };
 
 llvm::Error

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -42,6 +42,7 @@
 #include "DXResources.h"
 
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/Twine.h"
 #include "llvm/Object/DXContainer.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/FormatVariadic.h"
@@ -699,11 +700,12 @@ private:
 public:
   DXDevice(ComPtr<IDXCoreAdapter> A, ComPtr<ID3D12Device> D, DXQueue Q,
            DescriptorAllocator RTVAllocator, DescriptorAllocator DSVAllocator,
-           std::string Desc)
+           std::string Desc, std::string DriverVer)
       : Adapter(A), Device(D), GraphicsQueue(std::move(Q)),
         RTVAllocator(std::move(RTVAllocator)),
         DSVAllocator(std::move(DSVAllocator)) {
-    Description = Desc;
+    Description = std::move(Desc);
+    DriverVersion = std::move(DriverVer);
   }
   DXDevice(const DXDevice &) = delete;
   DXDevice &operator=(const DXDevice &) = delete;
@@ -1073,6 +1075,22 @@ public:
     std::vector<char> DescVec(BufferSize);
     Adapter->GetProperty(DXCoreAdapterProperty::DriverDescription, BufferSize,
                          (void *)DescVec.data());
+
+    std::string DriverVer;
+    if (Adapter->IsPropertySupported(DXCoreAdapterProperty::DriverVersion)) {
+      uint64_t Packed = 0;
+      if (SUCCEEDED(Adapter->GetProperty(DXCoreAdapterProperty::DriverVersion,
+                                         sizeof(Packed), &Packed))) {
+        const uint16_t Major = static_cast<uint16_t>((Packed >> 48) & 0xFFFF);
+        const uint16_t Minor = static_cast<uint16_t>((Packed >> 32) & 0xFFFF);
+        const uint16_t Build = static_cast<uint16_t>((Packed >> 16) & 0xFFFF);
+        const uint16_t Revision = static_cast<uint16_t>(Packed & 0xFFFF);
+        DriverVer = (llvm::Twine(Major) + "." + llvm::Twine(Minor) + "." +
+                     llvm::Twine(Build) + "." + llvm::Twine(Revision))
+                        .str();
+      }
+    }
+
     if (Config.EnableDebugLayer || Config.EnableValidationLayer)
       if (auto Err = configureInfoQueue(Device.Get()))
         return Err;
@@ -1094,7 +1112,7 @@ public:
     return std::make_unique<DXDevice>(
         Adapter, Device, std::move(*GraphicsQueueOrErr),
         std::move(*RTVHeapOrErr), std::move(*DSVHeapOrErr),
-        std::string(DescVec.data()));
+        std::string(DescVec.data()), std::move(DriverVer));
   }
 
   const Capabilities &getCapabilities() override {

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -976,6 +976,10 @@ public:
     const uint64_t DriverNameSz =
         strnlen(DriverProps.driverName, VK_MAX_DRIVER_NAME_SIZE);
     DriverName = std::string(DriverProps.driverName, DriverNameSz);
+
+    const uint64_t DriverInfoSz =
+        strnlen(DriverProps.driverInfo, VK_MAX_DRIVER_INFO_SIZE);
+    DriverVersion = std::string(DriverProps.driverInfo, DriverInfoSz);
 #if defined(__APPLE__) && defined(__aarch64__)
     // Apple silicon Macs may have multiple Vulkan drivers sharing one device
     // name. Include the driver name in the description to enable

--- a/tools/api-query/api-query.cpp
+++ b/tools/api-query/api-query.cpp
@@ -39,6 +39,7 @@ int main(int ArgC, char **ArgV) {
     outs() << "- API: " << D->getAPIName() << "\n";
     outs() << "  Description: " << D->getDescription() << "\n";
     outs() << "  Driver: " << D->getDriverName() << "\n";
+    outs() << "  Driver Version: " << D->getDriverVersion() << "\n";
     outs() << "  Features: \n";
     for (const auto &C : D->getCapabilities()) {
       outs() << "    ";

--- a/tools/api-query/api-query.cpp
+++ b/tools/api-query/api-query.cpp
@@ -39,7 +39,17 @@ int main(int ArgC, char **ArgV) {
     outs() << "- API: " << D->getAPIName() << "\n";
     outs() << "  Description: " << D->getDescription() << "\n";
     outs() << "  Driver: " << D->getDriverName() << "\n";
-    outs() << "  Driver Version: " << D->getDriverVersion() << "\n";
+    // Driver version strings can be vendor-specific freeform text that
+    // may contain ':' characters (e.g. Qualcomm's Vulkan driverInfo is
+    // "Driver Build: ..."). Emit as a double-quoted YAML scalar so
+    // lit.cfg.py's yaml.safe_load() can parse the output.
+    outs() << "  Driver Version: \"";
+    for (char C : D->getDriverVersion()) {
+      if (C == '"' || C == '\\')
+        outs() << '\\';
+      outs() << C;
+    }
+    outs() << "\"\n";
     outs() << "  Features: \n";
     for (const auto &C : D->getCapabilities()) {
       outs() << "    ";

--- a/tools/api-query/api-query.cpp
+++ b/tools/api-query/api-query.cpp
@@ -44,7 +44,7 @@ int main(int ArgC, char **ArgV) {
     // "Driver Build: ..."). Emit as a double-quoted YAML scalar so
     // lit.cfg.py's yaml.safe_load() can parse the output.
     outs() << "  Driver Version: \"";
-    for (char C : D->getDriverVersion()) {
+    for (const char C : D->getDriverVersion()) {
       if (C == '"' || C == '\\')
         outs() << '\\';
       outs() << C;


### PR DESCRIPTION
The "Dump GPU Info" step in CI runs `api-query` to log each adapter's API, description, and driver name. Logging the driver version would be useful too when triaging GPU/driver-specific failures, so we have a record of which driver build was in use when a test failed.

Changes:
- **`Device` base class:** Add `DriverVersion` member and `getDriverVersion()` getter.
- **D3D12:** Read `DXCoreAdapterProperty::DriverVersion` and decode the packed `LARGE_INTEGER` into `Major.Minor.Build.Revision`.
- **Vulkan:** Read `VkPhysicalDeviceDriverProperties::driverInfo` (vendor-specific human-readable build string, e.g. `"26.5.2 (AMD proprietary shader compiler)"`).
- **api-query:** Print a new `Driver Version:` line beneath `Driver:`.

Sample output:
```
- API: DirectX
  Description: AMD Radeon RX 6800
  Driver Version: 32.0.21043.10005
- API: Vulkan
  Description: AMD Radeon RX 6800
  Driver Version: 26.5.2 (AMD proprietary shader compiler)
```

> Note: the `Driver:` line is blank on D3D12 in the sample above — that's a pre-existing gap being addressed separately in #1206. This PR is independent.

---
Assisted by Copilot.