### PR TITLE
Add YAML-driven acceleration structure definitions for .test files

### DIFF
--- a/include/API/Enums.h
+++ b/include/API/Enums.h
@@ -23,6 +23,7 @@ enum class ResourceKind {
   ConstantBuffer,
   Sampler,
   SampledTexture2D,
+  AccelerationStructure,
 };
 
 enum ShaderContainerType {

--- a/include/API/Resources.h
+++ b/include/API/Resources.h
@@ -25,6 +25,8 @@ enum class MemoryLocation {
   GpuToCpu,
 };
 
+enum class IndexFormat { Uint16, Uint32 };
+
 // TODO: Add Unorm types (e.g. R8Unorm, RGBA8Unorm) which can be sampled as
 // floats.
 // TODO: Add SRGB types (e.g. RGBA8Srgb) once needed.

--- a/include/Support/Pipeline.h
+++ b/include/Support/Pipeline.h
@@ -14,6 +14,7 @@
 #define OFFLOADTEST_SUPPORT_PIPELINE_H
 
 #include "API/Enums.h"
+#include "API/Resources.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Error.h"
@@ -80,6 +81,7 @@ static inline DescriptorKind getDescriptorKind(ResourceKind RK) {
   case ResourceKind::StructuredBuffer:
   case ResourceKind::ByteAddressBuffer:
   case ResourceKind::Texture2D:
+  case ResourceKind::AccelerationStructure:
     return DescriptorKind::SRV;
 
   case ResourceKind::RWStructuredBuffer:
@@ -221,6 +223,8 @@ struct Result {
   double Epsilon;
 };
 
+struct TLASDesc;
+
 struct Resource {
   ResourceKind Kind;
   std::string Name;
@@ -231,6 +235,11 @@ struct Resource {
   bool HasCounter;
   std::optional<uint32_t> TilesMapped;
   bool IsReserved = false;
+  TLASDesc *TLASPtr = nullptr;
+
+  bool isAccelerationStructure() const {
+    return Kind == ResourceKind::AccelerationStructure;
+  }
 
   bool isRaw() const {
     switch (Kind) {
@@ -240,6 +249,7 @@ struct Resource {
     case ResourceKind::RWTexture2D:
     case ResourceKind::Sampler:
     case ResourceKind::SampledTexture2D:
+    case ResourceKind::AccelerationStructure:
       return false;
     case ResourceKind::StructuredBuffer:
     case ResourceKind::RWStructuredBuffer:
@@ -265,6 +275,7 @@ struct Resource {
     case ResourceKind::Texture2D:
     case ResourceKind::RWTexture2D:
     case ResourceKind::SampledTexture2D:
+    case ResourceKind::AccelerationStructure:
       return false;
     }
     llvm_unreachable("All cases handled");
@@ -280,6 +291,7 @@ struct Resource {
     case ResourceKind::RWByteAddressBuffer:
     case ResourceKind::ConstantBuffer:
     case ResourceKind::Sampler:
+    case ResourceKind::AccelerationStructure:
       return false;
     case ResourceKind::Texture2D:
     case ResourceKind::RWTexture2D:
@@ -319,18 +331,22 @@ struct Resource {
   }
 
   uint32_t getElementSize() const {
-    assert(!isSampler() && "Samplers do not have element size");
+    assert(!isSampler() && !isAccelerationStructure() &&
+           "Samplers and AS do not have element size");
     // ByteAddressBuffers are treated as 4-byte elements to match their memory
     // format.
     return isByteAddressBuffer() ? 4 : BufferPtr->getElementSize();
   }
 
   uint32_t getArraySize() const {
-    return isSampler() ? 1 : BufferPtr->ArraySize;
+    if (isSampler() || isAccelerationStructure())
+      return 1;
+    return BufferPtr->ArraySize;
   }
 
   uint32_t size() const {
-    assert(!isSampler() && "Samplers do not have size");
+    assert(!isSampler() && !isAccelerationStructure() &&
+           "Samplers and AS do not have size");
     return BufferPtr->size();
   }
 
@@ -343,6 +359,7 @@ struct Resource {
     case ResourceKind::ConstantBuffer:
     case ResourceKind::Sampler:
     case ResourceKind::SampledTexture2D:
+    case ResourceKind::AccelerationStructure:
       return false;
     case ResourceKind::RWBuffer:
     case ResourceKind::RWStructuredBuffer:
@@ -465,6 +482,51 @@ struct DispatchParametersSet {
   std::optional<uint32_t> VertexCount;
 };
 
+struct TriangleGeometry {
+  std::string VertexBuffer;
+  CPUBuffer *VertexBufferPtr = nullptr;
+  Format VertexFormat = Format::RGB32Float;
+  uint32_t VertexStride = 12;
+  uint32_t VertexCount = 0;
+  std::string IndexBuffer;
+  CPUBuffer *IndexBufferPtr = nullptr;
+  IndexFormat IdxFormat = IndexFormat::Uint32;
+  uint32_t IndexCount = 0;
+  bool Opaque = true;
+};
+
+struct AABBGeometry {
+  std::string AABBBuffer;
+  CPUBuffer *AABBBufferPtr = nullptr;
+  uint32_t AABBCount = 0;
+  uint32_t AABBStride = 24;
+  bool Opaque = true;
+};
+
+struct BLASDesc {
+  std::string Name;
+  llvm::SmallVector<TriangleGeometry> Triangles;
+  llvm::SmallVector<AABBGeometry> AABBs;
+};
+
+struct InstanceDesc {
+  std::string BLAS;
+  int BLASIdx = -1;
+  float Transform[12] = {1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0};
+  uint32_t InstanceID = 0;
+  uint8_t InstanceMask = 0xFF;
+};
+
+struct TLASDesc {
+  std::string Name;
+  llvm::SmallVector<InstanceDesc> Instances;
+};
+
+struct AccelerationStructureDescs {
+  llvm::SmallVector<BLASDesc> BLAS;
+  llvm::SmallVector<TLASDesc> TLAS;
+};
+
 struct Pipeline {
   ShaderPipelineKind Kind;
   llvm::SmallVector<Shader> Shaders;
@@ -477,6 +539,7 @@ struct Pipeline {
   llvm::SmallVector<Result> Results;
   llvm::SmallVector<DescriptorSet> Sets;
   DispatchParametersSet DispatchParameters;
+  AccelerationStructureDescs AccelStructs;
 
   uint32_t getVertexCount() const {
     if (DispatchParameters.VertexCount)
@@ -517,6 +580,20 @@ struct Pipeline {
     return nullptr;
   }
 
+  BLASDesc *getBLAS(llvm::StringRef Name) {
+    for (auto &B : AccelStructs.BLAS)
+      if (Name == B.Name)
+        return &B;
+    return nullptr;
+  }
+
+  TLASDesc *getTLAS(llvm::StringRef Name) {
+    for (auto &T : AccelStructs.TLAS)
+      if (Name == T.Name)
+        return &T;
+    return nullptr;
+  }
+
   llvm::Error validatePipelineKind();
   llvm::Error validateDispatchParameters();
 
@@ -545,6 +622,11 @@ LLVM_YAML_IS_SEQUENCE_VECTOR(offloadtest::SpecializationConstant)
 LLVM_YAML_IS_SEQUENCE_VECTOR(offloadtest::PushConstantBlock)
 LLVM_YAML_IS_SEQUENCE_VECTOR(offloadtest::PushConstantValue)
 LLVM_YAML_IS_SEQUENCE_VECTOR(offloadtest::DispatchParametersSet)
+LLVM_YAML_IS_SEQUENCE_VECTOR(offloadtest::TriangleGeometry)
+LLVM_YAML_IS_SEQUENCE_VECTOR(offloadtest::AABBGeometry)
+LLVM_YAML_IS_SEQUENCE_VECTOR(offloadtest::BLASDesc)
+LLVM_YAML_IS_SEQUENCE_VECTOR(offloadtest::InstanceDesc)
+LLVM_YAML_IS_SEQUENCE_VECTOR(offloadtest::TLASDesc)
 
 namespace llvm {
 namespace yaml {
@@ -627,6 +709,30 @@ template <> struct MappingTraits<offloadtest::RuntimeSettings> {
 
 template <> struct MappingTraits<offloadtest::SpecializationConstant> {
   static void mapping(IO &I, offloadtest::SpecializationConstant &C);
+};
+
+template <> struct MappingTraits<offloadtest::TriangleGeometry> {
+  static void mapping(IO &I, offloadtest::TriangleGeometry &G);
+};
+
+template <> struct MappingTraits<offloadtest::AABBGeometry> {
+  static void mapping(IO &I, offloadtest::AABBGeometry &G);
+};
+
+template <> struct MappingTraits<offloadtest::BLASDesc> {
+  static void mapping(IO &I, offloadtest::BLASDesc &D);
+};
+
+template <> struct MappingTraits<offloadtest::InstanceDesc> {
+  static void mapping(IO &I, offloadtest::InstanceDesc &D);
+};
+
+template <> struct MappingTraits<offloadtest::TLASDesc> {
+  static void mapping(IO &I, offloadtest::TLASDesc &D);
+};
+
+template <> struct MappingTraits<offloadtest::AccelerationStructureDescs> {
+  static void mapping(IO &I, offloadtest::AccelerationStructureDescs &D);
 };
 
 template <> struct ScalarEnumerationTraits<offloadtest::Rule> {
@@ -730,6 +836,41 @@ template <> struct ScalarEnumerationTraits<offloadtest::ResourceKind> {
     ENUM_CASE(ConstantBuffer);
     ENUM_CASE(Sampler);
     ENUM_CASE(SampledTexture2D);
+    ENUM_CASE(AccelerationStructure);
+#undef ENUM_CASE
+  }
+};
+
+template <> struct ScalarEnumerationTraits<offloadtest::Format> {
+  static void enumeration(IO &I, offloadtest::Format &V) {
+#define ENUM_CASE(Val) I.enumCase(V, #Val, offloadtest::Format::Val)
+    ENUM_CASE(R16Sint);
+    ENUM_CASE(R16Uint);
+    ENUM_CASE(RG16Sint);
+    ENUM_CASE(RG16Uint);
+    ENUM_CASE(RGBA16Sint);
+    ENUM_CASE(RGBA16Uint);
+    ENUM_CASE(R32Sint);
+    ENUM_CASE(R32Uint);
+    ENUM_CASE(R32Float);
+    ENUM_CASE(RG32Sint);
+    ENUM_CASE(RG32Uint);
+    ENUM_CASE(RG32Float);
+    ENUM_CASE(RGB32Float);
+    ENUM_CASE(RGBA32Sint);
+    ENUM_CASE(RGBA32Uint);
+    ENUM_CASE(RGBA32Float);
+    ENUM_CASE(D32Float);
+    ENUM_CASE(D32FloatS8Uint);
+#undef ENUM_CASE
+  }
+};
+
+template <> struct ScalarEnumerationTraits<offloadtest::IndexFormat> {
+  static void enumeration(IO &I, offloadtest::IndexFormat &V) {
+#define ENUM_CASE(Val) I.enumCase(V, #Val, offloadtest::IndexFormat::Val)
+    ENUM_CASE(Uint16);
+    ENUM_CASE(Uint32);
 #undef ENUM_CASE
   }
 };

--- a/lib/API/DX/DXFeatures.cpp
+++ b/lib/API/DX/DXFeatures.cpp
@@ -43,6 +43,15 @@ static ArrayRef<EnumEntry<MeshShaderTier>> getMeshShaderTiers() {
   return ArrayRef(MeshShaderTierNames);
 }
 
+#define RAYTRACING_TIER_ENUM(NewCase, Str, Value) {#Str, NewCase},
+static const EnumEntry<directx::RaytracingTier> RaytracingTierNames[]{
+#include "DXFeatures.def"
+};
+
+static ArrayRef<EnumEntry<RaytracingTier>> getRaytracingTiers() {
+  return ArrayRef(RaytracingTierNames);
+}
+
 template <typename T>
 static std::string enumEntryToString(ArrayRef<EnumEntry<T>> EnumValues,
                                      T Value) {
@@ -65,4 +74,9 @@ std::string CapabilityPrinter<directx::RootSignature>::toString(
 std::string CapabilityPrinter<directx::MeshShaderTier>::toString(
     const directx::MeshShaderTier &V) {
   return enumEntryToString(getMeshShaderTiers(), V);
+}
+
+std::string CapabilityPrinter<directx::RaytracingTier>::toString(
+    const directx::RaytracingTier &V) {
+  return enumEntryToString(getRaytracingTiers(), V);
 }

--- a/lib/API/DX/DXFeatures.def
+++ b/lib/API/DX/DXFeatures.def
@@ -28,10 +28,19 @@ MESH_SHADER_TIER_ENUM(MeshShaderTier1, Tier1,10)
 #undef MESH_SHADER_TIER_ENUM
 #endif
 
+#ifdef RAYTRACING_TIER_ENUM
+RAYTRACING_TIER_ENUM(RT_NotSupported, NotSupported, 0)
+RAYTRACING_TIER_ENUM(RT_1_0, 1.0, 10)
+RAYTRACING_TIER_ENUM(RT_1_1, 1.1, 11)
+RAYTRACING_TIER_ENUM(RT_1_2, 1.2, 12)
+#undef RAYTRACING_TIER_ENUM
+#endif
+
 #ifdef D3D_FEATURE_ENUM
 D3D_FEATURE_ENUM(directx::ShaderModel, HighestShaderModel)
 D3D_FEATURE_ENUM(directx::RootSignature, HighestRootSignatureVersion)
 D3D_FEATURE_ENUM(directx::MeshShaderTier, MeshShaderTier)
+D3D_FEATURE_ENUM(directx::RaytracingTier, RaytracingTier)
 #undef D3D_FEATURE_ENUM
 #endif
 

--- a/lib/API/DX/DXFeatures.h
+++ b/lib/API/DX/DXFeatures.h
@@ -37,6 +37,11 @@ enum MeshShaderTier {
 #include "DXFeatures.def"
 };
 
+#define RAYTRACING_TIER_ENUM(NewCase, Str, Value) NewCase = Value,
+enum RaytracingTier {
+#include "DXFeatures.def"
+};
+
 } // namespace directx
 
 template <> struct CapabilityPrinter<directx::ShaderModel> {
@@ -49,6 +54,10 @@ template <> struct CapabilityPrinter<directx::RootSignature> {
 
 template <> struct CapabilityPrinter<directx::MeshShaderTier> {
   static std::string toString(const directx::MeshShaderTier &V);
+};
+
+template <> struct CapabilityPrinter<directx::RaytracingTier> {
+  static std::string toString(const directx::RaytracingTier &V);
 };
 
 } // namespace offloadtest

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -64,6 +64,7 @@ using ID3D12GraphicsCommandListX = ID3D12GraphicsCommandList6;
 template <> char CapabilityValueEnum<directx::ShaderModel>::ID = 0;
 template <> char CapabilityValueEnum<directx::RootSignature>::ID = 0;
 template <> char CapabilityValueEnum<directx::MeshShaderTier>::ID = 0;
+template <> char CapabilityValueEnum<directx::RaytracingTier>::ID = 0;
 
 static std::mutex SignalHandlerMutex;
 static llvm::SmallVector<ID3D12DeviceX *> SignalHandlerDevices;
@@ -222,6 +223,7 @@ static D3D12_RESOURCE_DIMENSION getDXDimension(ResourceKind RK) {
   case ResourceKind::RWBuffer:
   case ResourceKind::RWByteAddressBuffer:
   case ResourceKind::ConstantBuffer:
+  case ResourceKind::AccelerationStructure:
     return D3D12_RESOURCE_DIMENSION_BUFFER;
   case ResourceKind::Texture2D:
   case ResourceKind::RWTexture2D:
@@ -303,6 +305,8 @@ static D3D12_SHADER_RESOURCE_VIEW_DESC getSRVDescription(const Resource &R) {
     llvm_unreachable("Not an SRV type!");
   case ResourceKind::SampledTexture2D:
     llvm_unreachable("Sampled textures aren't supported in DirectX!");
+  case ResourceKind::AccelerationStructure:
+    llvm_unreachable("Acceleration structures use a separate descriptor path!");
   }
   return Desc;
 }
@@ -342,6 +346,8 @@ static D3D12_UNORDERED_ACCESS_VIEW_DESC getUAVDescription(const Resource &R) {
     llvm_unreachable("Not a UAV type!");
   case ResourceKind::SampledTexture2D:
     llvm_unreachable("Sampled textures aren't supported in DirectX!");
+  case ResourceKind::AccelerationStructure:
+    llvm_unreachable("Acceleration structures use a separate descriptor path!");
   }
   return Desc;
 }

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -1102,6 +1102,8 @@ class MTLDevice : public offloadtest::Device {
       case ResourceKind::RWByteAddressBuffer:
       case ResourceKind::ConstantBuffer:
         llvm_unreachable("Raw is checked above");
+      case ResourceKind::AccelerationStructure:
+        llvm_unreachable("Acceleration structures use a separate path!");
       }
 
       MTL::Texture *NewTex = Device->newTexture(Desc);
@@ -2091,6 +2093,10 @@ private:
         Device->supportsFamily(MTL::GPUFamilyMetal3);
     Caps.insert(std::make_pair(
         "MeshShader", makeCapability<bool>("MeshShader", MeshShaderSupported)));
+    Caps.insert(
+        std::make_pair("supportsRaytracing",
+                       makeCapability<bool>("supportsRaytracing",
+                                            Device->supportsRaytracing())));
   }
 };
 } // namespace

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -95,6 +95,8 @@ static VkDescriptorType getDescriptorType(const ResourceKind RK) {
     return VK_DESCRIPTOR_TYPE_SAMPLER;
   case ResourceKind::SampledTexture2D:
     return VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+  case ResourceKind::AccelerationStructure:
+    return VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR;
   }
   llvm_unreachable("All cases handled");
 }
@@ -164,7 +166,9 @@ static VkBufferUsageFlagBits getFlagBits(const ResourceKind RK) {
   case ResourceKind::RWTexture2D:
   case ResourceKind::Sampler:
   case ResourceKind::SampledTexture2D:
-    llvm_unreachable("Textures and samplers don't have buffer usage bits!");
+  case ResourceKind::AccelerationStructure:
+    llvm_unreachable(
+        "Textures, samplers, and AS don't have buffer usage bits!");
   }
   llvm_unreachable("All cases handled");
 }
@@ -183,6 +187,7 @@ static VkImageViewType getImageViewType(const ResourceKind RK) {
   case ResourceKind::RWStructuredBuffer:
   case ResourceKind::ConstantBuffer:
   case ResourceKind::Sampler:
+  case ResourceKind::AccelerationStructure:
     llvm_unreachable("Not an image view!");
   }
   llvm_unreachable("All cases handled");

--- a/lib/Support/Pipeline.cpp
+++ b/lib/Support/Pipeline.cpp
@@ -65,6 +65,7 @@ void MappingTraits<offloadtest::Pipeline>::mapping(IO &I,
   I.mapRequired("DescriptorSets", P.Sets);
   I.mapOptional("Bindings", P.Bindings);
   I.mapOptional("PushConstants", P.PushConstants);
+  I.mapOptional("AccelerationStructures", P.AccelStructs);
 
   // Runs here (not right after Shaders) because the tessellation topology
   // check reads Bindings.Topology and Bindings.PatchControlPoints. Must
@@ -79,7 +80,11 @@ void MappingTraits<offloadtest::Pipeline>::mapping(IO &I,
   if (!I.outputting()) {
     for (auto &D : P.Sets) {
       for (auto &R : D.Resources) {
-        if (R.isSampledTexture()) {
+        if (R.isAccelerationStructure()) {
+          R.TLASPtr = P.getTLAS(R.Name);
+          if (!R.TLASPtr)
+            I.setError(Twine("Referenced TLAS ") + R.Name + " not found!");
+        } else if (R.isSampledTexture()) {
           R.SamplerPtr = P.getSampler(R.Name);
           if (!R.SamplerPtr)
             I.setError(Twine("Referenced sampler ") + R.Name + " not found!");
@@ -158,6 +163,45 @@ void MappingTraits<offloadtest::Pipeline>::mapping(IO &I,
       if (!P.Bindings.RTargetBufferPtr)
         I.setError(Twine("Referenced render target buffer ") +
                    P.Bindings.RenderTarget + " not found!");
+    }
+
+    // Resolve buffer name references in acceleration structure descriptions.
+    for (auto &B : P.AccelStructs.BLAS) {
+      for (auto &T : B.Triangles) {
+        T.VertexBufferPtr = P.getBuffer(T.VertexBuffer);
+        if (!T.VertexBufferPtr)
+          I.setError(Twine("BLAS '") + B.Name +
+                     "': referenced vertex buffer '" + T.VertexBuffer +
+                     "' not found!");
+        if (!T.IndexBuffer.empty()) {
+          T.IndexBufferPtr = P.getBuffer(T.IndexBuffer);
+          if (!T.IndexBufferPtr)
+            I.setError(Twine("BLAS '") + B.Name +
+                       "': referenced index buffer '" + T.IndexBuffer +
+                       "' not found!");
+        }
+      }
+      for (auto &A : B.AABBs) {
+        A.AABBBufferPtr = P.getBuffer(A.AABBBuffer);
+        if (!A.AABBBufferPtr)
+          I.setError(Twine("BLAS '") + B.Name + "': referenced AABB buffer '" +
+                     A.AABBBuffer + "' not found!");
+      }
+    }
+
+    // Resolve BLAS name references in TLAS instance descriptions.
+    for (auto &T : P.AccelStructs.TLAS) {
+      for (auto &Inst : T.Instances) {
+        for (int Idx = 0, E = P.AccelStructs.BLAS.size(); Idx < E; ++Idx) {
+          if (P.AccelStructs.BLAS[Idx].Name == Inst.BLAS) {
+            Inst.BLASIdx = Idx;
+            break;
+          }
+        }
+        if (Inst.BLASIdx < 0)
+          I.setError(Twine("TLAS '") + T.Name + "': referenced BLAS '" +
+                     Inst.BLAS + "' not found!");
+      }
     }
   }
 }
@@ -578,6 +622,64 @@ void MappingTraits<offloadtest::SpecializationConstant>::mapping(
   I.mapRequired("ConstantID", C.ConstantID);
   I.mapRequired("Type", C.Type);
   I.mapRequired("Value", C.Value);
+}
+
+void MappingTraits<offloadtest::TriangleGeometry>::mapping(
+    IO &I, offloadtest::TriangleGeometry &G) {
+  I.mapRequired("VertexBuffer", G.VertexBuffer);
+  I.mapOptional("VertexFormat", G.VertexFormat, Format::RGB32Float);
+  I.mapOptional("VertexStride", G.VertexStride, 12u);
+  I.mapRequired("VertexCount", G.VertexCount);
+  I.mapOptional("IndexBuffer", G.IndexBuffer, std::string());
+  I.mapOptional("IndexFormat", G.IdxFormat, IndexFormat::Uint32);
+  I.mapOptional("IndexCount", G.IndexCount, 0u);
+  I.mapOptional("Opaque", G.Opaque, true);
+}
+
+void MappingTraits<offloadtest::AABBGeometry>::mapping(
+    IO &I, offloadtest::AABBGeometry &G) {
+  I.mapRequired("AABBBuffer", G.AABBBuffer);
+  I.mapRequired("AABBCount", G.AABBCount);
+  I.mapOptional("AABBStride", G.AABBStride, 24u);
+  I.mapOptional("Opaque", G.Opaque, true);
+}
+
+void MappingTraits<offloadtest::BLASDesc>::mapping(IO &I,
+                                                   offloadtest::BLASDesc &D) {
+  I.mapRequired("Name", D.Name);
+  I.mapOptional("Triangles", D.Triangles);
+  I.mapOptional("AABBs", D.AABBs);
+}
+
+void MappingTraits<offloadtest::InstanceDesc>::mapping(
+    IO &I, offloadtest::InstanceDesc &D) {
+  I.mapRequired("BLAS", D.BLAS);
+  llvm::SmallVector<float> Transform(std::begin(D.Transform),
+                                     std::end(D.Transform));
+  I.mapOptional("Transform", Transform);
+  if (Transform.size() != std::size(D.Transform)) {
+    I.setError(llvm::Twine("InstanceDesc.Transform must have exactly ") +
+               llvm::Twine(std::size(D.Transform)) +
+               " floats (3x4 row-major), got " + llvm::Twine(Transform.size()));
+    return;
+  }
+  std::copy(Transform.begin(), Transform.end(), std::begin(D.Transform));
+  I.mapOptional("InstanceID", D.InstanceID, 0u);
+  uint32_t Mask = D.InstanceMask;
+  I.mapOptional("InstanceMask", Mask, 255u);
+  D.InstanceMask = static_cast<uint8_t>(Mask);
+}
+
+void MappingTraits<offloadtest::TLASDesc>::mapping(IO &I,
+                                                   offloadtest::TLASDesc &D) {
+  I.mapRequired("Name", D.Name);
+  I.mapRequired("Instances", D.Instances);
+}
+
+void MappingTraits<offloadtest::AccelerationStructureDescs>::mapping(
+    IO &I, offloadtest::AccelerationStructureDescs &D) {
+  I.mapOptional("BLAS", D.BLAS);
+  I.mapOptional("TLAS", D.TLAS);
 }
 
 } // namespace yaml

--- a/test/Feature/InlineRT/indexed-triangle-setup.test
+++ b/test/Feature/InlineRT/indexed-triangle-setup.test
@@ -1,0 +1,84 @@
+#--- source.hlsl
+
+RaytracingAccelerationStructure Scene : register(t0);
+RWStructuredBuffer<uint> Output : register(u0);
+
+[numthreads(1,1,1)]
+void main() {
+  // Placeholder: will use TraceRayInline when available
+  Output[0] = 1;
+}
+//--- pipeline.yaml
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+Buffers:
+  # Vertex 0 sits far above the ray's plane (z=10) so the triangle formed by
+  # the first three vertices misses the ray entirely. Only the index buffer
+  # selects the at-z=0 triangle (v1, v2, v3) that the ray actually hits — if a
+  # backend silently consumed VertexBuffer[0..2] instead of going through the
+  # index buffer, RayQuery would return no hit and the test would fail.
+  - Name: Vertices
+    Format: Float32
+    Stride: 12
+    Data: [ 0.0, 0.0, 10.0, 0.0, 1.0, 0.0, -1.0, -1.0, 0.0, 1.0, -1.0, 0.0 ]
+  - Name: Indices
+    Format: UInt32
+    Data: [ 1, 2, 3 ]
+  - Name: Output
+    Format: UInt32
+    Stride: 4
+    FillSize: 4
+  - Name: Expected
+    Format: UInt32
+    Stride: 4
+    Data: [ 1 ]
+AccelerationStructures:
+  BLAS:
+    - Name: IndexedBLAS
+      Triangles:
+        - VertexBuffer: Vertices
+          VertexFormat: RGB32Float
+          VertexStride: 12
+          VertexCount: 4
+          IndexBuffer: Indices
+          IndexFormat: Uint32
+          IndexCount: 3
+  TLAS:
+    - Name: Scene
+      Instances:
+        - BLAS: IndexedBLAS
+DescriptorSets:
+  - Resources:
+    - Name: Scene
+      Kind: AccelerationStructure
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: Output
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+Results:
+  - Result: IndexedTriangleSetup
+    Rule: BufferExact
+    Actual: Output
+    Expected: Expected
+...
+#--- end
+
+# REQUIRES: acceleration-structure
+# XFAIL: Clang
+
+# Unimplemented: https://github.com/llvm/offload-test-suite/issues/1158
+# XFAIL: *
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/InlineRT/multi-instance.test
+++ b/test/Feature/InlineRT/multi-instance.test
@@ -1,0 +1,81 @@
+#--- source.hlsl
+
+RaytracingAccelerationStructure Scene : register(t0);
+RWStructuredBuffer<uint> Output : register(u0);
+
+[numthreads(1,1,1)]
+void main() {
+  // Placeholder: will use TraceRayInline when available
+  Output[0] = 1;
+}
+//--- pipeline.yaml
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+Buffers:
+  - Name: Vertices
+    Format: Float32
+    Stride: 12
+    Data: [ 0.0, 1.0, 0.0, -1.0, -1.0, 0.0, 1.0, -1.0, 0.0 ]
+  - Name: Output
+    Format: UInt32
+    Stride: 4
+    FillSize: 4
+  - Name: Expected
+    Format: UInt32
+    Stride: 4
+    Data: [ 1 ]
+AccelerationStructures:
+  BLAS:
+    - Name: TriangleBLAS
+      Triangles:
+        - VertexBuffer: Vertices
+          VertexFormat: RGB32Float
+          VertexStride: 12
+          VertexCount: 3
+  TLAS:
+    - Name: Scene
+      Instances:
+        - BLAS: TriangleBLAS
+          InstanceID: 0
+          Transform: [1, 0, 0, 0,  0, 1, 0, 0,  0, 0, 1, 0]
+        - BLAS: TriangleBLAS
+          InstanceID: 1
+          Transform: [1, 0, 0, 5,  0, 1, 0, 0,  0, 0, 1, 0]
+        - BLAS: TriangleBLAS
+          InstanceID: 2
+          Transform: [1, 0, 0, -5,  0, 1, 0, 0,  0, 0, 1, 0]
+DescriptorSets:
+  - Resources:
+    - Name: Scene
+      Kind: AccelerationStructure
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: Output
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+Results:
+  - Result: MultiInstanceSetup
+    Rule: BufferExact
+    Actual: Output
+    Expected: Expected
+...
+#--- end
+
+# REQUIRES: acceleration-structure
+# XFAIL: Clang
+
+# Unimplemented: https://github.com/llvm/offload-test-suite/issues/1158
+# XFAIL: *
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/InlineRT/triangle-setup.test
+++ b/test/Feature/InlineRT/triangle-setup.test
@@ -1,0 +1,73 @@
+#--- source.hlsl
+
+RaytracingAccelerationStructure Scene : register(t0);
+RWStructuredBuffer<uint> Output : register(u0);
+
+[numthreads(1,1,1)]
+void main() {
+  // Placeholder: will use TraceRayInline when available
+  Output[0] = 1;
+}
+//--- pipeline.yaml
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+Buffers:
+  - Name: Vertices
+    Format: Float32
+    Stride: 12
+    Data: [ 0.0, 1.0, 0.0, -1.0, -1.0, 0.0, 1.0, -1.0, 0.0 ]
+  - Name: Output
+    Format: UInt32
+    Stride: 4
+    FillSize: 4
+  - Name: Expected
+    Format: UInt32
+    Stride: 4
+    Data: [ 1 ]
+AccelerationStructures:
+  BLAS:
+    - Name: TriangleBLAS
+      Triangles:
+        - VertexBuffer: Vertices
+          VertexFormat: RGB32Float
+          VertexStride: 12
+          VertexCount: 3
+  TLAS:
+    - Name: Scene
+      Instances:
+        - BLAS: TriangleBLAS
+DescriptorSets:
+  - Resources:
+    - Name: Scene
+      Kind: AccelerationStructure
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: Output
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+Results:
+  - Result: TriangleSetup
+    Rule: BufferExact
+    Actual: Output
+    Expected: Expected
+...
+#--- end
+
+# REQUIRES: acceleration-structure
+# XFAIL: Clang
+
+# Unimplemented: https://github.com/llvm/offload-test-suite/issues/1158
+# XFAIL: *
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -176,6 +176,8 @@ def setDeviceFeatures(config, device, compiler):
         if device["Features"].get("MeshShaderTier", "NotSupported") != "NotSupported":
             config.available_features.add("MeshShader")
         setWaveSizeFeaturesDirectX(config, device)
+        if device["Features"].get("RaytracingTier", "NotSupported") != "NotSupported":
+            config.available_features.add("acceleration-structure")
 
     if device["API"] == "Metal":
         config.available_features.add("Int16")
@@ -183,6 +185,8 @@ def setDeviceFeatures(config, device, compiler):
         config.available_features.add("Half")
         if device["Features"].get("MeshShader", False):
             config.available_features.add("MeshShader")
+        if device["Features"].get("supportsRaytracing", False):
+            config.available_features.add("acceleration-structure")
 
     if device["API"] == "Vulkan":
         if device["Features"].get("shaderInt16", False):
@@ -205,6 +209,9 @@ def setDeviceFeatures(config, device, compiler):
             config.available_features.add(Extension["ExtensionName"])
             if Extension["ExtensionName"] == "VK_EXT_mesh_shader":
                 config.available_features.add("MeshShader")
+
+        if "VK_KHR_acceleration_structure" in config.available_features:
+            config.available_features.add("acceleration-structure")
 
 
 offloader_args = []


### PR DESCRIPTION
For https://github.com/llvm/offload-test-suite/issues/1158

## Summary
- Add `AccelerationStructure` to `ResourceKind` and introduce pipeline structs (`TriangleGeometry`, `AABBGeometry`, `BLASDesc`, `InstanceDesc`, `TLASDesc`) in `include/Support/Pipeline.h` with YAML parsing and name-based resolution for buffer/BLAS/TLAS references in `lib/Support/Pipeline.cpp`.
- Add a DX `RaytracingTier` capability enum (`NotSupported`/`1.0`/`1.1`) wired through `DXFeatures.def`/`.h`/`.cpp` so the DX device can report a raytracing tier.
- Surface an `acceleration-structure` lit feature in `test/lit.cfg.py`, derived per-backend from DX `RaytracingTier != NotSupported`, Metal `supportsRaytracing`, and Vulkan `VK_KHR_acceleration_structure`.
- Add `AccelerationStructure` cases to the resource-kind switch statements in the DX, Metal, and Vulkan device backends (no execution yet — just enum coverage).
- Add three placeholder InlineRT test files (`triangle-setup`, `indexed-triangle-setup`, `multi-instance`) exercising the new YAML format, gated behind `REQUIRES: acceleration-structure` and marked `XFAIL: *` because backend execution of acceleration structures is not implemented yet.

This PR only introduces the YAML surface area, parsing, and capability detection — the runtime side that actually builds/binds acceleration structures is intentionally out of scope and will follow.

## Test plan
- [x] `check-hlsl-offload` passes on DX, Metal, and Vulkan with the three new tests reported as `XFAIL` (or skipped where `acceleration-structure` isn't available).
- [x] Existing tests are unaffected on all three backends.