### PR TITLE
Add ComputeEncoder::batchBuildAS() and shared AS-build orchestration helper

### DIFF
--- a/include/API/AccelerationStructure.h
+++ b/include/API/AccelerationStructure.h
@@ -65,12 +65,10 @@ struct BLASBuildRequest {
   std::variant<llvm::SmallVector<TriangleGeometryDesc>,
                llvm::SmallVector<AABBGeometryDesc>>
       Geometry;
-  AccelerationStructureSizes Sizes;
 };
 
 struct TLASBuildRequest {
   llvm::SmallVector<AccelerationStructureInstance> Instances;
-  AccelerationStructureSizes Sizes;
 };
 
 inline llvm::Error validateGeometryDesc(const TriangleGeometryDesc &D) {
@@ -154,6 +152,7 @@ inline llvm::Error validateTLASBuildRequest(const TLASBuildRequest &Req) {
 
 class AccelerationStructure {
   GPUAPI API;
+  AccelerationStructureSizes Sizes;
 
 public:
   virtual ~AccelerationStructure();
@@ -161,9 +160,14 @@ public:
   AccelerationStructure &operator=(const AccelerationStructure &) = delete;
 
   GPUAPI getAPI() const { return API; }
+  // Result/scratch sizes the AS was allocated for. Available for the GPU
+  // build path so it can size the scratch buffer without re-querying.
+  const AccelerationStructureSizes &getSizes() const { return Sizes; }
 
 protected:
-  explicit AccelerationStructure(GPUAPI API) : API(API) {}
+  explicit AccelerationStructure(GPUAPI API,
+                                 const AccelerationStructureSizes &Sizes)
+      : API(API), Sizes(Sizes) {}
 };
 
 } // namespace offloadtest

--- a/include/API/AccelerationStructure.h
+++ b/include/API/AccelerationStructure.h
@@ -59,6 +59,8 @@ struct AccelerationStructureInstance {
 };
 
 struct BLASBuildRequest {
+  // Target AS this build writes into.
+  AccelerationStructure *AS = nullptr;
   // DXR / Vulkan / Metal all forbid mixing triangle and AABB geometry in a
   // single BLAS, so the geometry list is held as a variant — the invalid
   // mixed-geometry state is unrepresentable.
@@ -68,6 +70,8 @@ struct BLASBuildRequest {
 };
 
 struct TLASBuildRequest {
+  // Target AS this build writes into.
+  AccelerationStructure *AS = nullptr;
   llvm::SmallVector<AccelerationStructureInstance> Instances;
 };
 

--- a/include/API/Buffer.h
+++ b/include/API/Buffer.h
@@ -21,6 +21,9 @@
 namespace offloadtest {
 
 enum class BufferUsage {
+  // Generic storage buffer (UAV/SSBO). Also covers acceleration-structure
+  // build inputs (vertex/index/instance buffers): backends widen this with
+  // any native AS-input flags they need.
   Storage,
   VertexBuffer,
 };

--- a/include/API/Device.h
+++ b/include/API/Device.h
@@ -264,20 +264,27 @@ public:
   virtual llvm::Expected<std::unique_ptr<CommandBuffer>>
   createCommandBuffer() = 0;
 
-  virtual llvm::Expected<BLASBuildRequest> createTriangleBLASBuildRequest(
-      llvm::ArrayRef<TriangleGeometryDesc> Triangles) = 0;
+  // Sizing queries: return the result/scratch sizes the backend needs to
+  // allocate an AS that can hold the given build inputs. The build-input
+  // pointers (geometry buffers, BLAS handles) are never consulted — only
+  // counts/strides — so these can be called before BLAS handles exist.
+  virtual llvm::Expected<AccelerationStructureSizes>
+  getBLASBuildSizes(llvm::ArrayRef<TriangleGeometryDesc> Triangles) = 0;
 
-  virtual llvm::Expected<BLASBuildRequest>
-  createAABBBLASBuildRequest(llvm::ArrayRef<AABBGeometryDesc> AABBs) = 0;
+  virtual llvm::Expected<AccelerationStructureSizes>
+  getBLASBuildSizes(llvm::ArrayRef<AABBGeometryDesc> AABBs) = 0;
 
-  virtual llvm::Expected<TLASBuildRequest> createTLASBuildRequest(
-      llvm::ArrayRef<AccelerationStructureInstance> Instances) = 0;
+  virtual llvm::Expected<AccelerationStructureSizes>
+  getTLASBuildSizes(uint32_t InstanceCount) = 0;
+
+  // Allocate the AS storage (no GPU build). The build is recorded later via
+  // ComputeEncoder::batchBuildAS(), which is the only place that consumes the
+  // associated *BuildRequest.
+  virtual llvm::Expected<std::unique_ptr<AccelerationStructure>>
+  createBLAS(const AccelerationStructureSizes &Sizes) = 0;
 
   virtual llvm::Expected<std::unique_ptr<AccelerationStructure>>
-  createAccelerationStructure(const BLASBuildRequest &Request) = 0;
-
-  virtual llvm::Expected<std::unique_ptr<AccelerationStructure>>
-  createAccelerationStructure(const TLASBuildRequest &Request) = 0;
+  createTLAS(const AccelerationStructureSizes &Sizes) = 0;
 
   virtual ~Device() = 0;
 

--- a/include/API/Device.h
+++ b/include/API/Device.h
@@ -323,6 +323,25 @@ createBufferWithData(Device &Dev, std::string Name,
                      size_t SizeInBytes, ComputeEncoder *Encoder,
                      std::unique_ptr<offloadtest::Buffer> *OutUploadBuffer);
 
+// Builds all BLAS / TLAS objects defined in `P.AccelStructs` using the
+// supplied compute encoder. Uploads each BLAS's vertex/index data, queries
+// sizes via `Dev.getBLASBuildSizes` / `Dev.getTLASBuildSizes`, allocates
+// the handles via `Dev.createBLAS` / `Dev.createTLAS`, and records the GPU
+// builds via two `Enc.batchBuildAS` calls (BLAS batch then TLAS batch — so
+// the AS-build-write barrier between BLAS and TLAS is automatic).
+//
+// Built AS objects are pushed to `OutAS` (in declaration order: BLASes first,
+// then TLASes). Vertex/index buffers used as build inputs are pushed to
+// `OutInputBuffers`; both must outlive command-buffer submission.
+//
+// TODO: `Pipeline` belongs to the test framework, not the rendering backend
+// API. This helper lives here only because `executeProgram` is still on
+// `Device` — once that moves out, this helper should follow.
+llvm::Error buildPipelineAccelerationStructures(
+    Device &Dev, ComputeEncoder &Enc, Pipeline &P,
+    llvm::SmallVectorImpl<std::unique_ptr<AccelerationStructure>> &OutAS,
+    llvm::SmallVectorImpl<std::unique_ptr<Buffer>> &OutInputBuffers);
+
 } // namespace offloadtest
 
 #endif // OFFLOADTEST_API_DEVICE_H

--- a/include/API/Encoder.h
+++ b/include/API/Encoder.h
@@ -11,6 +11,8 @@
 
 #include "API/API.h"
 
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/PointerUnion.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Error.h"
 
@@ -21,6 +23,18 @@ namespace offloadtest {
 
 class Buffer;
 class PipelineState;
+class AccelerationStructure;
+struct BLASBuildRequest;
+struct TLASBuildRequest;
+
+/// Tagged-pointer alias for an acceleration-structure build request. Each
+/// request carries its own target AS (`Req->AS`), so a batch is just an
+/// array of these pointers. The caller is responsible for ensuring no item
+/// in a batch has a memory dependency on another (e.g. a TLAS that reads a
+/// BLAS being built in the same batch must be in a separate batch — that
+/// barrier is inserted between batchBuildAS() calls automatically).
+using ASBuildItem =
+    llvm::PointerUnion<const BLASBuildRequest *, const TLASBuildRequest *>;
 
 /// Base class for all command encoders. An encoder records commands into a
 /// command buffer. Call endEncoding() when done recording. Barriers are
@@ -82,6 +96,14 @@ public:
   virtual llvm::Error copyBufferToBuffer(Buffer &Src, size_t SrcOffset,
                                          Buffer &Dst, size_t DstOffset,
                                          size_t Size) = 0;
+
+  /// Build a batch of acceleration structures in a single barrier slot. All
+  /// items in `Items` must be independent — no item may depend on another's
+  /// build output. Backends may issue this as one native batch call (Vulkan)
+  /// or as a sequence of single-AS calls without intermediate barriers (DX12,
+  /// Metal). A barrier covering AS-build writes is implicitly emitted before
+  /// any subsequent command that reads from the freshly-built structures.
+  virtual llvm::Error batchBuildAS(llvm::ArrayRef<ASBuildItem> Items) = 0;
 };
 
 struct Viewport {

--- a/include/Support/VkError.h
+++ b/include/Support/VkError.h
@@ -9,15 +9,16 @@
 #ifndef OFFLOADTEST_SUPPORT_VKERROR_H
 #define OFFLOADTEST_SUPPORT_VKERROR_H
 
+#include "llvm/ADT/Twine.h"
 #include "llvm/Support/Error.h"
 
 #include <vulkan/vulkan.h>
 
 namespace VK {
-inline llvm::Error toError(VkResult Result, llvm::StringRef Msg) {
+inline llvm::Error toError(VkResult Result, const llvm::Twine &Msg) {
   if (Result != VK_SUCCESS)
-    return llvm::createStringError("%s (VkResult = %d)", Msg.data(),
-                                   static_cast<int>(Result));
+    return llvm::createStringError(
+        Msg + " (VkResult = " + llvm::Twine(static_cast<int>(Result)) + ")");
   return llvm::Error::success();
 }
 } // namespace VK

--- a/include/Support/WinError.h
+++ b/include/Support/WinError.h
@@ -20,10 +20,11 @@
 #undef max
 #undef min
 
+#include "llvm/ADT/Twine.h"
 #include "llvm/Support/Error.h"
 
 namespace HR {
-inline llvm::Error toError(HRESULT HR, llvm::StringRef Msg) {
+inline llvm::Error toError(HRESULT HR, const llvm::Twine &Msg) {
   if (FAILED(HR)) {
     const std::error_code EC =
         std::error_code(static_cast<int>(HR), std::system_category());

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -587,13 +587,21 @@ public:
       override;
 };
 
+class DXDevice; // forward decl — defined below in this same anon ns
+
 class DXCommandBuffer : public offloadtest::CommandBuffer {
 public:
   ComPtr<ID3D12CommandAllocator> Allocator;
   ComPtr<ID3D12GraphicsCommandListX> CmdList;
+  /// Back-pointer to the owning device. Used by encoders that need access to
+  /// device-level resources (e.g. allocating AS scratch buffers).
+  DXDevice *Dev = nullptr;
   /// Whether a UAV barrier is pending from a prior compute command.
   bool PendingUAVBarrier = false;
   llvm::SmallVector<D3D12_RESOURCE_BARRIER> PendingTransitions;
+  /// Buffers that must outlive command-buffer submission (e.g. AS scratch
+  /// and TLAS instance buffers used during builds).
+  llvm::SmallVector<std::unique_ptr<offloadtest::Buffer>> KeepAliveOwned;
 
   static llvm::Expected<std::unique_ptr<DXCommandBuffer>>
   create(ComPtr<ID3D12DeviceX> Device) {
@@ -782,6 +790,10 @@ public:
 
     return llvm::Error::success();
   }
+
+  // Defined out-of-line below — needs DXDevice's full type for access to the
+  // ID3D12Device5 entry point and helper allocators.
+  llvm::Error batchBuildAS(llvm::ArrayRef<ASBuildItem> Items) override;
 
   void endEncodingImpl() override { popDebugGroup(); }
 };
@@ -1049,6 +1061,10 @@ DXCommandBuffer::createRenderEncoder(
 }
 
 class DXDevice : public offloadtest::Device {
+  // DXComputeEncoder needs access to Device5 for AS build commands and to the
+  // raw ID3D12Device for scratch buffer allocation.
+  friend class DXComputeEncoder;
+
 private:
   ComPtr<IDXCoreAdapter> Adapter;
   ComPtr<ID3D12DeviceX> Device;
@@ -1104,6 +1120,12 @@ private:
 
     llvm::SmallVector<DescriptorTable> DescTables;
     llvm::SmallVector<ResourcePair> RootResources;
+
+    // Built acceleration structures, kept alive for the pipeline lifetime.
+    llvm::SmallVector<std::unique_ptr<offloadtest::AccelerationStructure>>
+        AccelStructs;
+    // Vertex/index buffers consumed during AS builds; must outlive submission.
+    llvm::SmallVector<std::unique_ptr<offloadtest::Buffer>> ASInputBuffers;
   };
 
 public:
@@ -1691,7 +1713,11 @@ public:
 
   llvm::Expected<std::unique_ptr<offloadtest::CommandBuffer>>
   createCommandBuffer() override {
-    return DXCommandBuffer::create(Device);
+    auto CBOrErr = DXCommandBuffer::create(Device);
+    if (!CBOrErr)
+      return CBOrErr.takeError();
+    (*CBOrErr)->Dev = this;
+    return std::unique_ptr<offloadtest::CommandBuffer>(std::move(*CBOrErr));
   }
 
   llvm::Expected<std::unique_ptr<offloadtest::RenderPass>>
@@ -2694,7 +2720,18 @@ public:
     if (!CBOrErr)
       return CBOrErr.takeError();
     State.CB = std::move(*CBOrErr);
+    State.CB->Dev = this;
     llvm::outs() << "Command buffer created.\n";
+
+    if (!P.AccelStructs.BLAS.empty() || !P.AccelStructs.TLAS.empty()) {
+      auto EncOrErr = State.CB->createComputeEncoder();
+      if (!EncOrErr)
+        return EncOrErr.takeError();
+      if (auto Err = offloadtest::buildPipelineAccelerationStructures(
+              *this, **EncOrErr, P, State.AccelStructs, State.ASInputBuffers))
+        return Err;
+      (*EncOrErr)->endEncoding();
+    }
 
     if (auto Err = createBuffers(P, State))
       return Err;
@@ -2872,6 +2909,157 @@ public:
     return llvm::Error::success();
   }
 };
+
+llvm::Error DXComputeEncoder::batchBuildAS(llvm::ArrayRef<ASBuildItem> Items) {
+  if (Items.empty())
+    return llvm::Error::success();
+  if (!CB.Dev || !CB.Dev->Device)
+    return llvm::createStringError(
+        std::errc::not_supported,
+        "Ray tracing not supported on this command buffer's device.");
+  DXDevice *Dev = CB.Dev;
+
+  // BuildRaytracingAccelerationStructure() lives on ID3D12GraphicsCommandList4.
+  ComPtr<ID3D12GraphicsCommandList4> CmdList4;
+  if (auto Err = HR::toError(CB.CmdList.As(&CmdList4),
+                             "Failed to query ID3D12GraphicsCommandList4."))
+    return Err;
+
+  // Flush a pending barrier before reading, like dispatch(): a TLAS build must
+  // observe BLASes built in the previous batch.
+  CB.flushBarrier();
+
+  // Per the ComputeEncoder::batchBuildAS() contract, the caller guarantees no
+  // inter-item memory dependencies within a batch (BLAS and TLAS go in
+  // separate batches, so a TLAS never sees BLASes from the same call). Each
+  // item also gets its own scratch resource, so there's no aliasing between
+  // the builds — no intra-loop UAV barrier is needed.
+  for (const auto &Item : Items) {
+    D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC Desc = {};
+    llvm::SmallVector<D3D12_RAYTRACING_GEOMETRY_DESC> GeomDescs;
+    uint64_t ScratchSize = 0;
+
+    if (const auto *BLAS = llvm::dyn_cast<const BLASBuildRequest *>(Item)) {
+      auto *DXAS = llvm::cast<DXAccelerationStructure>(BLAS->AS);
+      Desc.DestAccelerationStructureData = DXAS->getGPUVirtualAddress();
+      Desc.Inputs.Type =
+          D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL;
+      Desc.Inputs.DescsLayout = D3D12_ELEMENTS_LAYOUT_ARRAY;
+
+      if (const auto *Tris =
+              std::get_if<llvm::SmallVector<TriangleGeometryDesc>>(
+                  &BLAS->Geometry)) {
+        GeomDescs.reserve(Tris->size());
+        for (const auto &T : *Tris) {
+          D3D12_RAYTRACING_GEOMETRY_DESC GD = {};
+          GD.Type = D3D12_RAYTRACING_GEOMETRY_TYPE_TRIANGLES;
+          if (T.Opaque)
+            GD.Flags = D3D12_RAYTRACING_GEOMETRY_FLAG_OPAQUE;
+          auto *VB = llvm::cast<DXBuffer>(T.VertexBuffer);
+          GD.Triangles.VertexBuffer.StartAddress =
+              VB->Buffer->GetGPUVirtualAddress() + T.VertexBufferOffset;
+          GD.Triangles.VertexBuffer.StrideInBytes = T.VertexStride;
+          GD.Triangles.VertexCount = T.VertexCount;
+          GD.Triangles.VertexFormat = getDXGIFormat(T.VertexFormat);
+          if (T.IndexBuffer) {
+            auto *IB = llvm::cast<DXBuffer>(T.IndexBuffer);
+            GD.Triangles.IndexBuffer =
+                IB->Buffer->GetGPUVirtualAddress() + T.IndexBufferOffset;
+            GD.Triangles.IndexCount = T.IndexCount;
+            GD.Triangles.IndexFormat = getDXGIIndexFormat(T.IdxFormat);
+          }
+          GeomDescs.push_back(GD);
+        }
+      } else {
+        const auto &AABBs =
+            std::get<llvm::SmallVector<AABBGeometryDesc>>(BLAS->Geometry);
+        GeomDescs.reserve(AABBs.size());
+        for (const auto &A : AABBs) {
+          D3D12_RAYTRACING_GEOMETRY_DESC GD = {};
+          GD.Type = D3D12_RAYTRACING_GEOMETRY_TYPE_PROCEDURAL_PRIMITIVE_AABBS;
+          if (A.Opaque)
+            GD.Flags = D3D12_RAYTRACING_GEOMETRY_FLAG_OPAQUE;
+          auto *AB = llvm::cast<DXBuffer>(A.AABBBuffer);
+          GD.AABBs.AABBs.StartAddress =
+              AB->Buffer->GetGPUVirtualAddress() + A.AABBBufferOffset;
+          GD.AABBs.AABBs.StrideInBytes = A.AABBStride;
+          GD.AABBs.AABBCount = A.AABBCount;
+          GeomDescs.push_back(GD);
+        }
+      }
+      Desc.Inputs.NumDescs = static_cast<UINT>(GeomDescs.size());
+      Desc.Inputs.pGeometryDescs = GeomDescs.data();
+      ScratchSize = BLAS->AS->getSizes().ScratchDataSizeInBytes;
+    } else {
+      const auto *TLAS = llvm::cast<const TLASBuildRequest *>(Item);
+      auto *DXAS = llvm::cast<DXAccelerationStructure>(TLAS->AS);
+      Desc.DestAccelerationStructureData = DXAS->getGPUVirtualAddress();
+      Desc.Inputs.Type = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL;
+      Desc.Inputs.DescsLayout = D3D12_ELEMENTS_LAYOUT_ARRAY;
+      Desc.Inputs.NumDescs = static_cast<UINT>(TLAS->Instances.size());
+
+      // D3D12_RAYTRACING_INSTANCE_DESC has the same byte layout as
+      // VkAccelerationStructureInstanceKHR. Serialize and upload via the
+      // shared abstract-API helper using an upload-heap (CpuToGpu) buffer.
+      llvm::SmallVector<D3D12_RAYTRACING_INSTANCE_DESC> Native;
+      Native.reserve(TLAS->Instances.size());
+      for (const auto &Inst : TLAS->Instances) {
+        D3D12_RAYTRACING_INSTANCE_DESC NI = {};
+        static_assert(sizeof(NI.Transform) == sizeof(Inst.Transform),
+                      "Transform layout mismatch");
+        memcpy(&NI.Transform, Inst.Transform, sizeof(Inst.Transform));
+        // D3D12_RAYTRACING_INSTANCE_DESC packs InstanceID into a 24-bit
+        // bitfield; truncate explicitly so the value matches the VK path
+        // (vkInstanceCustomIndex is likewise 24-bit) instead of relying on
+        // silent narrowing.
+        NI.InstanceID = Inst.InstanceID & 0xFFFFFFu;
+        NI.InstanceMask = Inst.InstanceMask;
+        NI.InstanceContributionToHitGroupIndex = 0;
+        NI.Flags = D3D12_RAYTRACING_INSTANCE_FLAG_NONE;
+        auto *BLASPtr = llvm::cast<DXAccelerationStructure>(Inst.BLAS);
+        NI.AccelerationStructure = BLASPtr->getGPUVirtualAddress();
+        Native.push_back(NI);
+      }
+      const size_t Bytes =
+          Native.size() * sizeof(D3D12_RAYTRACING_INSTANCE_DESC);
+
+      const BufferCreateDesc UploadDesc{MemoryLocation::CpuToGpu,
+                                        BufferUsage::Storage};
+      auto InstBufOrErr = offloadtest::createBufferWithData(
+          *Dev, "TLAS-Instances", UploadDesc, Native.data(), Bytes, nullptr,
+          nullptr);
+      if (!InstBufOrErr)
+        return InstBufOrErr.takeError();
+      auto *DXInstBuf = llvm::cast<DXBuffer>(InstBufOrErr->get());
+      Desc.Inputs.InstanceDescs = DXInstBuf->Buffer->GetGPUVirtualAddress();
+
+      CB.KeepAliveOwned.push_back(std::move(*InstBufOrErr));
+      ScratchSize = TLAS->AS->getSizes().ScratchDataSizeInBytes;
+    }
+
+    // Allocate scratch in the default heap; createBuffer() applies
+    // ALLOW_UNORDERED_ACCESS for default-heap allocations and creates the
+    // resource in COMMON state, which D3D12 implicitly promotes to
+    // UNORDERED_ACCESS on first GPU access during the AS build.
+    const BufferCreateDesc ScratchDesc{MemoryLocation::GpuOnly,
+                                       BufferUsage::Storage};
+    auto ScratchOrErr =
+        Dev->createBuffer("AS-Scratch", ScratchDesc, ScratchSize);
+    if (!ScratchOrErr)
+      return ScratchOrErr.takeError();
+    auto *DXScratchBuf = llvm::cast<DXBuffer>(ScratchOrErr->get());
+    Desc.ScratchAccelerationStructureData =
+        DXScratchBuf->Buffer->GetGPUVirtualAddress();
+    CB.KeepAliveOwned.push_back(std::move(*ScratchOrErr));
+
+    insertDebugSignpost("BuildRaytracingAccelerationStructure");
+    CmdList4->BuildRaytracingAccelerationStructure(&Desc, 0, nullptr);
+  }
+
+  // Signal that this batch's AS writes need a barrier before the next reader.
+  CB.addPendingUAVBarrier();
+  return llvm::Error::success();
+}
 } // namespace
 
 llvm::Expected<offloadtest::SubmitResult> DXQueue::submit(

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -453,8 +453,9 @@ class DXAccelerationStructure : public offloadtest::AccelerationStructure {
 public:
   ComPtr<ID3D12Resource> Resource;
 
-  DXAccelerationStructure(ComPtr<ID3D12Resource> Resource)
-      : offloadtest::AccelerationStructure(GPUAPI::DirectX),
+  DXAccelerationStructure(ComPtr<ID3D12Resource> Resource,
+                          const AccelerationStructureSizes &Sizes)
+      : offloadtest::AccelerationStructure(GPUAPI::DirectX, Sizes),
         Resource(Resource) {}
 
   D3D12_GPU_VIRTUAL_ADDRESS getGPUVirtualAddress() const {
@@ -1698,18 +1699,13 @@ public:
     return std::make_unique<DXRenderPass>(Desc);
   }
 
-  llvm::Expected<BLASBuildRequest> createTriangleBLASBuildRequest(
-      llvm::ArrayRef<TriangleGeometryDesc> Triangles) override {
+  llvm::Expected<AccelerationStructureSizes>
+  getBLASBuildSizes(llvm::ArrayRef<TriangleGeometryDesc> Triangles) override {
     if (auto Err = validateBLASGeometry(Triangles))
       return Err;
 
-    BLASBuildRequest Req;
-    Req.Geometry = llvm::SmallVector<TriangleGeometryDesc>(Triangles.begin(),
-                                                           Triangles.end());
-
     llvm::SmallVector<D3D12_RAYTRACING_GEOMETRY_DESC> GeomDescs;
     GeomDescs.reserve(Triangles.size());
-
     for (const auto &T : Triangles) {
       D3D12_RAYTRACING_GEOMETRY_DESC GD = {};
       GD.Type = D3D12_RAYTRACING_GEOMETRY_TYPE_TRIANGLES;
@@ -1730,24 +1726,16 @@ public:
 
       GeomDescs.push_back(GD);
     }
-
-    if (auto Err = queryBLASPrebuildSize(GeomDescs, Req.Sizes))
-      return Err;
-    return Req;
+    return queryBLASPrebuildSize(GeomDescs);
   }
 
-  llvm::Expected<BLASBuildRequest>
-  createAABBBLASBuildRequest(llvm::ArrayRef<AABBGeometryDesc> AABBs) override {
+  llvm::Expected<AccelerationStructureSizes>
+  getBLASBuildSizes(llvm::ArrayRef<AABBGeometryDesc> AABBs) override {
     if (auto Err = validateBLASGeometry(AABBs))
       return Err;
 
-    BLASBuildRequest Req;
-    Req.Geometry =
-        llvm::SmallVector<AABBGeometryDesc>(AABBs.begin(), AABBs.end());
-
     llvm::SmallVector<D3D12_RAYTRACING_GEOMETRY_DESC> GeomDescs;
     GeomDescs.reserve(AABBs.size());
-
     for (const auto &A : AABBs) {
       D3D12_RAYTRACING_GEOMETRY_DESC GD = {};
       GD.Type = D3D12_RAYTRACING_GEOMETRY_TYPE_PROCEDURAL_PRIMITIVE_AABBS;
@@ -1759,16 +1747,12 @@ public:
 
       GeomDescs.push_back(GD);
     }
-
-    if (auto Err = queryBLASPrebuildSize(GeomDescs, Req.Sizes))
-      return Err;
-    return Req;
+    return queryBLASPrebuildSize(GeomDescs);
   }
 
 private:
-  llvm::Error queryBLASPrebuildSize(
-      llvm::ArrayRef<D3D12_RAYTRACING_GEOMETRY_DESC> GeomDescs,
-      AccelerationStructureSizes &OutSizes) {
+  AccelerationStructureSizes queryBLASPrebuildSize(
+      llvm::ArrayRef<D3D12_RAYTRACING_GEOMETRY_DESC> GeomDescs) {
     D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS Inputs = {};
     Inputs.Type = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL;
     Inputs.DescsLayout = D3D12_ELEMENTS_LAYOUT_ARRAY;
@@ -1778,78 +1762,56 @@ private:
     D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO Info = {};
     Device->GetRaytracingAccelerationStructurePrebuildInfo(&Inputs, &Info);
 
-    OutSizes.ResultDataMaxSizeInBytes = Info.ResultDataMaxSizeInBytes;
-    OutSizes.ScratchDataSizeInBytes = Info.ScratchDataSizeInBytes;
-    OutSizes.UpdateScratchDataSizeInBytes = Info.UpdateScratchDataSizeInBytes;
-    return llvm::Error::success();
+    return {Info.ResultDataMaxSizeInBytes, Info.ScratchDataSizeInBytes,
+            Info.UpdateScratchDataSizeInBytes};
+  }
+
+  llvm::Expected<std::unique_ptr<offloadtest::AccelerationStructure>>
+  allocateAS(const AccelerationStructureSizes &Sizes, const char *Kind) {
+    const uint64_t AlignedSize =
+        llvm::alignTo(Sizes.ResultDataMaxSizeInBytes,
+                      D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BYTE_ALIGNMENT);
+    const D3D12_HEAP_PROPERTIES HeapProps =
+        CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT);
+    const D3D12_RESOURCE_DESC BufferDesc = CD3DX12_RESOURCE_DESC::Buffer(
+        AlignedSize, D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS);
+
+    ComPtr<ID3D12Resource> ASBuffer;
+    if (auto Err = HR::toError(
+            Device->CreateCommittedResource(
+                &HeapProps, D3D12_HEAP_FLAG_NONE, &BufferDesc,
+                D3D12_RESOURCE_STATE_RAYTRACING_ACCELERATION_STRUCTURE, nullptr,
+                IID_PPV_ARGS(&ASBuffer)),
+            "Failed to create " + llvm::Twine(Kind) + " resource."))
+      return Err;
+
+    return std::make_unique<DXAccelerationStructure>(ASBuffer, Sizes);
   }
 
 public:
-  llvm::Expected<TLASBuildRequest> createTLASBuildRequest(
-      llvm::ArrayRef<AccelerationStructureInstance> Instances) override {
-    TLASBuildRequest Req;
-    Req.Instances.assign(Instances.begin(), Instances.end());
-
-    if (auto Err = validateTLASBuildRequest(Req))
-      return Err;
-
+  llvm::Expected<AccelerationStructureSizes>
+  getTLASBuildSizes(uint32_t InstanceCount) override {
     D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS Inputs = {};
     Inputs.Type = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL;
     Inputs.DescsLayout = D3D12_ELEMENTS_LAYOUT_ARRAY;
-    Inputs.NumDescs = Instances.size();
+    Inputs.NumDescs = InstanceCount;
 
     D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO Info = {};
     Device->GetRaytracingAccelerationStructurePrebuildInfo(&Inputs, &Info);
 
-    Req.Sizes.ResultDataMaxSizeInBytes = Info.ResultDataMaxSizeInBytes;
-    Req.Sizes.ScratchDataSizeInBytes = Info.ScratchDataSizeInBytes;
-    Req.Sizes.UpdateScratchDataSizeInBytes = Info.UpdateScratchDataSizeInBytes;
-
-    return Req;
+    return AccelerationStructureSizes{Info.ResultDataMaxSizeInBytes,
+                                      Info.ScratchDataSizeInBytes,
+                                      Info.UpdateScratchDataSizeInBytes};
   }
 
   llvm::Expected<std::unique_ptr<offloadtest::AccelerationStructure>>
-  createAccelerationStructure(const BLASBuildRequest &Request) override {
-    const uint64_t AlignedSize =
-        llvm::alignTo(Request.Sizes.ResultDataMaxSizeInBytes,
-                      D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BYTE_ALIGNMENT);
-    const D3D12_HEAP_PROPERTIES HeapProps =
-        CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT);
-    const D3D12_RESOURCE_DESC BufferDesc = CD3DX12_RESOURCE_DESC::Buffer(
-        AlignedSize, D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS);
-
-    ComPtr<ID3D12Resource> ASBuffer;
-    if (auto Err = HR::toError(
-            Device->CreateCommittedResource(
-                &HeapProps, D3D12_HEAP_FLAG_NONE, &BufferDesc,
-                D3D12_RESOURCE_STATE_RAYTRACING_ACCELERATION_STRUCTURE, nullptr,
-                IID_PPV_ARGS(&ASBuffer)),
-            "Failed to create BLAS resource."))
-      return Err;
-
-    return std::make_unique<DXAccelerationStructure>(ASBuffer);
+  createBLAS(const AccelerationStructureSizes &Sizes) override {
+    return allocateAS(Sizes, "BLAS");
   }
 
   llvm::Expected<std::unique_ptr<offloadtest::AccelerationStructure>>
-  createAccelerationStructure(const TLASBuildRequest &Request) override {
-    const uint64_t AlignedSize =
-        llvm::alignTo(Request.Sizes.ResultDataMaxSizeInBytes,
-                      D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BYTE_ALIGNMENT);
-    const D3D12_HEAP_PROPERTIES HeapProps =
-        CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT);
-    const D3D12_RESOURCE_DESC BufferDesc = CD3DX12_RESOURCE_DESC::Buffer(
-        AlignedSize, D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS);
-
-    ComPtr<ID3D12Resource> ASBuffer;
-    if (auto Err = HR::toError(
-            Device->CreateCommittedResource(
-                &HeapProps, D3D12_HEAP_FLAG_NONE, &BufferDesc,
-                D3D12_RESOURCE_STATE_RAYTRACING_ACCELERATION_STRUCTURE, nullptr,
-                IID_PPV_ARGS(&ASBuffer)),
-            "Failed to create TLAS resource."))
-      return Err;
-
-    return std::make_unique<DXAccelerationStructure>(ASBuffer);
+  createTLAS(const AccelerationStructureSizes &Sizes) override {
+    return allocateAS(Sizes, "TLAS");
   }
 
   void addResourceUploadCommands(Resource &R, InvocationState &IS,

--- a/lib/API/Device.cpp
+++ b/lib/API/Device.cpp
@@ -15,6 +15,7 @@
 
 #include "Config.h"
 
+#include "llvm/ADT/StringMap.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/raw_ostream.h"
 
@@ -92,6 +93,134 @@ offloadtest::createRenderTargetFromCPUBuffer(Device &Dev,
     return Err;
 
   return Dev.createTexture("RenderTarget", Desc);
+}
+
+llvm::Error offloadtest::buildPipelineAccelerationStructures(
+    Device &Dev, ComputeEncoder &Enc, Pipeline &P,
+    llvm::SmallVectorImpl<std::unique_ptr<AccelerationStructure>> &OutAS,
+    llvm::SmallVectorImpl<std::unique_ptr<Buffer>> &OutInputBuffers) {
+  if (P.AccelStructs.BLAS.empty() && P.AccelStructs.TLAS.empty())
+    return llvm::Error::success();
+
+  // `BufferUsage::Storage` is the usage to pick for acceleration structure
+  // build inputs. Backends widen it with the native AS-input flags
+  // (e.g. Vulkan `SHADER_DEVICE_ADDRESS` + `ACCEL_BUILD_INPUT_READ_ONLY`)
+  // implicitly when ray tracing is supported.
+  const BufferCreateDesc UploadDesc{MemoryLocation::CpuToGpu,
+                                    BufferUsage::Storage};
+
+  // Stash the request structs while we build them up — the encoder reads
+  // them through pointers stored in ASBuildItem.
+  llvm::SmallVector<BLASBuildRequest> BLASRequests;
+  BLASRequests.reserve(P.AccelStructs.BLAS.size());
+  llvm::StringMap<size_t> BLASIndex;
+
+  for (const auto &BD : P.AccelStructs.BLAS) {
+    llvm::SmallVector<TriangleGeometryDesc> Triangles;
+    Triangles.reserve(BD.Triangles.size());
+    for (const auto &T : BD.Triangles) {
+      assert(T.VertexBufferPtr && "VertexBufferPtr not resolved");
+      auto VBOrErr = createBufferWithData(
+          Dev, "AS-Vertices", UploadDesc, T.VertexBufferPtr->Data[0].get(),
+          T.VertexBufferPtr->size(), nullptr, nullptr);
+      if (!VBOrErr)
+        return VBOrErr.takeError();
+
+      TriangleGeometryDesc TGD;
+      TGD.VertexBuffer = VBOrErr->get();
+      TGD.VertexCount = T.VertexCount;
+      TGD.VertexStride = T.VertexStride;
+      TGD.VertexFormat = T.VertexFormat;
+      TGD.Opaque = T.Opaque;
+
+      OutInputBuffers.push_back(std::move(*VBOrErr));
+
+      if (T.IndexBufferPtr) {
+        auto IBOrErr = createBufferWithData(
+            Dev, "AS-Indices", UploadDesc, T.IndexBufferPtr->Data[0].get(),
+            T.IndexBufferPtr->size(), nullptr, nullptr);
+        if (!IBOrErr)
+          return IBOrErr.takeError();
+        TGD.IndexBuffer = IBOrErr->get();
+        TGD.IndexCount = T.IndexCount;
+        TGD.IdxFormat = T.IdxFormat;
+        OutInputBuffers.push_back(std::move(*IBOrErr));
+      }
+      Triangles.push_back(TGD);
+    }
+    // TODO: AABB geometry support (would mirror the triangle path).
+
+    auto SizesOrErr = Dev.getBLASBuildSizes(Triangles);
+    if (!SizesOrErr)
+      return SizesOrErr.takeError();
+    auto ASOrErr = Dev.createBLAS(*SizesOrErr);
+    if (!ASOrErr)
+      return ASOrErr.takeError();
+
+    BLASBuildRequest Req;
+    Req.AS = ASOrErr->get();
+    Req.Geometry = std::move(Triangles);
+
+    BLASIndex[BD.Name] = OutAS.size();
+    OutAS.push_back(std::move(*ASOrErr));
+    BLASRequests.push_back(std::move(Req));
+  }
+
+  llvm::SmallVector<ASBuildItem> BLASBatch;
+  BLASBatch.reserve(BLASRequests.size());
+  for (const auto &Req : BLASRequests)
+    BLASBatch.push_back(&Req);
+  if (!BLASBatch.empty())
+    if (auto Err = Enc.batchBuildAS(BLASBatch))
+      return Err;
+
+  // TLAS pass — references BLASes built in the previous batch.
+  llvm::SmallVector<TLASBuildRequest> TLASRequests;
+  TLASRequests.reserve(P.AccelStructs.TLAS.size());
+
+  for (const auto &TD : P.AccelStructs.TLAS) {
+    TLASBuildRequest Req;
+    Req.Instances.reserve(TD.Instances.size());
+    for (const auto &I : TD.Instances) {
+      auto It = BLASIndex.find(I.BLAS);
+      if (It == BLASIndex.end())
+        return llvm::createStringError(std::errc::invalid_argument,
+                                       "TLAS '%s' references unknown BLAS '%s'",
+                                       TD.Name.c_str(), I.BLAS.c_str());
+
+      AccelerationStructureInstance Inst;
+      static_assert(sizeof(Inst.Transform) == sizeof(I.Transform),
+                    "Transform layout mismatch");
+      memcpy(Inst.Transform, I.Transform, sizeof(I.Transform));
+      Inst.InstanceID = I.InstanceID;
+      Inst.InstanceMask = I.InstanceMask;
+      Inst.BLAS = OutAS[It->second].get();
+      Req.Instances.push_back(Inst);
+    }
+    if (auto Err = validateTLASBuildRequest(Req))
+      return Err;
+    auto SizesOrErr =
+        Dev.getTLASBuildSizes(static_cast<uint32_t>(Req.Instances.size()));
+    if (!SizesOrErr)
+      return SizesOrErr.takeError();
+    auto ASOrErr = Dev.createTLAS(*SizesOrErr);
+    if (!ASOrErr)
+      return ASOrErr.takeError();
+
+    Req.AS = ASOrErr->get();
+    OutAS.push_back(std::move(*ASOrErr));
+    TLASRequests.push_back(std::move(Req));
+  }
+
+  llvm::SmallVector<ASBuildItem> TLASBatch;
+  TLASBatch.reserve(TLASRequests.size());
+  for (const auto &Req : TLASRequests)
+    TLASBatch.push_back(&Req);
+  if (!TLASBatch.empty())
+    if (auto Err = Enc.batchBuildAS(TLASBatch))
+      return Err;
+
+  return llvm::Error::success();
 }
 
 llvm::Expected<std::unique_ptr<Texture>>

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -373,9 +373,17 @@ public:
   }
 };
 
+class MTLDevice; // forward decl — defined below in this same anon ns
+
 class MTLCommandBuffer : public offloadtest::CommandBuffer {
 public:
   MTL::CommandBuffer *CmdBuffer = nullptr;
+  /// Back-pointer to the owning device; used by encoders that need to
+  /// allocate scratch / instance buffers for AS builds.
+  MTLDevice *Dev = nullptr;
+  /// Buffers that must outlive command-buffer submission (e.g. AS scratch
+  /// and TLAS instance buffers used during builds).
+  llvm::SmallVector<std::unique_ptr<offloadtest::Buffer>> KeepAliveOwned;
 
   static llvm::Expected<std::unique_ptr<MTLCommandBuffer>>
   create(MTL::CommandQueue *Queue) {
@@ -452,9 +460,13 @@ llvm::Expected<offloadtest::SubmitResult> MTLQueue::submit(
 }
 
 class MTLComputeEncoder : public offloadtest::ComputeEncoder {
+  MTLCommandBuffer *CB = nullptr;
   MTL::CommandBuffer *CmdBuffer;
   MTL::ComputeCommandEncoder *ComputeEnc = nullptr;
   MTL::BlitCommandEncoder *BlitEnc = nullptr;
+  /// Lazy AS encoder, created when batchBuildAS() is called and torn down at
+  /// the next encoder transition (via endEncodingImpl).
+  MTL::AccelerationStructureCommandEncoder *ASEnc = nullptr;
 
   /// Accumulated barrier scope from commands recorded since the last barrier.
   MTL::BarrierScope PendingScope = MTL::BarrierScope(0);
@@ -499,9 +511,9 @@ class MTLComputeEncoder : public offloadtest::ComputeEncoder {
   }
 
 public:
-  MTLComputeEncoder(MTL::CommandBuffer *CmdBuffer,
+  MTLComputeEncoder(MTLCommandBuffer *CB, MTL::CommandBuffer *CmdBuffer,
                     MTL::ComputeCommandEncoder *Encoder)
-      : ComputeEncoder(GPUAPI::Metal), CmdBuffer(CmdBuffer),
+      : ComputeEncoder(GPUAPI::Metal), CB(CB), CmdBuffer(CmdBuffer),
         ComputeEnc(Encoder) {}
 
   ~MTLComputeEncoder() override { endEncoding(); }
@@ -572,6 +584,24 @@ public:
     return llvm::Error::success();
   }
 
+  // Defined out-of-line below — needs MTLDevice's full type for access to the
+  // MTL::Device handle (used to allocate scratch and instance buffers).
+  llvm::Error batchBuildAS(llvm::ArrayRef<ASBuildItem> Items) override;
+
+  /// Lazily transition into an AccelerationStructureCommandEncoder; mirrors
+  /// the existing compute↔blit lazy switch.
+  llvm::Error ensureASEncoder() {
+    if (ASEnc)
+      return llvm::Error::success();
+    endEncodingImpl();
+    ASEnc = CmdBuffer->accelerationStructureCommandEncoder();
+    if (!ASEnc)
+      return llvm::createStringError(
+          std::errc::device_or_resource_busy,
+          "Failed to create Metal acceleration-structure encoder.");
+    return llvm::Error::success();
+  }
+
   void endEncodingImpl() override {
     if (ComputeEnc) {
       flushBarrier();
@@ -582,6 +612,10 @@ public:
     if (BlitEnc) {
       BlitEnc->endEncoding();
       BlitEnc = nullptr;
+    }
+    if (ASEnc) {
+      ASEnc->endEncoding();
+      ASEnc = nullptr;
     }
   }
 };
@@ -596,7 +630,7 @@ MTLCommandBuffer::createComputeEncoder() {
         "Failed to create Metal compute command encoder.");
   NativeEncoder->pushDebugGroup(
       NS::String::string("ComputeEncoder", NS::UTF8StringEncoding));
-  return std::make_unique<MTLComputeEncoder>(CmdBuffer, NativeEncoder);
+  return std::make_unique<MTLComputeEncoder>(this, CmdBuffer, NativeEncoder);
 }
 
 static MTL::LoadAction getMTLLoadAction(offloadtest::LoadAction Action) {
@@ -880,6 +914,10 @@ MTLCommandBuffer::createRenderEncoder(
 }
 
 class MTLDevice : public offloadtest::Device {
+  // MTLComputeEncoder needs access to the MTL::Device handle for AS scratch
+  // and instance buffer allocation.
+  friend class MTLComputeEncoder;
+
   Capabilities Caps;
   MTL::Device *Device;
   MTLQueue GraphicsQueue;
@@ -914,6 +952,12 @@ class MTLDevice : public offloadtest::Device {
 
     llvm::SmallVector<DescriptorTable> DescTables;
     // TODO: Support RootResources?
+
+    // Built acceleration structures, kept alive for the pipeline lifetime.
+    llvm::SmallVector<std::unique_ptr<offloadtest::AccelerationStructure>>
+        AccelStructs;
+    // Vertex/index buffers consumed during AS builds; must outlive submission.
+    llvm::SmallVector<std::unique_ptr<offloadtest::Buffer>> ASInputBuffers;
   };
 
   llvm::Error createRootSignature(
@@ -1577,7 +1621,11 @@ public:
 
   llvm::Expected<std::unique_ptr<offloadtest::CommandBuffer>>
   createCommandBuffer() override {
-    return MTLCommandBuffer::create(GraphicsQueue.Queue);
+    auto CBOrErr = MTLCommandBuffer::create(GraphicsQueue.Queue);
+    if (!CBOrErr)
+      return CBOrErr.takeError();
+    (*CBOrErr)->Dev = this;
+    return std::unique_ptr<offloadtest::CommandBuffer>(std::move(*CBOrErr));
   }
 
   llvm::Expected<std::unique_ptr<offloadtest::RenderPass>>
@@ -2102,6 +2150,17 @@ public:
     if (!CBOrErr)
       return CBOrErr.takeError();
     IS.CB = std::move(*CBOrErr);
+    IS.CB->Dev = this;
+
+    if (!P.AccelStructs.BLAS.empty() || !P.AccelStructs.TLAS.empty()) {
+      auto EncOrErr = IS.CB->createComputeEncoder();
+      if (!EncOrErr)
+        return EncOrErr.takeError();
+      if (auto Err = offloadtest::buildPipelineAccelerationStructures(
+              *this, **EncOrErr, P, IS.AccelStructs, IS.ASInputBuffers))
+        return Err;
+      (*EncOrErr)->endEncoding();
+    }
 
     if (auto Err = createDescriptorHeap(P, IS))
       return Err;
@@ -2253,6 +2312,166 @@ private:
                                             Device->supportsRaytracing())));
   }
 };
+
+llvm::Error MTLComputeEncoder::batchBuildAS(llvm::ArrayRef<ASBuildItem> Items) {
+  if (Items.empty())
+    return llvm::Error::success();
+  if (!CB || !CB->Dev)
+    return llvm::createStringError(
+        std::errc::not_supported,
+        "Metal command buffer has no associated MTLDevice.");
+  MTL::Device *MTLDev = CB->Dev->Device;
+  if (!MTLDev->supportsRaytracing())
+    return llvm::createStringError(
+        std::errc::not_supported,
+        "Ray tracing is not supported on this Metal device.");
+
+  if (auto Err = ensureASEncoder())
+    return Err;
+
+  for (const auto &Item : Items) {
+    MetalAccelerationStructure *AS = nullptr;
+    MTL::AccelerationStructureDescriptor *Desc = nullptr;
+    uint64_t ScratchSize = 0;
+
+    if (const auto *BLAS = llvm::dyn_cast<const BLASBuildRequest *>(Item)) {
+      AS = llvm::cast<MetalAccelerationStructure>(BLAS->AS);
+      llvm::SmallVector<MTL::AccelerationStructureGeometryDescriptor *> Geoms;
+      if (const auto *Tris =
+              std::get_if<llvm::SmallVector<TriangleGeometryDesc>>(
+                  &BLAS->Geometry)) {
+        Geoms.reserve(Tris->size());
+        for (const auto &T : *Tris) {
+          auto *TD =
+              MTL::AccelerationStructureTriangleGeometryDescriptor::alloc()
+                  ->init();
+          auto *VB = llvm::cast<MTLBuffer>(T.VertexBuffer);
+          TD->setVertexBuffer(VB->Buf);
+          TD->setVertexBufferOffset(T.VertexBufferOffset);
+          TD->setVertexStride(T.VertexStride);
+          TD->setVertexFormat(getMetalPositionFormat(T.VertexFormat));
+          TD->setTriangleCount(T.IndexBuffer ? T.IndexCount / 3
+                                             : T.VertexCount / 3);
+          if (T.IndexBuffer) {
+            auto *IB = llvm::cast<MTLBuffer>(T.IndexBuffer);
+            TD->setIndexBuffer(IB->Buf);
+            TD->setIndexBufferOffset(T.IndexBufferOffset);
+            TD->setIndexType(getMetalIndexType(T.IdxFormat));
+          }
+          TD->setOpaque(T.Opaque);
+          Geoms.push_back(TD);
+        }
+      } else {
+        const auto &AABBs =
+            std::get<llvm::SmallVector<AABBGeometryDesc>>(BLAS->Geometry);
+        Geoms.reserve(AABBs.size());
+        for (const auto &A : AABBs) {
+          auto *AD =
+              MTL::AccelerationStructureBoundingBoxGeometryDescriptor::alloc()
+                  ->init();
+          auto *BB = llvm::cast<MTLBuffer>(A.AABBBuffer);
+          AD->setBoundingBoxBuffer(BB->Buf);
+          AD->setBoundingBoxBufferOffset(A.AABBBufferOffset);
+          AD->setBoundingBoxStride(A.AABBStride);
+          AD->setBoundingBoxCount(A.AABBCount);
+          AD->setOpaque(A.Opaque);
+          Geoms.push_back(AD);
+        }
+      }
+      auto *PD = MTL::PrimitiveAccelerationStructureDescriptor::alloc()->init();
+      NS::Array *GeomArr = NS::Array::array(
+          reinterpret_cast<NS::Object *const *>(Geoms.data()), Geoms.size());
+      PD->setGeometryDescriptors(GeomArr);
+      Desc = PD;
+      ScratchSize = BLAS->AS->getSizes().ScratchDataSizeInBytes;
+      for (auto *G : Geoms)
+        G->release();
+    } else {
+      const auto *TLAS = llvm::cast<const TLASBuildRequest *>(Item);
+      AS = llvm::cast<MetalAccelerationStructure>(TLAS->AS);
+
+      // Metal's MTLAccelerationStructureInstanceDescriptor references BLASes
+      // by index into a separate `instancedAccelerationStructures` array,
+      // not by GPU address. Deduplicate the BLAS pointers and remember
+      // their indices.
+      llvm::SmallVector<MTL::AccelerationStructure *> UniqueBLASes;
+      llvm::SmallVector<uint32_t> InstanceASIdx;
+      InstanceASIdx.reserve(TLAS->Instances.size());
+      for (const auto &Inst : TLAS->Instances) {
+        auto *MTLBLAS = llvm::cast<MetalAccelerationStructure>(Inst.BLAS);
+        auto It = std::find(UniqueBLASes.begin(), UniqueBLASes.end(),
+                            MTLBLAS->AccelStruct);
+        uint32_t Idx;
+        if (It == UniqueBLASes.end()) {
+          Idx = static_cast<uint32_t>(UniqueBLASes.size());
+          UniqueBLASes.push_back(MTLBLAS->AccelStruct);
+        } else {
+          Idx = static_cast<uint32_t>(It - UniqueBLASes.begin());
+        }
+        InstanceASIdx.push_back(Idx);
+      }
+
+      // Pack instance descriptors. Layout differs from VK/DX12: 32-byte
+      // entries with an index instead of a GPU address.
+      llvm::SmallVector<MTL::AccelerationStructureInstanceDescriptor> Native;
+      Native.reserve(TLAS->Instances.size());
+      for (size_t I = 0; I < TLAS->Instances.size(); ++I) {
+        const auto &Src = TLAS->Instances[I];
+        MTL::AccelerationStructureInstanceDescriptor D = {};
+        // Metal stores transform as packed 4x3 column-major; our high-level
+        // Transform[3][4] is row-major. Transpose into Metal's layout.
+        for (int Row = 0; Row < 3; ++Row)
+          for (int Col = 0; Col < 4; ++Col)
+            D.transformationMatrix.columns[Col][Row] = Src.Transform[Row][Col];
+        D.options = MTL::AccelerationStructureInstanceOptionNone;
+        D.mask = Src.InstanceMask;
+        D.intersectionFunctionTableOffset = 0;
+        D.accelerationStructureIndex = InstanceASIdx[I];
+        Native.push_back(D);
+      }
+      const size_t InstByteSize =
+          Native.size() * sizeof(MTL::AccelerationStructureInstanceDescriptor);
+
+      const BufferCreateDesc UploadDesc{MemoryLocation::CpuToGpu,
+                                        BufferUsage::Storage};
+      auto InstBufOrErr = offloadtest::createBufferWithData(
+          *CB->Dev, "TLAS-Instances", UploadDesc, Native.data(), InstByteSize,
+          nullptr, nullptr);
+      if (!InstBufOrErr)
+        return InstBufOrErr.takeError();
+      auto *MTLInstBuf = llvm::cast<MTLBuffer>(InstBufOrErr->get());
+      CB->KeepAliveOwned.push_back(std::move(*InstBufOrErr));
+
+      auto *ID = MTL::InstanceAccelerationStructureDescriptor::alloc()->init();
+      ID->setInstanceDescriptorBuffer(MTLInstBuf->Buf);
+      ID->setInstanceCount(TLAS->Instances.size());
+      NS::Array *BLASArr = NS::Array::array(
+          reinterpret_cast<NS::Object *const *>(UniqueBLASes.data()),
+          UniqueBLASes.size());
+      ID->setInstancedAccelerationStructures(BLASArr);
+      Desc = ID;
+      ScratchSize = TLAS->AS->getSizes().ScratchDataSizeInBytes;
+    }
+
+    const BufferCreateDesc ScratchDesc{MemoryLocation::GpuOnly,
+                                       BufferUsage::Storage};
+    auto ScratchOrErr =
+        CB->Dev->createBuffer("AS-Scratch", ScratchDesc, ScratchSize);
+    if (!ScratchOrErr) {
+      Desc->release();
+      return ScratchOrErr.takeError();
+    }
+    auto *MTLScratch = llvm::cast<MTLBuffer>(ScratchOrErr->get());
+    CB->KeepAliveOwned.push_back(std::move(*ScratchOrErr));
+
+    insertDebugSignpost("BuildAccelerationStructure");
+    ASEnc->buildAccelerationStructure(AS->AccelStruct, Desc, MTLScratch->Buf,
+                                      0);
+    Desc->release();
+  }
+
+  return llvm::Error::success();
+}
 } // namespace
 
 llvm::Error offloadtest::initializeMetalDevices(

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -407,8 +407,9 @@ class MetalAccelerationStructure : public offloadtest::AccelerationStructure {
 public:
   MTL::AccelerationStructure *AccelStruct;
 
-  MetalAccelerationStructure(MTL::AccelerationStructure *AccelStruct)
-      : offloadtest::AccelerationStructure(GPUAPI::Metal),
+  MetalAccelerationStructure(MTL::AccelerationStructure *AccelStruct,
+                             const AccelerationStructureSizes &Sizes)
+      : offloadtest::AccelerationStructure(GPUAPI::Metal, Sizes),
         AccelStruct(AccelStruct) {}
 
   ~MetalAccelerationStructure() override {
@@ -1953,8 +1954,8 @@ public:
         MTL::CullModeNone, MeshTGSize, ObjectTGSize);
   }
 
-  llvm::Expected<BLASBuildRequest> createTriangleBLASBuildRequest(
-      llvm::ArrayRef<TriangleGeometryDesc> Triangles) override {
+  llvm::Expected<AccelerationStructureSizes>
+  getBLASBuildSizes(llvm::ArrayRef<TriangleGeometryDesc> Triangles) override {
     if (!Device->supportsRaytracing())
       return llvm::createStringError(
           std::errc::not_supported,
@@ -1962,10 +1963,6 @@ public:
 
     if (auto Err = validateBLASGeometry(Triangles))
       return Err;
-
-    BLASBuildRequest Req;
-    Req.Geometry = llvm::SmallVector<TriangleGeometryDesc>(Triangles.begin(),
-                                                           Triangles.end());
 
     llvm::SmallVector<MTL::AccelerationStructureGeometryDescriptor *> Descs;
     Descs.reserve(Triangles.size());
@@ -1989,14 +1986,14 @@ public:
       Descs.push_back(TD);
     }
 
-    queryBLASPrebuildSize(Descs, Req.Sizes);
+    AccelerationStructureSizes Sizes = queryBLASPrebuildSize(Descs);
     for (auto *D : Descs)
       D->release();
-    return Req;
+    return Sizes;
   }
 
-  llvm::Expected<BLASBuildRequest>
-  createAABBBLASBuildRequest(llvm::ArrayRef<AABBGeometryDesc> AABBs) override {
+  llvm::Expected<AccelerationStructureSizes>
+  getBLASBuildSizes(llvm::ArrayRef<AABBGeometryDesc> AABBs) override {
     if (!Device->supportsRaytracing())
       return llvm::createStringError(
           std::errc::not_supported,
@@ -2004,10 +2001,6 @@ public:
 
     if (auto Err = validateBLASGeometry(AABBs))
       return Err;
-
-    BLASBuildRequest Req;
-    Req.Geometry =
-        llvm::SmallVector<AABBGeometryDesc>(AABBs.begin(), AABBs.end());
 
     llvm::SmallVector<MTL::AccelerationStructureGeometryDescriptor *> Descs;
     Descs.reserve(AABBs.size());
@@ -2024,16 +2017,15 @@ public:
       Descs.push_back(AD);
     }
 
-    queryBLASPrebuildSize(Descs, Req.Sizes);
+    AccelerationStructureSizes Sizes = queryBLASPrebuildSize(Descs);
     for (auto *D : Descs)
       D->release();
-    return Req;
+    return Sizes;
   }
 
 private:
-  void queryBLASPrebuildSize(
-      llvm::ArrayRef<MTL::AccelerationStructureGeometryDescriptor *> Descs,
-      AccelerationStructureSizes &OutSizes) {
+  AccelerationStructureSizes queryBLASPrebuildSize(
+      llvm::ArrayRef<MTL::AccelerationStructureGeometryDescriptor *> Descs) {
     NS::Array *GeomDescs = NS::Array::array(
         reinterpret_cast<NS::Object *const *>(Descs.data()), Descs.size());
 
@@ -2044,71 +2036,63 @@ private:
     MTL::AccelerationStructureSizes Sizes =
         Device->accelerationStructureSizes(Descriptor);
 
-    OutSizes.ResultDataMaxSizeInBytes = Sizes.accelerationStructureSize;
-    OutSizes.ScratchDataSizeInBytes = Sizes.buildScratchBufferSize;
-    OutSizes.UpdateScratchDataSizeInBytes = Sizes.refitScratchBufferSize;
-
     Descriptor->release();
+
+    return {Sizes.accelerationStructureSize, Sizes.buildScratchBufferSize,
+            Sizes.refitScratchBufferSize};
   }
 
-public:
-  llvm::Expected<TLASBuildRequest> createTLASBuildRequest(
-      llvm::ArrayRef<AccelerationStructureInstance> Instances) override {
+  llvm::Expected<std::unique_ptr<offloadtest::AccelerationStructure>>
+  allocateAS(const AccelerationStructureSizes &Sizes, const char *Kind) {
     if (!Device->supportsRaytracing())
       return llvm::createStringError(
           std::errc::not_supported,
           "Ray tracing is not supported on this device.");
 
-    TLASBuildRequest Req;
-    Req.Instances.assign(Instances.begin(), Instances.end());
+    MTL::AccelerationStructure *AS =
+        Device->newAccelerationStructure(Sizes.ResultDataMaxSizeInBytes);
+    if (!AS)
+      return llvm::createStringError(
+          std::make_error_code(std::errc::not_enough_memory),
+          "Failed to create Metal " + llvm::Twine(Kind) + ".");
+    return std::make_unique<MetalAccelerationStructure>(AS, Sizes);
+  }
 
-    if (auto Err = validateTLASBuildRequest(Req))
-      return Err;
+public:
+  llvm::Expected<AccelerationStructureSizes>
+  getTLASBuildSizes(uint32_t InstanceCount) override {
+    if (!Device->supportsRaytracing())
+      return llvm::createStringError(
+          std::errc::not_supported,
+          "Ray tracing is not supported on this device.");
 
     auto *Descriptor =
         MTL::InstanceAccelerationStructureDescriptor::alloc()->init();
-    Descriptor->setInstanceCount(Instances.size());
+    Descriptor->setInstanceCount(InstanceCount);
+    // UserID descriptor type so per-instance InstanceID survives the
+    // build and is returned by HLSL CommittedInstanceID()/InstanceIndex()
+    // semantics on the shader side.
+    Descriptor->setInstanceDescriptorType(
+        MTL::AccelerationStructureInstanceDescriptorTypeUserID);
 
     MTL::AccelerationStructureSizes Sizes =
         Device->accelerationStructureSizes(Descriptor);
 
-    Req.Sizes.ResultDataMaxSizeInBytes = Sizes.accelerationStructureSize;
-    Req.Sizes.ScratchDataSizeInBytes = Sizes.buildScratchBufferSize;
-    Req.Sizes.UpdateScratchDataSizeInBytes = Sizes.refitScratchBufferSize;
-
     Descriptor->release();
 
-    return Req;
+    return AccelerationStructureSizes{Sizes.accelerationStructureSize,
+                                      Sizes.buildScratchBufferSize,
+                                      Sizes.refitScratchBufferSize};
   }
 
   llvm::Expected<std::unique_ptr<offloadtest::AccelerationStructure>>
-  createAccelerationStructure(const BLASBuildRequest &Request) override {
-    if (!Device->supportsRaytracing())
-      return llvm::createStringError(
-          std::errc::not_supported,
-          "Ray tracing is not supported on this device.");
-
-    MTL::AccelerationStructure *AS = Device->newAccelerationStructure(
-        Request.Sizes.ResultDataMaxSizeInBytes);
-    if (!AS)
-      return llvm::createStringError(std::errc::not_enough_memory,
-                                     "Failed to create Metal BLAS.");
-    return std::make_unique<MetalAccelerationStructure>(AS);
+  createBLAS(const AccelerationStructureSizes &Sizes) override {
+    return allocateAS(Sizes, "BLAS");
   }
 
   llvm::Expected<std::unique_ptr<offloadtest::AccelerationStructure>>
-  createAccelerationStructure(const TLASBuildRequest &Request) override {
-    if (!Device->supportsRaytracing())
-      return llvm::createStringError(
-          std::errc::not_supported,
-          "Ray tracing is not supported on this device.");
-
-    MTL::AccelerationStructure *AS = Device->newAccelerationStructure(
-        Request.Sizes.ResultDataMaxSizeInBytes);
-    if (!AS)
-      return llvm::createStringError(std::errc::not_enough_memory,
-                                     "Failed to create Metal TLAS.");
-    return std::make_unique<MetalAccelerationStructure>(AS);
+  createTLAS(const AccelerationStructureSizes &Sizes) override {
+    return allocateAS(Sizes, "TLAS");
   }
 
   llvm::Error executeProgram(Pipeline &P) override {

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -518,8 +518,9 @@ public:
                               VkAccelerationStructureKHR AccelStruct,
                               VkBuffer Buffer, VkDeviceMemory Memory,
                               VkDeviceAddress DeviceAddress,
-                              PFN_vkDestroyAccelerationStructureKHR FnDestroyAS)
-      : offloadtest::AccelerationStructure(GPUAPI::Vulkan), Dev(Dev),
+                              PFN_vkDestroyAccelerationStructureKHR FnDestroyAS,
+                              const AccelerationStructureSizes &Sizes)
+      : offloadtest::AccelerationStructure(GPUAPI::Vulkan, Sizes), Dev(Dev),
         AccelStruct(AccelStruct), Buffer(Buffer), Memory(Memory),
         DeviceAddress(DeviceAddress), FnDestroyAS(FnDestroyAS) {}
 
@@ -2575,14 +2576,10 @@ public:
                         VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT);
   }
 
-  llvm::Expected<BLASBuildRequest> createTriangleBLASBuildRequest(
-      llvm::ArrayRef<TriangleGeometryDesc> Triangles) override {
+  llvm::Expected<AccelerationStructureSizes>
+  getBLASBuildSizes(llvm::ArrayRef<TriangleGeometryDesc> Triangles) override {
     if (auto Err = validateBLASGeometry(Triangles))
       return Err;
-
-    BLASBuildRequest Req;
-    Req.Geometry = llvm::SmallVector<TriangleGeometryDesc>(Triangles.begin(),
-                                                           Triangles.end());
 
     llvm::SmallVector<VkAccelerationStructureGeometryKHR> Geoms;
     Geoms.reserve(Triangles.size());
@@ -2613,18 +2610,13 @@ public:
                                             : T.VertexCount / 3);
     }
 
-    queryBLASPrebuildSize(Geoms, MaxPrimCounts, Req.Sizes);
-    return Req;
+    return queryBLASPrebuildSize(Geoms, MaxPrimCounts);
   }
 
-  llvm::Expected<BLASBuildRequest>
-  createAABBBLASBuildRequest(llvm::ArrayRef<AABBGeometryDesc> AABBs) override {
+  llvm::Expected<AccelerationStructureSizes>
+  getBLASBuildSizes(llvm::ArrayRef<AABBGeometryDesc> AABBs) override {
     if (auto Err = validateBLASGeometry(AABBs))
       return Err;
-
-    BLASBuildRequest Req;
-    Req.Geometry =
-        llvm::SmallVector<AABBGeometryDesc>(AABBs.begin(), AABBs.end());
 
     llvm::SmallVector<VkAccelerationStructureGeometryKHR> Geoms;
     Geoms.reserve(AABBs.size());
@@ -2648,15 +2640,13 @@ public:
       MaxPrimCounts.push_back(A.AABBCount);
     }
 
-    queryBLASPrebuildSize(Geoms, MaxPrimCounts, Req.Sizes);
-    return Req;
+    return queryBLASPrebuildSize(Geoms, MaxPrimCounts);
   }
 
 private:
-  void queryBLASPrebuildSize(
+  AccelerationStructureSizes queryBLASPrebuildSize(
       llvm::ArrayRef<VkAccelerationStructureGeometryKHR> Geoms,
-      llvm::ArrayRef<uint32_t> MaxPrimCounts,
-      AccelerationStructureSizes &OutSizes) {
+      llvm::ArrayRef<uint32_t> MaxPrimCounts) {
     VkAccelerationStructureBuildGeometryInfoKHR BuildInfo = {};
     BuildInfo.sType =
         VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_BUILD_GEOMETRY_INFO_KHR;
@@ -2671,20 +2661,53 @@ private:
     RT.GetBuildSizes(Device, VK_ACCELERATION_STRUCTURE_BUILD_TYPE_DEVICE_KHR,
                      &BuildInfo, MaxPrimCounts.data(), &SizesInfo);
 
-    OutSizes.ResultDataMaxSizeInBytes = SizesInfo.accelerationStructureSize;
-    OutSizes.ScratchDataSizeInBytes = SizesInfo.buildScratchSize;
-    OutSizes.UpdateScratchDataSizeInBytes = SizesInfo.updateScratchSize;
+    return {SizesInfo.accelerationStructureSize, SizesInfo.buildScratchSize,
+            SizesInfo.updateScratchSize};
+  }
+
+  llvm::Expected<std::unique_ptr<offloadtest::AccelerationStructure>>
+  allocateAS(const AccelerationStructureSizes &Sizes,
+             VkAccelerationStructureTypeKHR Type, const char *Kind) {
+    if (!HasRayTracingSupport)
+      return llvm::createStringError(
+          std::errc::not_supported,
+          "Ray tracing is not supported on this device.");
+
+    auto BufOrErr = createBufferWithDeviceAddress(
+        Sizes.ResultDataMaxSizeInBytes,
+        VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR);
+    if (!BufOrErr)
+      return BufOrErr.takeError();
+
+    VkAccelerationStructureCreateInfoKHR CreateInfo = {};
+    CreateInfo.sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_CREATE_INFO_KHR;
+    CreateInfo.buffer = BufOrErr->Buffer;
+    CreateInfo.size = Sizes.ResultDataMaxSizeInBytes;
+    CreateInfo.type = Type;
+
+    VkAccelerationStructureKHR AccelStruct = VK_NULL_HANDLE;
+    if (auto Err =
+            VK::toError(RT.CreateAS(Device, &CreateInfo, nullptr, &AccelStruct),
+                        "Failed to create " + llvm::Twine(Kind) + ".")) {
+      vkDestroyBuffer(Device, BufOrErr->Buffer, nullptr);
+      vkFreeMemory(Device, BufOrErr->Memory, nullptr);
+      return Err;
+    }
+
+    VkAccelerationStructureDeviceAddressInfoKHR AddrInfo = {};
+    AddrInfo.sType =
+        VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_DEVICE_ADDRESS_INFO_KHR;
+    AddrInfo.accelerationStructure = AccelStruct;
+    const VkDeviceAddress DevAddr = RT.GetDeviceAddress(Device, &AddrInfo);
+
+    return std::make_unique<VulkanAccelerationStructure>(
+        Device, AccelStruct, BufOrErr->Buffer, BufOrErr->Memory, DevAddr,
+        RT.DestroyAS, Sizes);
   }
 
 public:
-  llvm::Expected<TLASBuildRequest> createTLASBuildRequest(
-      llvm::ArrayRef<AccelerationStructureInstance> Instances) override {
-    TLASBuildRequest Req;
-    Req.Instances.assign(Instances.begin(), Instances.end());
-
-    if (auto Err = validateTLASBuildRequest(Req))
-      return Err;
-
+  llvm::Expected<AccelerationStructureSizes>
+  getTLASBuildSizes(uint32_t InstanceCount) override {
     VkAccelerationStructureGeometryKHR Geom = {};
     Geom.sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_KHR;
     Geom.geometryType = VK_GEOMETRY_TYPE_INSTANCES_KHR;
@@ -2698,8 +2721,6 @@ public:
     BuildInfo.geometryCount = 1;
     BuildInfo.pGeometries = &Geom;
 
-    const uint32_t InstanceCount = static_cast<uint32_t>(Instances.size());
-
     VkAccelerationStructureBuildSizesInfoKHR SizesInfo = {};
     SizesInfo.sType =
         VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_BUILD_SIZES_INFO_KHR;
@@ -2707,89 +2728,21 @@ public:
     RT.GetBuildSizes(Device, VK_ACCELERATION_STRUCTURE_BUILD_TYPE_DEVICE_KHR,
                      &BuildInfo, &InstanceCount, &SizesInfo);
 
-    Req.Sizes.ResultDataMaxSizeInBytes = SizesInfo.accelerationStructureSize;
-    Req.Sizes.ScratchDataSizeInBytes = SizesInfo.buildScratchSize;
-    Req.Sizes.UpdateScratchDataSizeInBytes = SizesInfo.updateScratchSize;
-
-    return Req;
+    return AccelerationStructureSizes{SizesInfo.accelerationStructureSize,
+                                      SizesInfo.buildScratchSize,
+                                      SizesInfo.updateScratchSize};
   }
 
   llvm::Expected<std::unique_ptr<offloadtest::AccelerationStructure>>
-  createAccelerationStructure(const BLASBuildRequest &Request) override {
-    if (!HasRayTracingSupport)
-      return llvm::createStringError(
-          std::errc::not_supported,
-          "Ray tracing is not supported on this device.");
-
-    auto BufOrErr = createBufferWithDeviceAddress(
-        Request.Sizes.ResultDataMaxSizeInBytes,
-        VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR);
-    if (!BufOrErr)
-      return BufOrErr.takeError();
-
-    VkAccelerationStructureCreateInfoKHR CreateInfo = {};
-    CreateInfo.sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_CREATE_INFO_KHR;
-    CreateInfo.buffer = BufOrErr->Buffer;
-    CreateInfo.size = Request.Sizes.ResultDataMaxSizeInBytes;
-    CreateInfo.type = VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR;
-
-    VkAccelerationStructureKHR AccelStruct = VK_NULL_HANDLE;
-    if (auto Err =
-            VK::toError(RT.CreateAS(Device, &CreateInfo, nullptr, &AccelStruct),
-                        "Failed to create BLAS.")) {
-      vkDestroyBuffer(Device, BufOrErr->Buffer, nullptr);
-      vkFreeMemory(Device, BufOrErr->Memory, nullptr);
-      return Err;
-    }
-
-    VkAccelerationStructureDeviceAddressInfoKHR AddrInfo = {};
-    AddrInfo.sType =
-        VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_DEVICE_ADDRESS_INFO_KHR;
-    AddrInfo.accelerationStructure = AccelStruct;
-    const VkDeviceAddress DevAddr = RT.GetDeviceAddress(Device, &AddrInfo);
-
-    return std::make_unique<VulkanAccelerationStructure>(
-        Device, AccelStruct, BufOrErr->Buffer, BufOrErr->Memory, DevAddr,
-        RT.DestroyAS);
+  createBLAS(const AccelerationStructureSizes &Sizes) override {
+    return allocateAS(Sizes, VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR,
+                      "BLAS");
   }
 
   llvm::Expected<std::unique_ptr<offloadtest::AccelerationStructure>>
-  createAccelerationStructure(const TLASBuildRequest &Request) override {
-    if (!HasRayTracingSupport)
-      return llvm::createStringError(
-          std::errc::not_supported,
-          "Ray tracing is not supported on this device.");
-
-    auto BufOrErr = createBufferWithDeviceAddress(
-        Request.Sizes.ResultDataMaxSizeInBytes,
-        VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR);
-    if (!BufOrErr)
-      return BufOrErr.takeError();
-
-    VkAccelerationStructureCreateInfoKHR CreateInfo = {};
-    CreateInfo.sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_CREATE_INFO_KHR;
-    CreateInfo.buffer = BufOrErr->Buffer;
-    CreateInfo.size = Request.Sizes.ResultDataMaxSizeInBytes;
-    CreateInfo.type = VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR;
-
-    VkAccelerationStructureKHR AccelStruct = VK_NULL_HANDLE;
-    if (auto Err =
-            VK::toError(RT.CreateAS(Device, &CreateInfo, nullptr, &AccelStruct),
-                        "Failed to create TLAS.")) {
-      vkDestroyBuffer(Device, BufOrErr->Buffer, nullptr);
-      vkFreeMemory(Device, BufOrErr->Memory, nullptr);
-      return Err;
-    }
-
-    VkAccelerationStructureDeviceAddressInfoKHR AddrInfo = {};
-    AddrInfo.sType =
-        VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_DEVICE_ADDRESS_INFO_KHR;
-    AddrInfo.accelerationStructure = AccelStruct;
-    const VkDeviceAddress DevAddr = RT.GetDeviceAddress(Device, &AddrInfo);
-
-    return std::make_unique<VulkanAccelerationStructure>(
-        Device, AccelStruct, BufOrErr->Buffer, BufOrErr->Memory, DevAddr,
-        RT.DestroyAS);
+  createTLAS(const AccelerationStructureSizes &Sizes) override {
+    return allocateAS(Sizes, VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR,
+                      "TLAS");
   }
 
   llvm::Expected<BufferRef> createBuffer(VkBufferUsageFlags Usage,

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -428,14 +428,17 @@ public:
   VkDevice Dev; // Needed for clean-up
   VkBuffer Buffer;
   VkDeviceMemory Memory;
+  VkDeviceAddress DeviceAddress;
   std::string Name;
   BufferCreateDesc Desc;
   size_t SizeInBytes;
 
   VulkanBuffer(VkDevice Dev, VkBuffer Buffer, VkDeviceMemory Memory,
-               llvm::StringRef Name, BufferCreateDesc Desc, size_t SizeInBytes)
+               VkDeviceAddress DeviceAddress, llvm::StringRef Name,
+               BufferCreateDesc Desc, size_t SizeInBytes)
       : offloadtest::Buffer(GPUAPI::Vulkan), Dev(Dev), Buffer(Buffer),
-        Memory(Memory), Name(Name), Desc(Desc), SizeInBytes(SizeInBytes) {}
+        Memory(Memory), DeviceAddress(DeviceAddress), Name(Name), Desc(Desc),
+        SizeInBytes(SizeInBytes) {}
 
   size_t getSizeInBytes() const override { return SizeInBytes; }
 
@@ -466,6 +469,10 @@ public:
     vkDestroyBuffer(Dev, Buffer, nullptr);
     vkFreeMemory(Dev, Memory, nullptr);
   }
+
+  // Only valid when the buffer was created with VK_BUFFER_USAGE_SHADER_DEVICE_
+  // ADDRESS_BIT, which the device adds whenever ray tracing is supported.
+  VkDeviceAddress getDeviceAddress() const { return DeviceAddress; }
 
   static bool classof(const offloadtest::Buffer *B) {
     return B->getAPI() == GPUAPI::Vulkan;
@@ -624,10 +631,16 @@ public:
       override;
 };
 
+class VulkanDevice; // forward decl — defined below in this same anon ns
+
 class VulkanCommandBuffer : public offloadtest::CommandBuffer {
 public:
   VkDevice Device = VK_NULL_HANDLE;
   MeshShaderFunctions MeshShaderFns;
+  // Back-pointer to the owning device. Used by encoders that need access to
+  // device-loaded function pointers (e.g. ray-tracing entry points) and
+  // helper allocators.
+  VulkanDevice *Dev = nullptr;
   // Owned per command buffer so that recording, submission, and lifetime
   // management of each command buffer are independently safe without external
   // synchronization.
@@ -743,6 +756,11 @@ public:
     CmdInsertDebugUtilsLabel(CmdBuffer, &LabelInfo);
   }
 
+  /// Abstract-API Buffer wrappers (e.g. AS scratch and TLAS instance array
+  /// buffers) that must outlive submission. Held as unique_ptr so the wrapper
+  /// destructor frees both the VkBuffer and VkDeviceMemory.
+  llvm::SmallVector<std::unique_ptr<offloadtest::Buffer>> KeepAliveOwned;
+
   ~VulkanCommandBuffer() override {
     for (VkFramebuffer FB : OwnedFramebuffers)
       vkDestroyFramebuffer(Device, FB, nullptr);
@@ -845,6 +863,10 @@ public:
     vkCmdCopyBuffer(CB.CmdBuffer, VKSrc.Buffer, VKDst.Buffer, 1, &Region);
     return llvm::Error::success();
   }
+
+  // Defined out-of-line below — needs VulkanDevice's full type for access to
+  // the device-loaded ray-tracing entry points and helpers.
+  llvm::Error batchBuildAS(llvm::ArrayRef<ASBuildItem> Items) override;
 
   void endEncodingImpl() override { popDebugGroup(); }
 };
@@ -1130,6 +1152,10 @@ VulkanCommandBuffer::createRenderEncoder(
 }
 
 class VulkanDevice : public offloadtest::Device {
+  // VKComputeEncoder needs access to the device's RT entry points and the
+  // raw VkDevice handle to record acceleration-structure build commands.
+  friend class VKComputeEncoder;
+
 private:
   std::shared_ptr<VulkanInstance> Instance;
   VkPhysicalDevice PhysicalDevice = VK_NULL_HANDLE;
@@ -1157,6 +1183,7 @@ private:
     PFN_vkDestroyAccelerationStructureKHR DestroyAS = nullptr;
     PFN_vkGetAccelerationStructureBuildSizesKHR GetBuildSizes = nullptr;
     PFN_vkGetAccelerationStructureDeviceAddressKHR GetDeviceAddress = nullptr;
+    PFN_vkCmdBuildAccelerationStructuresKHR CmdBuild = nullptr;
   };
   RaytracingFunctions RT;
 
@@ -1238,6 +1265,12 @@ private:
     llvm::SmallVector<VkDescriptorSet> DescriptorSets;
     llvm::SmallVector<VkBufferView> BufferViews;
     llvm::SmallVector<VkImageView> ImageViews;
+
+    // Built acceleration structures, kept alive for the pipeline lifetime.
+    llvm::SmallVector<std::unique_ptr<offloadtest::AccelerationStructure>>
+        AccelStructs;
+    // Vertex/index buffers consumed during AS builds; must outlive submission.
+    llvm::SmallVector<std::unique_ptr<offloadtest::Buffer>> ASInputBuffers;
   };
 
 public:
@@ -1489,6 +1522,10 @@ public:
           reinterpret_cast<PFN_vkGetAccelerationStructureDeviceAddressKHR>(
               vkGetDeviceProcAddr(
                   Device, "vkGetAccelerationStructureDeviceAddressKHR"));
+      Dev->RT.CmdBuild =
+          reinterpret_cast<PFN_vkCmdBuildAccelerationStructuresKHR>(
+              vkGetDeviceProcAddr(Device,
+                                  "vkCmdBuildAccelerationStructuresKHR"));
     }
 
     return Dev;
@@ -2234,6 +2271,13 @@ public:
                        VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
       break;
     }
+    // When ray tracing is supported, every buffer is eligible to act as an
+    // acceleration-structure build input and to expose a device address. The
+    // shared AS build helper assumes Storage buffers carry these flags.
+    if (HasRayTracingSupport)
+      BufInfo.usage |=
+          VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT |
+          VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR;
     BufInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
 
     VkBuffer DeviceBuffer;
@@ -2245,8 +2289,14 @@ public:
     VkMemoryRequirements MemReqs;
     vkGetBufferMemoryRequirements(Device, DeviceBuffer, &MemReqs);
 
+    VkMemoryAllocateFlagsInfo AllocFlagsInfo = {};
+    AllocFlagsInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_FLAGS_INFO;
+    AllocFlagsInfo.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT;
+
     VkMemoryAllocateInfo AllocInfo = {};
     AllocInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+    if (HasRayTracingSupport)
+      AllocInfo.pNext = &AllocFlagsInfo;
     AllocInfo.allocationSize = MemReqs.size;
     auto MemIdx = getMemoryIndex(PhysicalDevice, MemReqs.memoryTypeBits,
                                  getVulkanMemoryFlags(Desc.Location));
@@ -2264,8 +2314,16 @@ public:
             "Failed to bind device buffer memory."))
       return Err;
 
+    VkDeviceAddress DevAddr = 0;
+    if (HasRayTracingSupport) {
+      VkBufferDeviceAddressInfo AddrInfo = {};
+      AddrInfo.sType = VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO;
+      AddrInfo.buffer = DeviceBuffer;
+      DevAddr = vkGetBufferDeviceAddress(Device, &AddrInfo);
+    }
+
     return std::make_unique<VulkanBuffer>(Device, DeviceBuffer, DeviceMemory,
-                                          Name, Desc, SizeInBytes);
+                                          DevAddr, Name, Desc, SizeInBytes);
   }
 
   llvm::Expected<std::unique_ptr<offloadtest::Texture>>
@@ -2486,9 +2544,13 @@ private:
 public:
   llvm::Expected<std::unique_ptr<offloadtest::CommandBuffer>>
   createCommandBuffer() override {
-    return VulkanCommandBuffer::create(
+    auto CBOrErr = VulkanCommandBuffer::create(
         Device, GraphicsQueue.QueueFamilyIdx, CmdBeginDebugUtilsLabel,
         CmdEndDebugUtilsLabel, CmdInsertDebugUtilsLabel, MeshShaderFns);
+    if (!CBOrErr)
+      return CBOrErr.takeError();
+    (*CBOrErr)->Dev = this;
+    return std::unique_ptr<offloadtest::CommandBuffer>(std::move(*CBOrErr));
   }
 
   llvm::Expected<std::unique_ptr<offloadtest::RenderPass>>
@@ -3908,7 +3970,18 @@ public:
     if (!CBOrErr)
       return CBOrErr.takeError();
     State.CB = std::move(*CBOrErr);
+    State.CB->Dev = this;
     llvm::outs() << "Command buffer created.\n";
+
+    if (!P.AccelStructs.BLAS.empty() || !P.AccelStructs.TLAS.empty()) {
+      auto EncOrErr = State.CB->createComputeEncoder();
+      if (!EncOrErr)
+        return EncOrErr.takeError();
+      if (auto Err = offloadtest::buildPipelineAccelerationStructures(
+              *this, **EncOrErr, P, State.AccelStructs, State.ASInputBuffers))
+        return Err;
+      (*EncOrErr)->endEncoding();
+    }
 
     if (auto Err = createResources(P, State))
       return Err;
@@ -4075,6 +4148,7 @@ public:
     if (!DispatchCBOrErr)
       return DispatchCBOrErr.takeError();
     State.CB = std::move(*DispatchCBOrErr);
+    State.CB->Dev = this;
     llvm::outs() << "Execute command buffer created.\n";
     if (auto Err = createDescriptorPool(P, State))
       return Err;
@@ -4098,6 +4172,191 @@ public:
     return llvm::Error::success();
   }
 };
+
+llvm::Error VKComputeEncoder::batchBuildAS(llvm::ArrayRef<ASBuildItem> Items) {
+  if (Items.empty())
+    return llvm::Error::success();
+  if (!CB.Dev || !CB.Dev->RT.CmdBuild)
+    return llvm::createStringError(
+        std::errc::not_supported,
+        "Ray tracing not supported on this command buffer's device.");
+  VulkanDevice *Dev = CB.Dev;
+
+  // Pre-call barrier: ensure prior writes complete before AS-build reads
+  // (vertex/index/instance input buffers and, for TLAS, sibling BLASes built
+  // in a previous batchBuildAS() call). Including the READ bit is what makes a
+  // back-to-back BLAS-then-TLAS sequence safe: the second call's barrier
+  // flushes AS-build-write from the first into AS-build-read.
+  addDstBarrier(VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR,
+                VK_ACCESS_ACCELERATION_STRUCTURE_WRITE_BIT_KHR |
+                    VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_KHR);
+
+  const size_t N = Items.size();
+  // Per-item arrays must outlive the RT.CmdBuild() call.
+  llvm::SmallVector<llvm::SmallVector<VkAccelerationStructureGeometryKHR>>
+      Geoms(N);
+  llvm::SmallVector<llvm::SmallVector<VkAccelerationStructureBuildRangeInfoKHR>>
+      Ranges(N);
+  llvm::SmallVector<VkAccelerationStructureBuildGeometryInfoKHR> BuildInfos(N);
+  llvm::SmallVector<const VkAccelerationStructureBuildRangeInfoKHR *> RangePtrs(
+      N);
+
+  for (size_t I = 0; I < N; ++I) {
+    const auto &Item = Items[I];
+
+    auto &BI = BuildInfos[I];
+    BI.sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_BUILD_GEOMETRY_INFO_KHR;
+    BI.mode = VK_BUILD_ACCELERATION_STRUCTURE_MODE_BUILD_KHR;
+
+    uint64_t ScratchSize = 0;
+    if (const auto *BLAS = llvm::dyn_cast<const BLASBuildRequest *>(Item)) {
+      auto *VkAS = llvm::cast<VulkanAccelerationStructure>(BLAS->AS);
+      BI.dstAccelerationStructure = VkAS->AccelStruct;
+      BI.type = VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR;
+
+      if (const auto *Tris =
+              std::get_if<llvm::SmallVector<TriangleGeometryDesc>>(
+                  &BLAS->Geometry)) {
+        Geoms[I].reserve(Tris->size());
+        Ranges[I].reserve(Tris->size());
+        for (const auto &T : *Tris) {
+          VkAccelerationStructureGeometryKHR G = {};
+          G.sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_KHR;
+          G.geometryType = VK_GEOMETRY_TYPE_TRIANGLES_KHR;
+          if (T.Opaque)
+            G.flags = VK_GEOMETRY_OPAQUE_BIT_KHR;
+          auto &Tri = G.geometry.triangles;
+          Tri.sType =
+              VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_TRIANGLES_DATA_KHR;
+          auto *VB = llvm::cast<VulkanBuffer>(T.VertexBuffer);
+          Tri.vertexFormat = getVulkanFormat(T.VertexFormat);
+          Tri.vertexData.deviceAddress =
+              VB->getDeviceAddress() + T.VertexBufferOffset;
+          Tri.vertexStride = T.VertexStride;
+          Tri.maxVertex = T.VertexCount - 1;
+          if (T.IndexBuffer) {
+            auto *IB = llvm::cast<VulkanBuffer>(T.IndexBuffer);
+            Tri.indexType = getVulkanIndexType(T.IdxFormat);
+            Tri.indexData.deviceAddress =
+                IB->getDeviceAddress() + T.IndexBufferOffset;
+          } else {
+            Tri.indexType = VK_INDEX_TYPE_NONE_KHR;
+          }
+          Geoms[I].push_back(G);
+
+          VkAccelerationStructureBuildRangeInfoKHR R = {};
+          R.primitiveCount =
+              T.IndexBuffer ? T.IndexCount / 3 : T.VertexCount / 3;
+          Ranges[I].push_back(R);
+        }
+      } else {
+        const auto &AABBs =
+            std::get<llvm::SmallVector<AABBGeometryDesc>>(BLAS->Geometry);
+        Geoms[I].reserve(AABBs.size());
+        Ranges[I].reserve(AABBs.size());
+        for (const auto &A : AABBs) {
+          VkAccelerationStructureGeometryKHR G = {};
+          G.sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_KHR;
+          G.geometryType = VK_GEOMETRY_TYPE_AABBS_KHR;
+          if (A.Opaque)
+            G.flags = VK_GEOMETRY_OPAQUE_BIT_KHR;
+          auto &Ab = G.geometry.aabbs;
+          Ab.sType =
+              VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_AABBS_DATA_KHR;
+          Ab.stride = A.AABBStride;
+          auto *AB = llvm::cast<VulkanBuffer>(A.AABBBuffer);
+          Ab.data.deviceAddress = AB->getDeviceAddress() + A.AABBBufferOffset;
+          Geoms[I].push_back(G);
+
+          VkAccelerationStructureBuildRangeInfoKHR R = {};
+          R.primitiveCount = A.AABBCount;
+          Ranges[I].push_back(R);
+        }
+      }
+
+      BI.geometryCount = Geoms[I].size();
+      BI.pGeometries = Geoms[I].data();
+      ScratchSize = BLAS->AS->getSizes().ScratchDataSizeInBytes;
+    } else {
+      const auto *TLAS = llvm::cast<const TLASBuildRequest *>(Item);
+      auto *VkAS = llvm::cast<VulkanAccelerationStructure>(TLAS->AS);
+      BI.dstAccelerationStructure = VkAS->AccelStruct;
+      BI.type = VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR;
+
+      // Serialize instances into the Vulkan-native struct.
+      llvm::SmallVector<VkAccelerationStructureInstanceKHR> Native;
+      Native.reserve(TLAS->Instances.size());
+      for (const auto &Inst : TLAS->Instances) {
+        VkAccelerationStructureInstanceKHR NI = {};
+        static_assert(sizeof(NI.transform.matrix) == sizeof(Inst.Transform),
+                      "Transform layout mismatch");
+        memcpy(&NI.transform.matrix, Inst.Transform, sizeof(Inst.Transform));
+        NI.instanceCustomIndex = Inst.InstanceID & 0xFFFFFFu;
+        NI.mask = Inst.InstanceMask;
+        NI.instanceShaderBindingTableRecordOffset = 0;
+        NI.flags = 0;
+        auto *BLASPtr = llvm::cast<VulkanAccelerationStructure>(Inst.BLAS);
+        NI.accelerationStructureReference = BLASPtr->getDeviceAddress();
+        Native.push_back(NI);
+      }
+      const size_t Bytes =
+          Native.size() * sizeof(VkAccelerationStructureInstanceKHR);
+
+      // Upload the instance array. Storage + CpuToGpu now carries device
+      // address and AS-build-input flags (because RT is supported).
+      const BufferCreateDesc Desc{MemoryLocation::CpuToGpu,
+                                  BufferUsage::Storage};
+      auto InstBufOrErr = offloadtest::createBufferWithData(
+          *Dev, "TLAS-Instances", Desc, Native.data(), Bytes, nullptr, nullptr);
+      if (!InstBufOrErr)
+        return InstBufOrErr.takeError();
+      auto *VkInstBuf = llvm::cast<VulkanBuffer>(InstBufOrErr->get());
+
+      VkAccelerationStructureGeometryKHR G = {};
+      G.sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_KHR;
+      G.geometryType = VK_GEOMETRY_TYPE_INSTANCES_KHR;
+      auto &Inst = G.geometry.instances;
+      Inst.sType =
+          VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_INSTANCES_DATA_KHR;
+      Inst.arrayOfPointers = VK_FALSE;
+      Inst.data.deviceAddress = VkInstBuf->getDeviceAddress();
+      Geoms[I].push_back(G);
+
+      VkAccelerationStructureBuildRangeInfoKHR R = {};
+      R.primitiveCount = static_cast<uint32_t>(TLAS->Instances.size());
+      Ranges[I].push_back(R);
+
+      BI.geometryCount = 1;
+      BI.pGeometries = Geoms[I].data();
+      ScratchSize = TLAS->AS->getSizes().ScratchDataSizeInBytes;
+
+      // Keep the instance buffer alive across submission.
+      CB.KeepAliveOwned.push_back(std::move(*InstBufOrErr));
+    }
+
+    // Allocate scratch (one per item; non-overlapping ranges as required).
+    // createBuffer() applies SHADER_DEVICE_ADDRESS + storage usage when ray
+    // tracing is supported, so we can re-use the same Buffer wrapper as the
+    // TLAS instance allocation and drop the raw-handle keep-alive bookkeeping.
+    const BufferCreateDesc ScratchDesc{MemoryLocation::GpuOnly,
+                                       BufferUsage::Storage};
+    auto ScratchOrErr =
+        Dev->createBuffer("AS-Scratch", ScratchDesc, ScratchSize);
+    if (!ScratchOrErr)
+      return ScratchOrErr.takeError();
+    auto *VkScratchBuf = llvm::cast<VulkanBuffer>(ScratchOrErr->get());
+    BI.scratchData.deviceAddress = VkScratchBuf->getDeviceAddress();
+    CB.KeepAliveOwned.push_back(std::move(*ScratchOrErr));
+
+    RangePtrs[I] = Ranges[I].data();
+  }
+
+  insertDebugSignpost(
+      llvm::formatv("BuildAccelerationStructures x{0}", N).str());
+  Dev->RT.CmdBuild(CB.CmdBuffer, static_cast<uint32_t>(N), BuildInfos.data(),
+                   RangePtrs.data());
+  return llvm::Error::success();
+}
 } // namespace
 
 llvm::Expected<offloadtest::SubmitResult> VulkanQueue::submit(


### PR DESCRIPTION
For https://github.com/llvm/offload-test-suite/issues/1158

This PR contains two stacked commits:

### `Refactor AS sizing/alloc into a Device::getXBuildSizes() + createBLAS()/createTLAS() API`

A build request now strictly describes build *inputs* — its `AccelerationStructureSizes` field moves out and is queried via a new sizing-only entry point on `Device`. Allocation no longer accepts a build request:

- `Expected<AccelerationStructureSizes> getBLASBuildSizes(triangles)`
- `Expected<AccelerationStructureSizes> getBLASBuildSizes(aabbs)`
- `Expected<AccelerationStructureSizes> getTLASBuildSizes(instanceCount)`
- `Expected<unique_ptr<AS>>             createBLAS(sizes)`
- `Expected<unique_ptr<AS>>             createTLAS(sizes)`

The old `createTriangleBLASBuildRequest()` / `createAABBBLASBuildRequest()` / `createTLASBuildRequest()` / `createAccelerationStructure(Request)` entry points are removed. The `AccelerationStructure` base class additionally stores the sizes it was allocated for and exposes `getSizes()` so the GPU build path can size its scratch buffer without re-querying. The per-backend `createBLAS()` / `createTLAS()` implementations fold the existing "create request + allocate" pair into one allocation step parameterised solely on `AccelerationStructureSizes`.

### `Add ComputeEncoder::batchBuildAS() and shared AS-build orchestration helper`

Move acceleration-structure build commands behind the abstract `ComputeEncoder` interface so the orchestration (data upload, AS allocation, build recording) can live in one place rather than splitting across three backends.

`ComputeEncoder` gains a single `batchBuildAS(ArrayRef<ASBuildItem>)` method. `BLASBuildRequest` / `TLASBuildRequest` each carry their own target `AS *` field (filled in by the caller after `Dev.createBLAS()` / `createTLAS()`); `ASBuildItem` collapses to a `PointerUnion<const BLASBuildRequest *, const TLASBuildRequest *>` alias, and backends size their scratch via `Req->AS->getSizes()` rather than reaching into the request for sizes or into a separate item struct for the target. The caller guarantees no inter-item memory dependencies inside a batch — backends record the whole batch with one barrier slot, no per-element barriers.

- **Vulkan**: single `vkCmdBuildAccelerationStructuresKHR()` call covering the whole batch. TLAS items serialize `VkAccelerationStructureInstanceKHR` into a device-address upload buffer; BLAS items pull addresses from each `VulkanBuffer` (new `getDeviceAddress()` accessor). Storage buffers transparently gain `SHADER_DEVICE_ADDRESS` + `ACCEL_BUILD_INPUT_READ_ONLY` flags when ray tracing is supported, with the matching `VkMemoryAllocateFlagsInfo` chained on every allocation.
- **DX12**: loop calling `BuildRaytracingAccelerationStructure()` per item with no intermediate barriers; `D3D12_RAYTRACING_INSTANCE_DESC` is bit-identical to the Vulkan instance struct.
- **Metal**: lazy transition to `MTL::AccelerationStructureCommandEncoder`, deduplicates BLAS handles into the `MTL::InstanceAccelerationStructureDescriptor`'s `instancedAccelerationStructures` array (Metal references BLASes by index, not GPU address).

A shared helper `buildPipelineAccelerationStructures()` in `lib/API/Device.cpp` walks `Pipeline::AccelStructs`, uploads vertex/index data via the new `createBufferWithData()`, queries sizes via `Dev.getBLASBuildSizes()` / `Dev.getTLASBuildSizes()`, allocates handles via `Dev.createBLAS()` / `Dev.createTLAS()`, and issues two `batchBuildAS()` calls (BLAS batch then TLAS batch — VUID-03403 forbids referencing a sibling `dstAccelerationStructure` in one command). Each backend's `executeProgram()` calls this helper to build the pipeline's AS objects.

Descriptor binding for AS resources is intentionally not in this PR — the existing InlineRT tests still fail at the descriptor-creation step (an unbound AS resource trips `createSRV()` / equivalents in each backend) and stay caught by their `XFAIL: *` annotation. #1245 wires the AS descriptor write and flips them green.
