### PR TITLE
Add tessellation support to DX/VK backends with accompanying `SimpleTriangleTess.test`

### DIFF
--- a/include/API/Device.h
+++ b/include/API/Device.h
@@ -87,8 +87,13 @@ struct TraditionalRasterPipelineCreateDesc {
   llvm::SmallVector<Format> RTFormats;
   std::optional<Format> DSFormat;
   PrimitiveTopology Topology;
+  // Only meaningful when Topology == PatchList. Validated in Pipeline.cpp.
+  uint32_t PatchControlPoints = 0;
   ShaderContainer VS;
-  // TODO: Optional Hull & Domain Shaders
+  // Hull and Domain are independent optionals here; Pipeline.cpp enforces that
+  // they must be set as a pair (and only with PatchList topology).
+  std::optional<ShaderContainer> HS;
+  std::optional<ShaderContainer> DS;
   std::optional<ShaderContainer> GS;
   ShaderContainer PS;
 
@@ -96,6 +101,12 @@ struct TraditionalRasterPipelineCreateDesc {
     switch (Stage) {
     case Stages::Vertex:
       VS = std::move(SC);
+      break;
+    case Stages::Hull:
+      HS = std::move(SC);
+      break;
+    case Stages::Domain:
+      DS = std::move(SC);
       break;
     case Stages::Geometry:
       GS = std::move(SC);

--- a/include/API/Device.h
+++ b/include/API/Device.h
@@ -87,8 +87,10 @@ struct TraditionalRasterPipelineCreateDesc {
   llvm::SmallVector<Format> RTFormats;
   std::optional<Format> DSFormat;
   PrimitiveTopology Topology;
-  // Only meaningful when Topology == PatchList. Validated in Pipeline.cpp.
-  uint32_t PatchControlPoints = 0;
+  // Set if Topology == PatchList. Validated in
+  // Pipeline.cpp::validatePipelineKind.
+  std::optional<uint32_t> PatchControlPoints;
+
   ShaderContainer VS;
   // Hull and Domain are independent optionals here; Pipeline.cpp enforces that
   // they must be set as a pair (and only with PatchList topology).

--- a/include/API/Enums.h
+++ b/include/API/Enums.h
@@ -44,7 +44,7 @@ enum class StoreAction {
   DontCare, ///< Contents may be discarded after the pass.
 };
 
-enum class PrimitiveTopology { TriangleList, PointList };
+enum class PrimitiveTopology { TriangleList, PointList, PatchList };
 
 } // namespace offloadtest
 

--- a/include/Support/Pipeline.h
+++ b/include/Support/Pipeline.h
@@ -21,6 +21,7 @@
 #include "llvm/Support/YAMLTraits.h"
 #include <limits>
 #include <memory>
+#include <optional>
 #include <string>
 #include <variant>
 
@@ -42,9 +43,8 @@ enum class Stages {
   Mesh
 };
 inline constexpr std::array AllStages = {
-    Stages::Compute,       Stages::Vertex, Stages::Hull, Stages::Domain,
-    Stages::Geometry,      Stages::Pixel,  Stages::Amplification,
-    Stages::Mesh,
+    Stages::Compute,  Stages::Vertex, Stages::Hull,          Stages::Domain,
+    Stages::Geometry, Stages::Pixel,  Stages::Amplification, Stages::Mesh,
 };
 inline constexpr size_t NumStages = AllStages.size();
 
@@ -405,10 +405,11 @@ struct IOBindings {
   CPUBuffer *RTargetBufferPtr = nullptr;
   PrimitiveTopology Topology = PrimitiveTopology::TriangleList;
 
-  // Number of control points per patch. Required when Topology == PatchList.
-  // Valid range is 1..32 (matches both D3D12's per-CP-patchlist topologies and
-  // Vulkan's VkPipelineTessellationStateCreateInfo::patchControlPoints).
-  uint32_t PatchControlPoints = 0;
+  // Set if Topology == PatchList. Validated in
+  // Pipeline.cpp::validatePipelineKind. Valid range is 1..32 (matches both
+  // D3D12's per-CP-patchlist topologies and Vulkan's
+  // VkPipelineTessellationStateCreateInfo::patchControlPoints).
+  std::optional<uint32_t> PatchControlPoints;
 
   uint32_t getVertexStride() const {
     uint32_t Stride = 0;

--- a/include/Support/Pipeline.h
+++ b/include/Support/Pipeline.h
@@ -32,6 +32,8 @@ enum class Stages {
 
   // Traditional Raster
   Vertex,
+  Hull,
+  Domain,
   Geometry,
   Pixel,
 
@@ -40,8 +42,9 @@ enum class Stages {
   Mesh
 };
 inline constexpr std::array AllStages = {
-    Stages::Compute, Stages::Vertex,        Stages::Geometry,
-    Stages::Pixel,   Stages::Amplification, Stages::Mesh,
+    Stages::Compute,       Stages::Vertex, Stages::Hull, Stages::Domain,
+    Stages::Geometry,      Stages::Pixel,  Stages::Amplification,
+    Stages::Mesh,
 };
 inline constexpr size_t NumStages = AllStages.size();
 
@@ -402,6 +405,11 @@ struct IOBindings {
   CPUBuffer *RTargetBufferPtr = nullptr;
   PrimitiveTopology Topology = PrimitiveTopology::TriangleList;
 
+  // Number of control points per patch. Required when Topology == PatchList.
+  // Valid range is 1..32 (matches both D3D12's per-CP-patchlist topologies and
+  // Vulkan's VkPipelineTessellationStateCreateInfo::patchControlPoints).
+  uint32_t PatchControlPoints = 0;
+
   uint32_t getVertexStride() const {
     uint32_t Stride = 0;
     for (auto VA : VertexAttributes)
@@ -730,6 +738,8 @@ template <> struct ScalarEnumerationTraits<offloadtest::Stages> {
 #define ENUM_CASE(Val) I.enumCase(V, #Val, offloadtest::Stages::Val)
     ENUM_CASE(Compute);
     ENUM_CASE(Vertex);
+    ENUM_CASE(Hull);
+    ENUM_CASE(Domain);
     ENUM_CASE(Geometry);
     ENUM_CASE(Pixel);
     ENUM_CASE(Amplification);
@@ -743,6 +753,7 @@ template <> struct ScalarEnumerationTraits<offloadtest::PrimitiveTopology> {
 #define ENUM_CASE(Val) I.enumCase(V, #Val, offloadtest::PrimitiveTopology::Val)
     ENUM_CASE(TriangleList);
     ENUM_CASE(PointList);
+    ENUM_CASE(PatchList);
 #undef ENUM_CASE
   }
 };

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -164,17 +164,26 @@ getDXPrimitiveTopologyType(PrimitiveTopology Topology) {
     return D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
   case PrimitiveTopology::PointList:
     return D3D12_PRIMITIVE_TOPOLOGY_TYPE_POINT;
+  case PrimitiveTopology::PatchList:
+    return D3D12_PRIMITIVE_TOPOLOGY_TYPE_PATCH;
   }
   llvm_unreachable("All PrimitiveTopology cases handled");
 }
 
 static D3D_PRIMITIVE_TOPOLOGY
-getDXPrimitiveTopology(PrimitiveTopology Topology) {
+getDXPrimitiveTopology(PrimitiveTopology Topology,
+                       uint32_t PatchControlPoints) {
   switch (Topology) {
   case PrimitiveTopology::TriangleList:
     return D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST;
   case PrimitiveTopology::PointList:
     return D3D_PRIMITIVE_TOPOLOGY_POINTLIST;
+  case PrimitiveTopology::PatchList:
+    // _N_CONTROL_POINT_PATCHLIST enums are contiguous from 1..32.
+    assert(PatchControlPoints >= 1 && PatchControlPoints <= 32);
+    return static_cast<D3D_PRIMITIVE_TOPOLOGY>(
+        D3D_PRIMITIVE_TOPOLOGY_1_CONTROL_POINT_PATCHLIST +
+        (PatchControlPoints - 1));
   }
   llvm_unreachable("All PrimitiveTopology cases handled");
 }
@@ -1159,6 +1168,12 @@ public:
       return llvm::createStringError(std::errc::invalid_argument,
                                      "Graphics pipeline requires both a vertex "
                                      "shader and a pixel shader.");
+    if (Desc.HS)
+      PSODesc.HS = {Desc.HS->Shader->getBuffer().data(),
+                    Desc.HS->Shader->getBuffer().size()};
+    if (Desc.DS)
+      PSODesc.DS = {Desc.DS->Shader->getBuffer().data(),
+                    Desc.DS->Shader->getBuffer().size()};
     if (Desc.GS)
       PSODesc.GS = {Desc.GS->Shader->getBuffer().data(),
                     Desc.GS->Shader->getBuffer().size()};
@@ -1187,7 +1202,8 @@ public:
       return Err;
 
     return std::make_unique<DXPipelineState>(
-        Name, RootSig, PSO, getDXPrimitiveTopology(Desc.Topology));
+        Name, RootSig, PSO,
+        getDXPrimitiveTopology(Desc.Topology, Desc.PatchControlPoints));
   }
 
   llvm::Expected<std::unique_ptr<PipelineState>>
@@ -2489,6 +2505,7 @@ public:
 
         TraditionalRasterPipelineCreateDesc PipelineDesc = {};
         PipelineDesc.Topology = P.Bindings.Topology;
+        PipelineDesc.PatchControlPoints = P.Bindings.PatchControlPoints;
         PipelineDesc.DSFormat = Format::D32FloatS8Uint;
         for (auto &Shader : P.Shaders) {
           ShaderContainer SC = {};

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -172,7 +172,7 @@ getDXPrimitiveTopologyType(PrimitiveTopology Topology) {
 
 static D3D_PRIMITIVE_TOPOLOGY
 getDXPrimitiveTopology(PrimitiveTopology Topology,
-                       uint32_t PatchControlPoints) {
+                       std::optional<uint32_t> PatchControlPoints) {
   switch (Topology) {
   case PrimitiveTopology::TriangleList:
     return D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST;
@@ -180,10 +180,11 @@ getDXPrimitiveTopology(PrimitiveTopology Topology,
     return D3D_PRIMITIVE_TOPOLOGY_POINTLIST;
   case PrimitiveTopology::PatchList:
     // _N_CONTROL_POINT_PATCHLIST enums are contiguous from 1..32.
-    assert(PatchControlPoints >= 1 && PatchControlPoints <= 32);
+    assert(PatchControlPoints && *PatchControlPoints >= 1 &&
+           *PatchControlPoints <= 32);
     return static_cast<D3D_PRIMITIVE_TOPOLOGY>(
         D3D_PRIMITIVE_TOPOLOGY_1_CONTROL_POINT_PATCHLIST +
-        (PatchControlPoints - 1));
+        (*PatchControlPoints - 1));
   }
   llvm_unreachable("All PrimitiveTopology cases handled");
 }

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -133,6 +133,10 @@ static IRShaderStage getShaderStage(Stages Stage) {
     return IRShaderStageCompute;
   case Stages::Vertex:
     return IRShaderStageVertex;
+  case Stages::Hull:
+    llvm_unreachable("Hull shaders are not supported on Metal.");
+  case Stages::Domain:
+    llvm_unreachable("Domain shaders are not supported on Metal.");
   case Stages::Geometry:
     llvm_unreachable("Geometry shaders are not supported on Metal.");
   case Stages::Pixel:
@@ -1587,6 +1591,11 @@ public:
       return llvm::createStringError(
           std::errc::not_supported,
           "Geometry shaders are not supported on this backend.");
+    if (Desc.HS || Desc.DS)
+      return llvm::createStringError(
+          std::errc::not_supported,
+          "Hull/Domain (tessellation) shaders are not supported on this "
+          "backend.");
     if (Desc.Topology != PrimitiveTopology::TriangleList)
       return llvm::createStringError(
           std::errc::not_supported,

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -1684,11 +1684,10 @@ public:
     InputAssemblyCI.topology = getVkPrimitiveTopology(Desc.Topology);
 
     VkPipelineTessellationStateCreateInfo TessellationCI = {};
-    const bool HasTessellation = HS.has_value() && DS.has_value();
-    if (HasTessellation) {
+    if (Desc.PatchControlPoints) {
       TessellationCI.sType =
           VK_STRUCTURE_TYPE_PIPELINE_TESSELLATION_STATE_CREATE_INFO;
-      TessellationCI.patchControlPoints = Desc.PatchControlPoints;
+      TessellationCI.patchControlPoints = *Desc.PatchControlPoints;
     }
 
     VkPipelineViewportStateCreateInfo ViewportCI = {};
@@ -1741,7 +1740,8 @@ public:
     PipelineCI.pStages = ShaderStages.data();
     PipelineCI.pVertexInputState = &VertexInputCI;
     PipelineCI.pInputAssemblyState = &InputAssemblyCI;
-    PipelineCI.pTessellationState = HasTessellation ? &TessellationCI : nullptr;
+    PipelineCI.pTessellationState =
+        Desc.PatchControlPoints ? &TessellationCI : nullptr;
     PipelineCI.pViewportState = &ViewportCI;
     PipelineCI.pRasterizationState = &RastCI;
     PipelineCI.pMultisampleState = &MultisampleCI;

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -206,6 +206,10 @@ static VkShaderStageFlagBits getShaderStageFlag(Stages Stage) {
     return VK_SHADER_STAGE_COMPUTE_BIT;
   case Stages::Vertex:
     return VK_SHADER_STAGE_VERTEX_BIT;
+  case Stages::Hull:
+    return VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT;
+  case Stages::Domain:
+    return VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT;
   case Stages::Geometry:
     return VK_SHADER_STAGE_GEOMETRY_BIT;
   case Stages::Pixel:
@@ -224,6 +228,8 @@ static VkPrimitiveTopology getVkPrimitiveTopology(PrimitiveTopology Topology) {
     return VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
   case PrimitiveTopology::PointList:
     return VK_PRIMITIVE_TOPOLOGY_POINT_LIST;
+  case PrimitiveTopology::PatchList:
+    return VK_PRIMITIVE_TOPOLOGY_PATCH_LIST;
   }
   llvm_unreachable("All PrimitiveTopology cases handled");
 }
@@ -1461,6 +1467,8 @@ public:
       const TraditionalRasterPipelineCreateDesc &Desc) override {
     const ShaderContainer &VS = Desc.VS;
     const ShaderContainer &PS = Desc.PS;
+    const std::optional<ShaderContainer> &HS = Desc.HS;
+    const std::optional<ShaderContainer> &DS = Desc.DS;
     const std::optional<ShaderContainer> &GS = Desc.GS;
     const llvm::ArrayRef<InputLayoutDesc> InputLayout = Desc.InputLayout;
     const llvm::ArrayRef<Format> RTFormats = Desc.RTFormats;
@@ -1494,6 +1502,56 @@ public:
       ShaderStage.pName = VS.EntryPoint.c_str();
       ShaderStage.pSpecializationInfo =
           VS.SpecializationConstants.empty() ? nullptr : &VSSpecInfo;
+      ShaderStages.push_back(ShaderStage);
+    }
+
+    llvm::SmallVector<VkSpecializationMapEntry> HSSpecEntries;
+    llvm::SmallVector<char> HSSpecData;
+    VkSpecializationInfo HSSpecInfo = {};
+    if (HS) {
+      if (auto Err = parseSpecializationConstants(HS->SpecializationConstants,
+                                                  HSSpecEntries, HSSpecData,
+                                                  HSSpecInfo))
+        return Err;
+
+      auto HSModOrErr = createShaderModule(HS->Shader, "hull");
+      if (!HSModOrErr)
+        return HSModOrErr.takeError();
+
+      GraphicsFlags |= VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT;
+
+      VkPipelineShaderStageCreateInfo ShaderStage = {};
+      ShaderStage.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+      ShaderStage.stage = VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT;
+      ShaderStage.module = *HSModOrErr;
+      ShaderStage.pName = HS->EntryPoint.c_str();
+      ShaderStage.pSpecializationInfo =
+          HS->SpecializationConstants.empty() ? nullptr : &HSSpecInfo;
+      ShaderStages.push_back(ShaderStage);
+    }
+
+    llvm::SmallVector<VkSpecializationMapEntry> DSSpecEntries;
+    llvm::SmallVector<char> DSSpecData;
+    VkSpecializationInfo DSSpecInfo = {};
+    if (DS) {
+      if (auto Err = parseSpecializationConstants(DS->SpecializationConstants,
+                                                  DSSpecEntries, DSSpecData,
+                                                  DSSpecInfo))
+        return Err;
+
+      auto DSModOrErr = createShaderModule(DS->Shader, "domain");
+      if (!DSModOrErr)
+        return DSModOrErr.takeError();
+
+      GraphicsFlags |= VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT;
+
+      VkPipelineShaderStageCreateInfo ShaderStage = {};
+      ShaderStage.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+      ShaderStage.stage = VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT;
+      ShaderStage.module = *DSModOrErr;
+      ShaderStage.pName = DS->EntryPoint.c_str();
+      ShaderStage.pSpecializationInfo =
+          DS->SpecializationConstants.empty() ? nullptr : &DSSpecInfo;
       ShaderStages.push_back(ShaderStage);
     }
 
@@ -1625,6 +1683,14 @@ public:
         VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
     InputAssemblyCI.topology = getVkPrimitiveTopology(Desc.Topology);
 
+    VkPipelineTessellationStateCreateInfo TessellationCI = {};
+    const bool HasTessellation = HS.has_value() && DS.has_value();
+    if (HasTessellation) {
+      TessellationCI.sType =
+          VK_STRUCTURE_TYPE_PIPELINE_TESSELLATION_STATE_CREATE_INFO;
+      TessellationCI.patchControlPoints = Desc.PatchControlPoints;
+    }
+
     VkPipelineViewportStateCreateInfo ViewportCI = {};
     ViewportCI.sType = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO;
     ViewportCI.viewportCount = 1;
@@ -1675,6 +1741,7 @@ public:
     PipelineCI.pStages = ShaderStages.data();
     PipelineCI.pVertexInputState = &VertexInputCI;
     PipelineCI.pInputAssemblyState = &InputAssemblyCI;
+    PipelineCI.pTessellationState = HasTessellation ? &TessellationCI : nullptr;
     PipelineCI.pViewportState = &ViewportCI;
     PipelineCI.pRasterizationState = &RastCI;
     PipelineCI.pMultisampleState = &MultisampleCI;
@@ -3222,6 +3289,7 @@ public:
     } else if (P.isTraditionalRaster()) {
       TraditionalRasterPipelineCreateDesc PipelineDesc = {};
       PipelineDesc.Topology = P.Bindings.Topology;
+      PipelineDesc.PatchControlPoints = P.Bindings.PatchControlPoints;
       PipelineDesc.DSFormat = Format::D32FloatS8Uint;
       for (auto &Shader : P.Shaders) {
         ShaderContainer SC = {};

--- a/lib/Support/Pipeline.cpp
+++ b/lib/Support/Pipeline.cpp
@@ -614,18 +614,16 @@ llvm::Error offloadtest::Pipeline::validatePipelineKind() {
     const bool HasDS = HasShaderType[llvm::to_underlying(Stages::Domain)];
     if (HasHS != HasDS)
       return llvm::createStringError(
-          "Hull and Domain shaders must be used together: a tessellation "
-          "pipeline requires both stages, never just one.");
+          "Hull and Domain shaders must be used together");
 
     const bool IsTessellated = HasHS && HasDS;
     const bool IsPatchList = Bindings.Topology == PrimitiveTopology::PatchList;
     if (IsTessellated != IsPatchList)
       return llvm::createStringError(
-          "Tessellation pipelines must use PatchList topology, and PatchList "
-          "topology requires Hull and Domain shaders.");
-    if (IsPatchList && (!Bindings.PatchControlPoints ||
-                        *Bindings.PatchControlPoints < 1 ||
-                        *Bindings.PatchControlPoints > 32))
+          "Tessellation pipelines must use PatchList topology");
+    if (IsPatchList &&
+        (!Bindings.PatchControlPoints || *Bindings.PatchControlPoints < 1 ||
+         *Bindings.PatchControlPoints > 32))
       return llvm::createStringError(
           "PatchList topology requires PatchControlPoints in the range 1..32.");
     if (!IsPatchList && Bindings.PatchControlPoints)

--- a/lib/Support/Pipeline.cpp
+++ b/lib/Support/Pipeline.cpp
@@ -427,6 +427,7 @@ void MappingTraits<offloadtest::IOBindings>::mapping(
   I.mapOptional("RenderTarget", B.RenderTarget);
   I.mapOptional("Topology", B.Topology,
                 offloadtest::PrimitiveTopology::TriangleList);
+  I.mapOptional("PatchControlPoints", B.PatchControlPoints, uint32_t{0});
 }
 
 void MappingTraits<offloadtest::PushConstantBlock>::mapping(
@@ -604,6 +605,28 @@ llvm::Error offloadtest::Pipeline::validatePipelineKind() {
         HasShaderType[llvm::to_underlying(Stages::Mesh)])
       return llvm::createStringError("Vertex and Mesh/Amplification Shaders "
                                      "cannot be used in the same pipeline.");
+
+    const bool HasHS = HasShaderType[llvm::to_underlying(Stages::Hull)];
+    const bool HasDS = HasShaderType[llvm::to_underlying(Stages::Domain)];
+    if (HasHS != HasDS)
+      return llvm::createStringError(
+          "Hull and Domain shaders must be used together: a tessellation "
+          "pipeline requires both stages, never just one.");
+
+    const bool IsTessellated = HasHS && HasDS;
+    const bool IsPatchList =
+        Bindings.Topology == PrimitiveTopology::PatchList;
+    if (IsTessellated != IsPatchList)
+      return llvm::createStringError(
+          "Tessellation pipelines must use PatchList topology, and PatchList "
+          "topology requires Hull and Domain shaders.");
+    if (IsPatchList && (Bindings.PatchControlPoints < 1 ||
+                        Bindings.PatchControlPoints > 32))
+      return llvm::createStringError(
+          "PatchList topology requires PatchControlPoints in the range 1..32.");
+    if (!IsPatchList && Bindings.PatchControlPoints != 0)
+      return llvm::createStringError(
+          "PatchControlPoints is only valid with PatchList topology.");
 
     Kind = ShaderPipelineKind::TraditionalRaster;
     return llvm::Error::success();

--- a/lib/Support/Pipeline.cpp
+++ b/lib/Support/Pipeline.cpp
@@ -55,8 +55,6 @@ namespace yaml {
 void MappingTraits<offloadtest::Pipeline>::mapping(IO &I,
                                                    offloadtest::Pipeline &P) {
   I.mapRequired("Shaders", P.Shaders);
-  if (auto Err = P.validatePipelineKind())
-    I.setError(llvm::toString(std::move(Err)));
 
   // Runtime-specific settings.
   I.mapOptional("RuntimeSettings", P.Settings);
@@ -67,6 +65,12 @@ void MappingTraits<offloadtest::Pipeline>::mapping(IO &I,
   I.mapRequired("DescriptorSets", P.Sets);
   I.mapOptional("Bindings", P.Bindings);
   I.mapOptional("PushConstants", P.PushConstants);
+
+  // Runs here (not right after Shaders) because the tessellation topology
+  // check reads Bindings.Topology and Bindings.PatchControlPoints. Must
+  // still run before validateDispatchParameters, which reads P.Kind.
+  if (auto Err = P.validatePipelineKind())
+    I.setError(llvm::toString(std::move(Err)));
 
   I.mapOptional("DispatchParameters", P.DispatchParameters);
   if (auto Err = P.validateDispatchParameters())
@@ -427,7 +431,7 @@ void MappingTraits<offloadtest::IOBindings>::mapping(
   I.mapOptional("RenderTarget", B.RenderTarget);
   I.mapOptional("Topology", B.Topology,
                 offloadtest::PrimitiveTopology::TriangleList);
-  I.mapOptional("PatchControlPoints", B.PatchControlPoints, uint32_t{0});
+  I.mapOptional("PatchControlPoints", B.PatchControlPoints);
 }
 
 void MappingTraits<offloadtest::PushConstantBlock>::mapping(
@@ -614,17 +618,17 @@ llvm::Error offloadtest::Pipeline::validatePipelineKind() {
           "pipeline requires both stages, never just one.");
 
     const bool IsTessellated = HasHS && HasDS;
-    const bool IsPatchList =
-        Bindings.Topology == PrimitiveTopology::PatchList;
+    const bool IsPatchList = Bindings.Topology == PrimitiveTopology::PatchList;
     if (IsTessellated != IsPatchList)
       return llvm::createStringError(
           "Tessellation pipelines must use PatchList topology, and PatchList "
           "topology requires Hull and Domain shaders.");
-    if (IsPatchList && (Bindings.PatchControlPoints < 1 ||
-                        Bindings.PatchControlPoints > 32))
+    if (IsPatchList && (!Bindings.PatchControlPoints ||
+                        *Bindings.PatchControlPoints < 1 ||
+                        *Bindings.PatchControlPoints > 32))
       return llvm::createStringError(
           "PatchList topology requires PatchControlPoints in the range 1..32.");
-    if (!IsPatchList && Bindings.PatchControlPoints != 0)
+    if (!IsPatchList && Bindings.PatchControlPoints)
       return llvm::createStringError(
           "PatchControlPoints is only valid with PatchList topology.");
 

--- a/test/Graphics/SimpleTriangleTess.test
+++ b/test/Graphics/SimpleTriangleTess.test
@@ -1,0 +1,175 @@
+#--- vertex.hlsl
+struct VSOutput
+{
+    float4 position : POSITION;
+    float4 color : COLOR;
+};
+
+// Pass-through: control points travel unchanged into the Hull stage.
+VSOutput main(float4 position : POSITION, float4 color : COLOR)
+{
+    VSOutput o;
+    o.position = position;
+    o.color = color;
+    return o;
+}
+
+#--- hull.hlsl
+struct HSInput
+{
+    float4 position : POSITION;
+    float4 color : COLOR;
+};
+
+struct HSOutput
+{
+    float4 position : POSITION;
+    float4 color : COLOR;
+};
+
+struct HSPatchConstants
+{
+    float Edges[3]  : SV_TessFactor;
+    float Inside    : SV_InsideTessFactor;
+};
+
+// Edges = 2, Inside = 2 with integer partitioning gives the Sierpinski-1
+// subdivision: three corner sub-triangles + one central inverted triangle, all
+// tiling the original triangle exactly.
+HSPatchConstants PatchConstants(InputPatch<HSInput, 3> patch,
+                                uint patchID : SV_PrimitiveID)
+{
+    HSPatchConstants c;
+    c.Edges[0] = 2.0;
+    c.Edges[1] = 2.0;
+    c.Edges[2] = 2.0;
+    c.Inside   = 2.0;
+    return c;
+}
+
+[domain("tri")]
+[partitioning("integer")]
+[outputtopology("triangle_cw")]
+[outputcontrolpoints(3)]
+[patchconstantfunc("PatchConstants")]
+HSOutput main(InputPatch<HSInput, 3> patch,
+              uint i : SV_OutputControlPointID)
+{
+    HSOutput o;
+    o.position = patch[i].position;
+    o.color    = patch[i].color;
+    return o;
+}
+
+#--- domain.hlsl
+struct DSInput
+{
+    float4 position : POSITION;
+    float4 color : COLOR;
+};
+
+struct DSPatchConstants
+{
+    float Edges[3]  : SV_TessFactor;
+    float Inside    : SV_InsideTessFactor;
+};
+
+struct DSOutput
+{
+    float4 position : SV_POSITION;
+    float4 color : COLOR;
+};
+
+// Evaluate each generated vertex by barycentric interpolation of the patch's
+// control points. The output triangles tile the original triangle exactly, so
+// the rasterized image must match SimpleTriangle.test pixel-for-pixel.
+[domain("tri")]
+DSOutput main(DSPatchConstants constants,
+              float3 bary : SV_DomainLocation,
+              const OutputPatch<DSInput, 3> patch)
+{
+    DSOutput o;
+    o.position = bary.x * patch[0].position
+               + bary.y * patch[1].position
+               + bary.z * patch[2].position;
+    o.color    = bary.x * patch[0].color
+               + bary.y * patch[1].color
+               + bary.z * patch[2].color;
+    return o;
+}
+
+#--- pixel.hlsl
+struct PSInput
+{
+    float4 position : SV_POSITION;
+    float4 color : COLOR;
+};
+
+float4 main(PSInput input) : SV_TARGET
+{
+    return input.color;
+}
+
+#--- pipeline.yaml
+---
+Shaders:
+  - Stage: Vertex
+    Entry: main
+  - Stage: Hull
+    Entry: main
+  - Stage: Domain
+    Entry: main
+  - Stage: Pixel
+    Entry: main
+Buffers:
+  - Name: VertexData
+    Format: Float32
+    Stride: 28 # 32 bytes per vertex
+    Data: [ 0.0, 0.25, 0.0, 1.0, 0.0, 0.0, 1.0,
+            0.25, -0.25, 0.0, 0.0, 1.0, 0.0, 1.0,
+           -0.25, -0.25, 0.0, 0.0, 0.0, 1.0, 1.0 ]
+  - Name: Output
+    Format: Float32
+    Channels: 4
+    FillSize: 1048576 # 256x256 @ 16 bytes per pixel
+    OutputProps:
+      Height: 256
+      Width: 256
+      Depth: 1
+Bindings:
+  VertexBuffer: VertexData
+  VertexAttributes:
+    - Format: Float32
+      Channels: 3
+      Offset: 0
+      Name: POSITION
+    - Format: Float32
+      Channels: 4
+      Offset: 12
+      Name: COLOR
+  Topology: PatchList
+  PatchControlPoints: 3
+  RenderTarget: Output
+DescriptorSets: []
+...
+#--- rules.yaml
+---
+- Type: PixelPercent
+  Val: 0.2 # No more than 0.2% of pixels may be visibly different.
+...
+#--- end
+
+# Metal has no native Hull/Domain shader stages; tessellation would require
+# routing through mesh shaders via the Metal IR converter. Skip this backend.
+# UNSUPPORTED: Metal
+
+# XFAIL: Clang && !Vulkan
+# REQUIRES: goldenimage
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T vs_6_0 -Fo %t-vertex.o %t/vertex.hlsl
+# RUN: %dxc_target -T hs_6_0 -Fo %t-hull.o   %t/hull.hlsl
+# RUN: %dxc_target -T ds_6_0 -Fo %t-domain.o %t/domain.hlsl
+# RUN: %dxc_target -T ps_6_0 -Fo %t-pixel.o  %t/pixel.hlsl
+# RUN: %offloader %t/pipeline.yaml %t-vertex.o %t-hull.o %t-domain.o %t-pixel.o -r Output -o %t/Output.png
+# RUN: imgdiff %t/Output.png %goldenimage_dir/hlsl/Graphics/SimpleTriangle.png -rules %t/rules.yaml

--- a/test/Graphics/SimpleTriangleTess.test
+++ b/test/Graphics/SimpleTriangleTess.test
@@ -159,11 +159,12 @@ DescriptorSets: []
 ...
 #--- end
 
-# Metal has no native Hull/Domain shader stages; tessellation would require
-# routing through mesh shaders via the Metal IR converter. Skip this backend.
+# Metal has tessellation but no Hull/Domain stages: HS is a compute kernel
+# writing per-patch factors, DS is a post-tessellation vertex function tagged
+# [[patch(...)]]. Mapping HLSL HS/DS onto that isn't wired up, so skip this backend.
 # UNSUPPORTED: Metal
 
-# XFAIL: Clang && !Vulkan
+# XFAIL: Clang
 # REQUIRES: goldenimage
 
 # RUN: split-file %s %t


### PR DESCRIPTION
Adds `Hull` and `Domain` shader support, plus a `PatchList` primitive topology with per-call control-point count. 
Wires the new stages on the DX12 and Vulkan backends. 
Metal explicitly rejects them. Metal's tessellation model (HS as a compute kernel, DS as a `[[patch(...)]]`-tagged vertex function) doesn't neatly fit the HS/DS shape, so the path is intentionally left unimplemented. 
Adds one end-to-end test, `SimpleTriangleTess.test`, exercising a VS → HS → DS → PS pipeline that renders the `SimpleTriangle` image test via tessellation.