### PR TITLE
Pass-through geometry shader test

### DIFF
--- a/test/Graphics/gs_passthrough.test
+++ b/test/Graphics/gs_passthrough.test
@@ -1,0 +1,102 @@
+#--- vertex.hlsl
+struct VSOutput {
+  float4 position : SV_POSITION;
+};
+
+// Pass-through vertex shader. Real coverage decisions are made by the input
+// vertex data, not the shader.
+VSOutput main(float4 position : POSITION) {
+  VSOutput o;
+  o.position = position;
+  return o;
+}
+
+#--- geometry.hlsl
+struct GSInput {
+  float4 position : SV_POSITION;
+};
+
+struct GSOutput {
+  float4 position : SV_POSITION;
+};
+
+// Identity geometry shader: one triangle in, one triangle out, vertices
+// untouched. Exercises the GS pipeline path on the default TriangleList
+// topology without any expansion or topology change — if this test breaks
+// before gs_point_to_quad, the bug is in GS plumbing, not topology handling.
+[maxvertexcount(3)]
+void main(triangle GSInput input[3], inout TriangleStream<GSOutput> stream) {
+  GSOutput v;
+  v.position = input[0].position;
+  stream.Append(v);
+  v.position = input[1].position;
+  stream.Append(v);
+  v.position = input[2].position;
+  stream.Append(v);
+}
+
+#--- pixel.hlsl
+struct PSInput {
+  float4 position : SV_POSITION;
+};
+
+float4 main(PSInput input) : SV_TARGET {
+  return float4(1.0, 0.0, 0.0, 1.0);
+}
+
+#--- pipeline.yaml
+---
+Shaders:
+  - Stage: Vertex
+    Entry: main
+  - Stage: Geometry
+    Entry: main
+  - Stage: Pixel
+    Entry: main
+Buffers:
+  # One oversized triangle that covers the full 2x2 viewport in clip space.
+  - Name: VertexData
+    Format: Float32
+    Stride: 16 # 3 vertices, 16 bytes each
+    Data: [ -1.0, -1.0, 0.0, 1.0,
+             3.0, -1.0, 0.0, 1.0,
+            -1.0,  3.0, 0.0, 1.0 ]
+  - Name: Output
+    Format: Float32
+    Channels: 4
+    FillSize: 64 # 2x2 @ 16 bytes per pixel
+    OutputProps:
+      Height: 2
+      Width: 2
+      Depth: 1
+Bindings:
+  VertexBuffer: VertexData
+  VertexAttributes:
+    - Format: Float32
+      Channels: 4
+      Offset: 0
+      Name: POSITION
+  RenderTarget: Output
+DescriptorSets: []
+...
+#--- end
+
+# Metal has no native geometry shader stage (equivalents would require mesh or
+# tessellation shaders). Skip this test on that backend entirely.
+# UNSUPPORTED: Metal
+
+# Clang's HLSL frontend does not yet support geometry shader stream types
+# (e.g. TriangleStream<T>::Append), so compiling geometry.hlsl with clang-dxc
+# fails on both D3D12 and Vulkan code paths.
+# Tracked upstream: https://github.com/llvm/llvm-project/issues/136963
+# XFAIL: Clang
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T vs_6_0 -Fo %t-vertex.o %t/vertex.hlsl
+# RUN: %dxc_target -T gs_6_0 -Fo %t-geometry.o %t/geometry.hlsl
+# RUN: %dxc_target -T ps_6_0 -Fo %t-pixel.o %t/pixel.hlsl
+# RUN: %offloader %t/pipeline.yaml %t-vertex.o %t-geometry.o %t-pixel.o | FileCheck %s
+
+# All 4 pixels of the 2x2 render target must be opaque red.
+# CHECK: Name: Output
+# CHECK: Data: [ 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1 ]

--- a/test/Graphics/gs_passthrough.test
+++ b/test/Graphics/gs_passthrough.test
@@ -18,9 +18,6 @@ struct GSOutput {
   float4 position : SV_POSITION;
 };
 
-// Identity geometry shader: one triangle in, one triangle out, vertices
-// untouched. Exercises the GS pipeline path on the default TriangleList
-// topology without any expansion or topology change.
 [maxvertexcount(3)]
 void main(triangle GSInput input[3], inout TriangleStream<GSOutput> stream) {
   GSOutput v;

--- a/test/Graphics/gs_passthrough.test
+++ b/test/Graphics/gs_passthrough.test
@@ -3,8 +3,6 @@ struct VSOutput {
   float4 position : SV_POSITION;
 };
 
-// Pass-through vertex shader. Real coverage decisions are made by the input
-// vertex data, not the shader.
 VSOutput main(float4 position : POSITION) {
   VSOutput o;
   o.position = position;
@@ -22,8 +20,7 @@ struct GSOutput {
 
 // Identity geometry shader: one triangle in, one triangle out, vertices
 // untouched. Exercises the GS pipeline path on the default TriangleList
-// topology without any expansion or topology change — if this test breaks
-// before gs_point_to_quad, the bug is in GS plumbing, not topology handling.
+// topology without any expansion or topology change.
 [maxvertexcount(3)]
 void main(triangle GSInput input[3], inout TriangleStream<GSOutput> stream) {
   GSOutput v;
@@ -81,13 +78,10 @@ DescriptorSets: []
 ...
 #--- end
 
-# Metal has no native geometry shader stage (equivalents would require mesh or
-# tessellation shaders). Skip this test on that backend entirely.
+# Metal has no native geometry shader stage.
 # UNSUPPORTED: Metal
 
 # Clang's HLSL frontend does not yet support geometry shader stream types
-# (e.g. TriangleStream<T>::Append), so compiling geometry.hlsl with clang-dxc
-# fails on both D3D12 and Vulkan code paths.
 # Tracked upstream: https://github.com/llvm/llvm-project/issues/136963
 # XFAIL: Clang
 


### PR DESCRIPTION
Adds a passthrough geometry shader test that exercises the GS pipeline path without any vertex expansion or topology change. 
The GS takes a triangle in and emits the same triangle, vertices untouched. A single oversized triangle covers the 2×2 render target, and the pixel shader writes opaque red.