### PR TITLE
[api-query] Restore DriverVersion assignment on D3D12 devices

### DIFF
--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -961,6 +961,7 @@ public:
         RTVAllocator(std::move(RTVAllocator)),
         DSVAllocator(std::move(DSVAllocator)) {
     Description = std::move(Desc);
+    DriverVersion = std::move(DriverVer);
     DriverName = "DirectX";
   }
   DXDevice(const DXDevice &) = delete;


### PR DESCRIPTION
Fixes an improperly resolved merge conflict in #1206 that accidentally dropped the `DriverVersion = std::move(DriverVer);` line introduced in #1205, leaving the `DriverVer` constructor parameter unused and breaking Windows CI via clang-tidy's `misc-unused-parameters` warning-as-error.