### PR TITLE
Remove XFAIL for reversebit.64 when targeting vulkan

### DIFF
--- a/test/Feature/HLSLLib/reversebits.64.test
+++ b/test/Feature/HLSLLib/reversebits.64.test
@@ -79,9 +79,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug https://github.com/llvm/llvm-project/issues/197810
-# XFAIL: Clang && Vulkan
-
 # REQUIRES: Int64
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/reversebits.64.test
+++ b/test/Feature/HLSLLib/reversebits.64.test
@@ -79,7 +79,7 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug https://github.com/llvm/llvm-project/issues/197810
+# Bug https://github.com/llvm/offload-test-suite/issues/1241
 # XFAIL: QC && Vulkan && Clang
 
 # REQUIRES: Int64

--- a/test/Feature/HLSLLib/reversebits.64.test
+++ b/test/Feature/HLSLLib/reversebits.64.test
@@ -79,6 +79,9 @@ DescriptorSets:
 ...
 #--- end
 
+# Bug https://github.com/llvm/llvm-project/issues/197810
+# XFAIL: QC && Vulkan && Clang
+
 # REQUIRES: Int64
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl


### PR DESCRIPTION
The original issue was fixed, so now we can remove the xfail