### PR TITLE
[Metal] Fix inverted SV_IsFrontFace and XFAIL SV_CullDistance

### DIFF
--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -678,6 +678,8 @@ public:
     if (MTLPSO.DepthStencilState)
       RenderEnc->setDepthStencilState(MTLPSO.DepthStencilState);
     RenderEnc->setCullMode(MTLPSO.CullMode);
+    // Match the DX/VK convention (CCW = front) hardcoded in those backends.
+    RenderEnc->setFrontFacingWinding(MTL::WindingCounterClockwise);
 
     // IRRuntimeDrawPrimitives also sets the DrawParams / DrawInfo argument
     // buffers that metal-irconverter consults for SV_VertexID and friends.

--- a/test/Feature/Semantics/CullDistance.test
+++ b/test/Feature/Semantics/CullDistance.test
@@ -86,6 +86,12 @@ DescriptorSets: []
 # Clang's HLSL frontend does not yet lower SV_CullDistance on either the
 # DXIL or SPIR-V path.
 # XFAIL: Clang
+# Metal Shading Language has no cull_distance attribute (only clip_distance,
+# per the MSL Specification at
+# https://developer.apple.com/metal/Metal-Shading-Language-Specification.pdf)
+# and Apple's metal-irconverter does not emulate SV_CullDistance via
+# clip_distance, so the culled primitive still rasterizes.
+# XFAIL: Metal
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T vs_6_0 -Fo %t-vertex.o %t/vertex.hlsl


### PR DESCRIPTION
## Summary

Two recently-added graphics-stage semantics tests have been failing on
`check-hlsl-mtl` since landing, even though they pass on DX12 and Vulkan.

- **`Feature/Semantics/GraphicsSystemValues.test`** — `SV_IsFrontFace`
  came out inverted: CCW triangles reported back-facing and CW reported
  front-facing. #1127 set `MTL::WindingCounterClockwise` alongside the
  cull-mode call so Metal matched DX (`FrontCounterClockwise=TRUE`) and
  Vulkan (`VK_FRONT_FACE_COUNTER_CLOCKWISE`); the #1169 RenderEncoder
  refactor moved the cull-mode call into `drawInstanced` but dropped the
  winding call, so Metal silently fell back to the default
  `WindingClockwise`. Restored.

- **`Feature/Semantics/CullDistance.test`** — MSL has no `cull_distance`
  attribute, and Apple's `metal-irconverter` does not emulate
  `SV_CullDistance` via `clip_distance`, so the all-negative primitive
  still rasterizes. Marked `XFAIL: Metal`.

Fixes #1212.

## Test plan
- [ ] `check-hlsl-mtl` on macOS reports `GraphicsSystemValues.test` PASS
- [ ] `check-hlsl-mtl` on macOS reports `CullDistance.test` XFAIL
- [ ] No regressions on `check-hlsl-clang-mtl`, `check-hlsl-d3d12`, `check-hlsl-vk`

🤖 Generated with [Claude Code](https://claude.com/claude-code)