### PR TITLE
[Metal] Fix vertex buffer binding and tighten input layout checks

### DIFF
--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -734,6 +734,8 @@ public:
 
   void setVertexBuffer(uint32_t Slot, offloadtest::Buffer *VB, size_t Offset,
                        uint32_t Stride) override {
+    assert(Slot < D3D12_IA_VERTEX_INPUT_RESOURCE_SLOT_COUNT &&
+           "Vertex buffer slot exceeds D3D12 IA input resource slot count");
     if (VB) {
       auto &DXVB = llvm::cast<DXBuffer>(*VB);
       D3D12_VERTEX_BUFFER_VIEW VBView = {};

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -808,7 +808,6 @@ DXCommandBuffer::createRenderEncoder(
 
   DXTexture *DSTexture = nullptr;
   D3D12_CPU_DESCRIPTOR_HANDLE DSVHandle = {};
-  const D3D12_CPU_DESCRIPTOR_HANDLE *DSVPtr = nullptr;
   if (Desc.DepthStencil) {
     auto &DXDS = llvm::cast<DXTexture>(*Desc.DepthStencil);
     if (DXDS.DSVHandle.ptr == 0)
@@ -817,12 +816,12 @@ DXCommandBuffer::createRenderEncoder(
           "Depth-stencil texture was not created with DepthStencil usage.");
     DSTexture = &DXDS;
     DSVHandle = DXDS.DSVHandle;
-    DSVPtr = &DSVHandle;
   }
 
-  CmdList->OMSetRenderTargets(
-      static_cast<UINT>(RTVHandles.size()), RTVHandles.data(),
-      /*RTsSingleHandleToDescriptorRange=*/false, DSVPtr);
+  CmdList->OMSetRenderTargets(static_cast<UINT>(RTVHandles.size()),
+                              RTVHandles.data(),
+                              /*RTsSingleHandleToDescriptorRange=*/false,
+                              Desc.DepthStencil ? &DSVHandle : nullptr);
 
   for (size_t I = 0; I < PassDesc.ColorAttachments.size(); ++I) {
     if (PassDesc.ColorAttachments[I].Load != offloadtest::LoadAction::Clear)

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -736,6 +736,7 @@ public:
                        uint32_t Stride) override {
     assert(Slot < D3D12_IA_VERTEX_INPUT_RESOURCE_SLOT_COUNT &&
            "Vertex buffer slot exceeds D3D12 IA input resource slot count");
+    assert(Slot == 0 && "Pipeline input layout only describes slot 0");
     if (VB) {
       auto &DXVB = llvm::cast<DXBuffer>(*VB);
       D3D12_VERTEX_BUFFER_VIEW VBView = {};

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -658,6 +658,7 @@ public:
     assert(Slot <
                sizeof(IRRuntimeVertexBuffers) / sizeof(IRRuntimeVertexBuffer) &&
            "Vertex buffer slot exceeds Metal Shader Converter limit");
+    assert(Slot == 0 && "Pipeline vertex descriptor only describes slot 0");
     if (VB) {
       auto &MTLVB = llvm::cast<MTLBuffer>(*VB);
       RenderEnc->setVertexBuffer(MTLVB.Buf, Offset, BufIdx);

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -1628,14 +1628,10 @@ public:
             std::errc::invalid_argument,
             "Vertex shader has no vertex attributes.");
 
-      if (FnAttrs->count() != InputLayout.size())
-        return llvm::createStringError(
-            std::errc::invalid_argument,
-            "Mismatch between vertex shader attribute count and pipeline "
-            "vertex input count.");
-
       // Collect the attribute indices the shader expects so that we can map
-      // the specified attributes onto the correct indices.
+      // the specified attributes onto the correct indices. Only active
+      // attributes are exposed via stage_in; inactive entries are dropped by
+      // the optimizer and have no corresponding [[attribute(N)]] slot.
       llvm::StringMap<uint32_t> ShaderAttrIndices;
       for (uint32_t I = 0; I < FnAttrs->count(); ++I) {
         auto *A = static_cast<MTL::VertexAttribute *>(FnAttrs->object(I));
@@ -1646,6 +1642,12 @@ public:
                        << " at index " << A->attributeIndex() << "\n";
         }
       }
+
+      if (ShaderAttrIndices.size() != InputLayout.size())
+        return llvm::createStringError(
+            std::errc::invalid_argument,
+            "Mismatch between vertex shader active attribute count and "
+            "pipeline vertex input count.");
 
       MTL::VertexDescriptor *VtxDesc = MTL::VertexDescriptor::alloc()->init();
       auto VtxDescScope = llvm::scope_exit([&] { VtxDesc->release(); });

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -1661,13 +1661,21 @@ public:
         // We'll need to revisit this if we ever support indexed attributes.
         AttrName += "0";
 
+        auto It = ShaderAttrIndices.find(AttrName);
+        if (It == ShaderAttrIndices.end())
+          return llvm::createStringError(
+              std::errc::invalid_argument,
+              "Input layout element '%s' does not match any active vertex "
+              "shader attribute.",
+              AttrName.c_str());
+
         const uint32_t ElemSize = getFormatSizeInBytes(Elem.Fmt);
         MTL::VertexAttributeDescriptor *AttrDesc =
             MTL::VertexAttributeDescriptor::alloc()->init();
         AttrDesc->setBufferIndex(kIRVertexBufferBindPoint);
         AttrDesc->setOffset(Elem.OffsetInBytes);
         AttrDesc->setFormat(getMetalVertexFormat(Elem.Fmt));
-        VtxDesc->attributes()->setObject(AttrDesc, ShaderAttrIndices[AttrName]);
+        VtxDesc->attributes()->setObject(AttrDesc, It->getValue());
         AttrDesc->release();
         Stride = std::max(Stride, Elem.OffsetInBytes + ElemSize);
       }

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -701,11 +701,10 @@ public:
   }
 
   void endEncodingImpl() override {
-    if (RenderEnc) {
-      RenderEnc->popDebugGroup();
-      RenderEnc->endEncoding();
-      RenderEnc = nullptr;
-    }
+    assert(RenderEnc);
+    RenderEnc->popDebugGroup();
+    RenderEnc->endEncoding();
+    RenderEnc = nullptr;
   }
 };
 

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -650,11 +650,19 @@ public:
   void setVertexBuffer(uint32_t Slot, offloadtest::Buffer *VB, size_t Offset,
                        uint32_t /*Stride*/) override {
     // Stride is needed in DX12 at binding time, ignore parameter here.
+    // Metal Shader Converter reserves low buffer indices for its own tables;
+    // vertex buffers start at kIRVertexBufferBindPoint. See
+    // https://developer.apple.com/metal/shader-converter/ ("Metal vertex
+    // fetch").
+    const NS::UInteger BufIdx = kIRVertexBufferBindPoint + Slot;
+    assert(Slot <
+               sizeof(IRRuntimeVertexBuffers) / sizeof(IRRuntimeVertexBuffer) &&
+           "Vertex buffer slot exceeds Metal Shader Converter limit");
     if (VB) {
       auto &MTLVB = llvm::cast<MTLBuffer>(*VB);
-      RenderEnc->setVertexBuffer(MTLVB.Buf, Offset, Slot);
+      RenderEnc->setVertexBuffer(MTLVB.Buf, Offset, BufIdx);
     } else {
-      RenderEnc->setVertexBuffer(nullptr, 0, Slot);
+      RenderEnc->setVertexBuffer(nullptr, 0, BufIdx);
     }
   }
 
@@ -1656,7 +1664,7 @@ public:
         const uint32_t ElemSize = getFormatSizeInBytes(Elem.Fmt);
         MTL::VertexAttributeDescriptor *AttrDesc =
             MTL::VertexAttributeDescriptor::alloc()->init();
-        AttrDesc->setBufferIndex(0);
+        AttrDesc->setBufferIndex(kIRVertexBufferBindPoint);
         AttrDesc->setOffset(Elem.OffsetInBytes);
         AttrDesc->setFormat(getMetalVertexFormat(Elem.Fmt));
         VtxDesc->attributes()->setObject(AttrDesc, ShaderAttrIndices[AttrName]);
@@ -1669,7 +1677,7 @@ public:
       LDesc->setStride(Stride);
       LDesc->setStepRate(1);
       LDesc->setStepFunction(MTL::VertexStepFunctionPerVertex);
-      VtxDesc->layouts()->setObject(LDesc, 0);
+      VtxDesc->layouts()->setObject(LDesc, kIRVertexBufferBindPoint);
       LDesc->release();
 
       Desc->setVertexDescriptor(VtxDesc);

--- a/lib/API/Util.h
+++ b/lib/API/Util.h
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 //
 // Helper functions that are shared between the various backends, but which
-// should not be exposed to the uesr of the graphics layer.
+// should not be exposed to the user of the graphics layer.
 //
 //===----------------------------------------------------------------------===//
 

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -1909,7 +1909,6 @@ public:
     }
 
     VkAttachmentReference DepthReference = {};
