### PR TITLE
Introduce `createBufferWithData` function for easy buffer creation.

### DIFF
--- a/include/API/Buffer.h
+++ b/include/API/Buffer.h
@@ -30,8 +30,7 @@ struct BufferCreateDesc {
   BufferUsage Usage;
 
   static BufferCreateDesc uploadBuffer() {
-    return BufferCreateDesc{.Location = MemoryLocation::CpuToGpu,
-                            .Usage = BufferUsage::Storage};
+    return BufferCreateDesc{MemoryLocation::CpuToGpu, BufferUsage::Storage};
   }
 };
 

--- a/include/API/Buffer.h
+++ b/include/API/Buffer.h
@@ -28,6 +28,13 @@ enum class BufferUsage {
 struct BufferCreateDesc {
   MemoryLocation Location;
   BufferUsage Usage;
+
+  static BufferCreateDesc uploadBuffer() {
+    BufferCreateDesc Result = {};
+    Result.Location = MemoryLocation::CpuToGpu;
+    Result.Usage = BufferUsage::Storage;
+    return Result;
+  }
 };
 
 class Buffer {

--- a/include/API/Buffer.h
+++ b/include/API/Buffer.h
@@ -30,10 +30,8 @@ struct BufferCreateDesc {
   BufferUsage Usage;
 
   static BufferCreateDesc uploadBuffer() {
-    BufferCreateDesc Result = {};
-    Result.Location = MemoryLocation::CpuToGpu;
-    Result.Usage = BufferUsage::Storage;
-    return Result;
+    return BufferCreateDesc{.Location = MemoryLocation::CpuToGpu,
+                            .Usage = BufferUsage::Storage};
   }
 };
 

--- a/include/API/Device.h
+++ b/include/API/Device.h
@@ -208,9 +208,11 @@ createRenderTargetFromCPUBuffer(Device &Dev, const CPUBuffer &Buf);
 llvm::Expected<std::unique_ptr<Texture>>
 createDefaultDepthStencilTarget(Device &Dev, uint32_t Width, uint32_t Height);
 
-// Creates a vertex buffer and uploads the given CPU-side vertex data into it.
-llvm::Expected<std::unique_ptr<Buffer>>
-createVertexBufferFromCPUBuffer(Device &Dev, const CPUBuffer &Buf);
+llvm::Expected<std::unique_ptr<offloadtest::Buffer>>
+createBufferWithData(Device &Dev, std::string Name,
+                     const BufferCreateDesc &Desc, const void *Data,
+                     size_t SizeInBytes, ComputeEncoder *Encoder,
+                     std::unique_ptr<offloadtest::Buffer> *OutUploadBuffer);
 
 } // namespace offloadtest
 

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -1640,11 +1640,17 @@ public:
     }
 
     if (P.isTraditionalRaster() && P.Bindings.VertexBufferPtr) {
-      auto VBOrErr = offloadtest::createVertexBufferFromCPUBuffer(
-          *this, *P.Bindings.VertexBufferPtr);
-      if (!VBOrErr)
-        return VBOrErr.takeError();
-      IS.VB = std::move(*VBOrErr);
+      const CPUBuffer *VBuffer = P.Bindings.VertexBufferPtr;
+
+      BufferCreateDesc BufDesc = {};
+      BufDesc.Location = MemoryLocation::CpuToGpu;
+      BufDesc.Usage = BufferUsage::VertexBuffer;
+      auto BufOrErr = createBufferWithData(*this, "VertexBuffer", BufDesc,
+                                           VBuffer->Data[0].get(),
+                                           VBuffer->size(), nullptr, nullptr);
+      if (!BufOrErr)
+        return BufOrErr.takeError();
+      IS.VB = std::move(*BufOrErr);
       llvm::outs() << "Vertex buffer created.\n";
     }
 