-    bool HasDS = false;
     if (Desc.DepthStencil) {
       const auto &DS = *Desc.DepthStencil;
       VkAttachmentDescription AD = {};
@@ -1929,14 +1928,14 @@ public:
       DepthReference.layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
 
       Attachments.push_back(AD);
-      HasDS = true;
     }
 
     VkSubpassDescription Subpass = {};
     Subpass.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
     Subpass.colorAttachmentCount = static_cast<uint32_t>(ColorRefs.size());
     Subpass.pColorAttachments = ColorRefs.data();
-    Subpass.pDepthStencilAttachment = HasDS ? &DepthReference : nullptr;
+    Subpass.pDepthStencilAttachment =
+        Desc.DepthStencil ? &DepthReference : nullptr;
 
     VkRenderPassCreateInfo RPCI = {};
     RPCI.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -1894,7 +1894,8 @@ public:
       // optimal state.
       // If we are NOT loading (clearing or don't care), we are discarding the
       // original contents of the texture, and use an undefined layout. This
-      // allows us to use _any_ layout including unitialized textures.
+      // allows us to receive a texture in _any_ layout including uninitialized
+      // textures.
       AD.initialLayout = Color.Load == LoadAction::Load
                              ? VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL
                              : VK_IMAGE_LAYOUT_UNDEFINED;

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -877,6 +877,7 @@ public:
   void setVertexBuffer(uint32_t Slot, offloadtest::Buffer *VB, size_t Offset,
                        uint32_t /*Stride*/) override {
     // Stride is needed in DX12 at binding time, ignore parameter here.
+    assert(Slot == 0 && "Pipeline vertex input only describes binding 0");
     if (VB) {
       VkBuffer Handle = llvm::cast<VulkanBuffer>(*VB).Buffer;
       const VkDeviceSize VKOffset = Offset;


### PR DESCRIPTION
The Metal backend bound the vertex buffer at buffer index `0`, which collides with `kIRDescriptorHeapBindPoint` from Metal Shader Converter. When a descriptor heap is in use, `MTLDescriptorHeap::bind()` from #1061 first writes to slot 0 and the subsequent `setVertexBuffer(..., 0)` overwrites it, breaking dynamic resource indexing.

Apple's MSC sample binds the stage-in vertex buffer at `kIRVertexBufferBindPoint`; this PR moves the encoder binding and the vertex descriptor's attribute buffer index / layout slot to that constant.

While here, two related rough edges:

* `ShaderAttrIndices[AttrName]` used `StringMap::operator[]`, which silently inserts `0` on miss. A typo or shader/input-layout mismatch therefore mapped the offending element to MSL `[[attribute(0)]]`, clobbering whatever was placed there. Use `find()` and return a clear error.
* The "vertex shader attribute count vs. pipeline vertex input count" check compared `FnAttrs->count()` (which includes inactive attributes) to `InputLayout.size()`, while the rest of the code only tracks active attributes. Build the active-attribute map first, then compare its size.

Tested locally with `check-hlsl-mtl-graphics` (6/6 pass) and the broader `check-hlsl-mtl` suite (320 pass, 0 regressions).