--- a/lib/API/Device.cpp
+++ b/lib/API/Device.cpp
@@ -122,7 +122,7 @@ offloadtest::createBufferWithData(
 
     // Create Upload buffer
     const BufferCreateDesc UploadDesc = BufferCreateDesc::uploadBuffer();
-    std::string UploadBufferName = Name + " (Upload Buffer)";
+    const std::string UploadBufferName = Name + " (Upload Buffer)";
     auto UploadBufferOrErr = createBufferWithData(
         Dev, UploadBufferName, UploadDesc, Data, SizeInBytes, nullptr, nullptr);
     if (!UploadBufferOrErr)
@@ -130,7 +130,9 @@ offloadtest::createBufferWithData(
     *OutUploadBuffer = std::move(*UploadBufferOrErr);
 
     // Copy Buffer to Buffer
-    Encoder->copyBufferToBuffer(**OutUploadBuffer, 0, *Buffer, 0, SizeInBytes);
+    if (auto Err = Encoder->copyBufferToBuffer(**OutUploadBuffer, 0, *Buffer, 0,
+                                               SizeInBytes))
+      return Err;
 
   } else {
     // Copy data over

--- a/lib/API/Device.cpp
+++ b/lib/API/Device.cpp
@@ -90,29 +90,6 @@ offloadtest::createRenderTargetFromCPUBuffer(Device &Dev,
   return Dev.createTexture("RenderTarget", Desc);
 }
 
-llvm::Expected<std::unique_ptr<Buffer>>
-offloadtest::createVertexBufferFromCPUBuffer(Device &Dev,
-                                             const CPUBuffer &Buf) {
-  BufferCreateDesc BufDesc = {};
-  BufDesc.Location = MemoryLocation::CpuToGpu;
-  BufDesc.Usage = BufferUsage::VertexBuffer;
-  auto BufOrErr = Dev.createBuffer("VertexBuffer", BufDesc, Buf.size());
-  if (!BufOrErr)
-    return BufOrErr.takeError();
-  auto VB = std::move(*BufOrErr);
-
-  // TODO: Currently uses a single CpuToGpu mapped buffer.
-  // On discrete GPUs consider using a staging buffer + copy to a GpuOnly vertex
-  // buffer for optimal GPU read performance.
-  auto PtrOrErr = VB->map();
-  if (!PtrOrErr)
-    return PtrOrErr.takeError();
-  memcpy(*PtrOrErr, Buf.Data[0].get(), Buf.size());
-  VB->unmap();
-
-  return VB;
-}
-
 llvm::Expected<std::unique_ptr<Texture>>
 offloadtest::createDefaultDepthStencilTarget(Device &Dev, uint32_t Width,
                                              uint32_t Height) {
@@ -126,4 +103,44 @@ offloadtest::createDefaultDepthStencilTarget(Device &Dev, uint32_t Width,
   Desc.OptimizedClearValue = ClearDepthStencil{1.0f, 0};
 
   return Dev.createTexture("DepthStencil", Desc);
+}
+
+llvm::Expected<std::unique_ptr<offloadtest::Buffer>>
+offloadtest::createBufferWithData(
+    Device &Dev, std::string Name, const BufferCreateDesc &Desc,
+    const void *Data, size_t SizeInBytes, ComputeEncoder *Encoder,
+    std::unique_ptr<offloadtest::Buffer> *OutUploadBuffer) {
+  auto BufferOrErr = Dev.createBuffer(Name, Desc, SizeInBytes);
+  if (!BufferOrErr)
+    return BufferOrErr.takeError();
+  auto Buffer = std::move(*BufferOrErr);
+
+  if (Desc.Location == MemoryLocation::GpuOnly) {
+    if (OutUploadBuffer == nullptr)
+      return llvm::createStringError(
+          "An upload buffer is required to create a GpuOnly buffer with data.");
+
+    // Create Upload buffer
+    const BufferCreateDesc UploadDesc = BufferCreateDesc::uploadBuffer();
+    std::string UploadBufferName = Name + " (Upload Buffer)";
+    auto UploadBufferOrErr = createBufferWithData(
+        Dev, UploadBufferName, UploadDesc, Data, SizeInBytes, nullptr, nullptr);
+    if (!UploadBufferOrErr)
+      return UploadBufferOrErr.takeError();
+    *OutUploadBuffer = std::move(*UploadBufferOrErr);
+
+    // Copy Buffer to Buffer
+    Encoder->copyBufferToBuffer(**OutUploadBuffer, 0, *Buffer, 0, SizeInBytes);
+
+  } else {
+    // Copy data over
+    auto MappedPtrOrErr = Buffer->map();
+    if (!MappedPtrOrErr)
+      return MappedPtrOrErr.takeError();
+    void *MappedPtr = *MappedPtrOrErr;
+    memcpy(MappedPtr, Data, SizeInBytes);
+    Buffer->unmap();
+  }
+
+  return Buffer;
 }

--- a/lib/API/Device.cpp
+++ b/lib/API/Device.cpp
@@ -105,6 +105,33 @@ offloadtest::createDefaultDepthStencilTarget(Device &Dev, uint32_t Width,
   return Dev.createTexture("DepthStencil", Desc);
 }
 
+// This is a separate function because recursion is not allowed in this code
+// base.
+static llvm::Expected<std::unique_ptr<offloadtest::Buffer>>
+createUploadBufferWithData(Device &Dev, std::string Name, const void *Data,
+                           size_t SizeInBytes) {
+
+  // Create Upload buffer
+  const BufferCreateDesc UploadDesc = BufferCreateDesc::uploadBuffer();
+  const std::string UploadBufferName = Name + " (Upload Buffer)";
+
+  auto UploadBufferOrErr =
+      Dev.createBuffer(UploadBufferName, UploadDesc, SizeInBytes);
+  if (!UploadBufferOrErr)
+    return UploadBufferOrErr.takeError();
+  auto UploadBuffer = std::move(*UploadBufferOrErr);
+
+  // Copy data over
+  auto MappedPtrOrErr = UploadBuffer->map();
+  if (!MappedPtrOrErr)
+    return MappedPtrOrErr.takeError();
+  void *MappedPtr = *MappedPtrOrErr;
+  memcpy(MappedPtr, Data, SizeInBytes);
+  UploadBuffer->unmap();
+
+  return std::move(UploadBuffer);
+}
+
 llvm::Expected<std::unique_ptr<offloadtest::Buffer>>
 offloadtest::createBufferWithData(
     Device &Dev, std::string Name, const BufferCreateDesc &Desc,
@@ -121,10 +148,8 @@ offloadtest::createBufferWithData(
           "An upload buffer is required to create a GpuOnly buffer with data.");
 
     // Create Upload buffer
-    const BufferCreateDesc UploadDesc = BufferCreateDesc::uploadBuffer();
-    const std::string UploadBufferName = Name + " (Upload Buffer)";
-    auto UploadBufferOrErr = createBufferWithData(
-        Dev, UploadBufferName, UploadDesc, Data, SizeInBytes, nullptr, nullptr);
+    auto UploadBufferOrErr =
+        createUploadBufferWithData(Dev, Name, Data, SizeInBytes);
     if (!UploadBufferOrErr)
       return UploadBufferOrErr.takeError();
     *OutUploadBuffer = std::move(*UploadBufferOrErr);

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -956,11 +956,17 @@ class MTLDevice : public offloadtest::Device {
     }
 
     if (P.isTraditionalRaster() && P.Bindings.VertexBufferPtr) {
-      auto VBOrErr = offloadtest::createVertexBufferFromCPUBuffer(
-          *this, *P.Bindings.VertexBufferPtr);
-      if (!VBOrErr)
-        return VBOrErr.takeError();
-      IS.VB = std::move(*VBOrErr);
+      const CPUBuffer *VBuffer = P.Bindings.VertexBufferPtr;
+
+      BufferCreateDesc BufDesc = {};
+      BufDesc.Location = MemoryLocation::CpuToGpu;
+      BufDesc.Usage = BufferUsage::VertexBuffer;
+      auto BufOrErr = createBufferWithData(*this, "VertexBuffer", BufDesc,
+                                           VBuffer->Data[0].get(),
+                                           VBuffer->size(), nullptr, nullptr);
+      if (!BufOrErr)
+        return BufOrErr.takeError();
+      IS.VB = std::move(*BufOrErr);
       llvm::outs() << "Vertex buffer created.\n";
     }
     return llvm::Error::success();

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -1934,11 +1934,17 @@ public:
     }
 
     if (P.isTraditionalRaster() && P.Bindings.VertexBufferPtr) {
-      auto VBOrErr = offloadtest::createVertexBufferFromCPUBuffer(
-          *this, *P.Bindings.VertexBufferPtr);
-      if (!VBOrErr)
-        return VBOrErr.takeError();
-      IS.VB = std::move(*VBOrErr);
+      const CPUBuffer *VBuffer = P.Bindings.VertexBufferPtr;
+
+      BufferCreateDesc BufDesc = {};
+      BufDesc.Location = MemoryLocation::CpuToGpu;
+      BufDesc.Usage = BufferUsage::VertexBuffer;
+      auto BufOrErr = createBufferWithData(*this, "VertexBuffer", BufDesc,
+                                           VBuffer->Data[0].get(),
+                                           VBuffer->size(), nullptr, nullptr);
+      if (!BufOrErr)
+        return BufOrErr.takeError();
+      IS.VB = std::move(*BufOrErr);
       llvm::outs() << "Vertex buffer created.\n";
     }
 


### PR DESCRIPTION
As a step towards making resource and descriptor creation the same across graphics APIs we need a function to handle creating buffers and uploading data. This includes optionally creating an upload buffer.

Right now, it's only used to create the vertex buffer and avoids the use of an upload buffer by placing the vertices in host visible memory.

In a future PR, all generic buffers should be created via this path, and the same for textures with similar functions. However, this is quite a bit of refactoring. Ideally, we do this in smaller steps so PRs are easier to review. On top of that, this work is fairly low priority.

Ideally at some point we do introduce lifetime tracking so that `createBufferWithData` becomes even easier to use since the caller won't have to care about keeping the upload buffer alive.