### PR TITLE
Bind acceleration structures and enable the InlineRT tests

### DIFF
--- a/include/API/Device.h
+++ b/include/API/Device.h
@@ -25,6 +25,7 @@
 #include "Support/Pipeline.h"
 
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/iterator_range.h"
 #include "llvm/Support/Error.h"
@@ -323,23 +324,21 @@ createBufferWithData(Device &Dev, std::string Name,
                      size_t SizeInBytes, ComputeEncoder *Encoder,
                      std::unique_ptr<offloadtest::Buffer> *OutUploadBuffer);
 
-// Builds all BLAS / TLAS objects defined in `P.AccelStructs` using the
-// supplied compute encoder. Uploads each BLAS's vertex/index data, queries
-// sizes via `Dev.getBLASBuildSizes` / `Dev.getTLASBuildSizes`, allocates
-// the handles via `Dev.createBLAS` / `Dev.createTLAS`, and records the GPU
-// builds via two `Enc.batchBuildAS` calls (BLAS batch then TLAS batch — so
-// the AS-build-write barrier between BLAS and TLAS is automatic).
-//
-// Built AS objects are pushed to `OutAS` (in declaration order: BLASes first,
-// then TLASes). Vertex/index buffers used as build inputs are pushed to
-// `OutInputBuffers`; both must outlive command-buffer submission.
+// TLAS handles come in pre-allocated because the caller's binding loop
+// stamps the AS pointer into descriptor bundles before this helper runs;
+// BLAS handles are allocated inline since BLASes aren't user-bindable.
+// BLAS and TLAS builds get separate `Enc.batchBuildAS()` calls so the
+// implicit BLAS-write → TLAS-read barrier sits between them. Outputs
+// (`OutBLAS`, `OutInputBuffers`) must outlive command-buffer submission.
 //
 // TODO: `Pipeline` belongs to the test framework, not the rendering backend
 // API. This helper lives here only because `executeProgram` is still on
 // `Device` — once that moves out, this helper should follow.
 llvm::Error buildPipelineAccelerationStructures(
     Device &Dev, ComputeEncoder &Enc, Pipeline &P,
-    llvm::SmallVectorImpl<std::unique_ptr<AccelerationStructure>> &OutAS,
+    llvm::SmallVectorImpl<std::unique_ptr<AccelerationStructure>> &OutBLAS,
+    const llvm::StringMap<std::unique_ptr<AccelerationStructure>>
+        &PreallocatedTLASes,
     llvm::SmallVectorImpl<std::unique_ptr<Buffer>> &OutInputBuffers);
 
 } // namespace offloadtest

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -1078,21 +1078,26 @@ private:
     ComPtr<ID3D12Resource> Buffer;
     std::unique_ptr<offloadtest::Buffer> Readback;
     ComPtr<ID3D12Heap> Heap;
-    ResourceSet(ComPtr<ID3D12Resource> Upload, ComPtr<ID3D12Resource> Buffer,
-                std::unique_ptr<offloadtest::Buffer> Readback,
-                ComPtr<ID3D12Heap> Heap = nullptr)
+    // AS-only; mutually exclusive with the buffer/heap fields above.
+    DXAccelerationStructure *AS = nullptr;
+    explicit ResourceSet(ComPtr<ID3D12Resource> Upload,
+                         ComPtr<ID3D12Resource> Buffer,
+                         std::unique_ptr<offloadtest::Buffer> Readback,
+                         ComPtr<ID3D12Heap> Heap = nullptr)
         : Upload(Upload), Buffer(Buffer), Readback(std::move(Readback)),
           Heap(Heap) {}
+    explicit ResourceSet(DXAccelerationStructure *AS) : AS(AS) {}
     ResourceSet(const ResourceSet &) = delete;
     ResourceSet(ResourceSet &&A)
         : Upload(A.Upload), Buffer(A.Buffer), Readback(std::move(A.Readback)),
-          Heap(A.Heap) {}
+          Heap(A.Heap), AS(A.AS) {}
     ResourceSet &operator=(const ResourceSet &) = delete;
     ResourceSet &operator=(ResourceSet &&A) {
       Upload = A.Upload;
       Buffer = A.Buffer;
       Readback = std::move(A.Readback);
       Heap = A.Heap;
+      AS = A.AS;
       return *this;
     }
   };
@@ -1121,9 +1126,11 @@ private:
     llvm::SmallVector<DescriptorTable> DescTables;
     llvm::SmallVector<ResourcePair> RootResources;
 
-    // Built acceleration structures, kept alive for the pipeline lifetime.
+    // Parallel-indexed to `P.AccelStructs.BLAS`.
     llvm::SmallVector<std::unique_ptr<offloadtest::AccelerationStructure>>
-        AccelStructs;
+        BLASes;
+    // Keyed by `TLASDesc::Name`.
+    llvm::StringMap<std::unique_ptr<offloadtest::AccelerationStructure>> TLASes;
     // Vertex/index buffers consumed during AS builds; must outlive submission.
     llvm::SmallVector<std::unique_ptr<offloadtest::Buffer>> ASInputBuffers;
   };
@@ -2007,21 +2014,40 @@ public:
   // returns the next available HeapIdx
   uint32_t bindSRV(Resource &R, InvocationState &IS, uint32_t HeapIdx,
                    const ResourceBundle &ResBundle) {
-    const uint32_t EltSize = R.getElementSize();
-    const uint32_t NumElts = R.size() / EltSize;
-    const D3D12_SHADER_RESOURCE_VIEW_DESC SRVDesc = getSRVDescription(R);
     const uint32_t DescHandleIncSize = Device->GetDescriptorHandleIncrementSize(
         D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
     const D3D12_CPU_DESCRIPTOR_HANDLE SRVHandleHeapStart =
         IS.DescHeap->GetCPUDescriptorHandleForHeapStart();
 
-    for (const ResourceSet &RS : ResBundle) {
-      llvm::outs() << "SRV: HeapIdx = " << HeapIdx << " EltSize = " << EltSize
-                   << " NumElts = " << NumElts << "\n";
-      D3D12_CPU_DESCRIPTOR_HANDLE SRVHandle = SRVHandleHeapStart;
-      SRVHandle.ptr += HeapIdx * DescHandleIncSize;
-      Device->CreateShaderResourceView(RS.Buffer.Get(), &SRVDesc, SRVHandle);
-      HeapIdx++;
+    if (R.isAccelerationStructure()) {
+      // AS SRVs are created with a null resource; the AS lives in the
+      // buffer referenced by Location.
+      D3D12_SHADER_RESOURCE_VIEW_DESC SRVDesc = {};
+      SRVDesc.Format = DXGI_FORMAT_UNKNOWN;
+      SRVDesc.ViewDimension =
+          D3D12_SRV_DIMENSION_RAYTRACING_ACCELERATION_STRUCTURE;
+      SRVDesc.Shader4ComponentMapping =
+          D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+      for (const ResourceSet &RS : ResBundle) {
+        SRVDesc.RaytracingAccelerationStructure.Location =
+            RS.AS->getGPUVirtualAddress();
+        D3D12_CPU_DESCRIPTOR_HANDLE SRVHandle = SRVHandleHeapStart;
+        SRVHandle.ptr += HeapIdx * DescHandleIncSize;
+        Device->CreateShaderResourceView(nullptr, &SRVDesc, SRVHandle);
+        HeapIdx++;
+      }
+    } else {
+      const uint32_t EltSize = R.getElementSize();
+      const uint32_t NumElts = R.size() / EltSize;
+      const D3D12_SHADER_RESOURCE_VIEW_DESC SRVDesc = getSRVDescription(R);
+      for (const ResourceSet &RS : ResBundle) {
+        llvm::outs() << "SRV: HeapIdx = " << HeapIdx << " EltSize = " << EltSize
+                     << " NumElts = " << NumElts << "\n";
+        D3D12_CPU_DESCRIPTOR_HANDLE SRVHandle = SRVHandleHeapStart;
+        SRVHandle.ptr += HeapIdx * DescHandleIncSize;
+        Device->CreateShaderResourceView(RS.Buffer.Get(), &SRVDesc, SRVHandle);
+        HeapIdx++;
+      }
     }
     return HeapIdx;
   }
@@ -2228,11 +2254,35 @@ public:
     return HeapIdx;
   }
 
+  llvm::Expected<std::unique_ptr<AccelerationStructure>> createAS(Resource &R) {
+    assert(R.TLASPtr && "AS resource must be resolved to a TLAS");
+    assert(R.getArraySize() == 1 && "AS arrays not yet supported");
+    auto SizesOrErr =
+        getTLASBuildSizes(static_cast<uint32_t>(R.TLASPtr->Instances.size()));
+    if (!SizesOrErr)
+      return SizesOrErr.takeError();
+    return createTLAS(*SizesOrErr);
+  }
+
   llvm::Error createBuffers(Pipeline &P, InvocationState &IS) {
     auto CreateBuffer =
         [&IS,
          this](Resource &R,
                llvm::SmallVectorImpl<ResourcePair> &Resources) -> llvm::Error {
+      if (R.isAccelerationStructure()) {
+        auto ASOrErr = createAS(R);
+        if (!ASOrErr)
+          return ASOrErr.takeError();
+        ResourceBundle Bundle;
+        Bundle.emplace_back(
+            llvm::cast<DXAccelerationStructure>(ASOrErr->get()));
+        auto Inserted =
+            IS.TLASes.try_emplace(R.TLASPtr->Name, std::move(*ASOrErr));
+        assert(Inserted.second && "TLAS bound to multiple resources NYI");
+        (void)Inserted;
+        Resources.push_back(std::make_pair(&R, std::move(Bundle)));
+        return llvm::Error::success();
+      }
       switch (getDescriptorKind(R.Kind)) {
       case DescriptorKind::SRV: {
         auto ExRes = createSRV(R, IS);
@@ -2723,19 +2773,20 @@ public:
     State.CB->Dev = this;
     llvm::outs() << "Command buffer created.\n";
 
+    if (auto Err = createBuffers(P, State))
+      return Err;
+    llvm::outs() << "Buffers created.\n";
+
     if (!P.AccelStructs.BLAS.empty() || !P.AccelStructs.TLAS.empty()) {
       auto EncOrErr = State.CB->createComputeEncoder();
       if (!EncOrErr)
         return EncOrErr.takeError();
       if (auto Err = offloadtest::buildPipelineAccelerationStructures(
-              *this, **EncOrErr, P, State.AccelStructs, State.ASInputBuffers))
+              *this, **EncOrErr, P, State.BLASes, State.TLASes,
+              State.ASInputBuffers))
         return Err;
       (*EncOrErr)->endEncoding();
     }
-
-    if (auto Err = createBuffers(P, State))
-      return Err;
-    llvm::outs() << "Buffers created.\n";
 
     BindingsDesc BndDesc = {};
     for (auto &S : P.Sets) {

--- a/lib/API/Device.cpp
+++ b/lib/API/Device.cpp
@@ -97,7 +97,9 @@ offloadtest::createRenderTargetFromCPUBuffer(Device &Dev,
 
 llvm::Error offloadtest::buildPipelineAccelerationStructures(
     Device &Dev, ComputeEncoder &Enc, Pipeline &P,
-    llvm::SmallVectorImpl<std::unique_ptr<AccelerationStructure>> &OutAS,
+    llvm::SmallVectorImpl<std::unique_ptr<AccelerationStructure>> &OutBLAS,
+    const llvm::StringMap<std::unique_ptr<AccelerationStructure>>
+        &PreallocatedTLASes,
     llvm::SmallVectorImpl<std::unique_ptr<Buffer>> &OutInputBuffers) {
   if (P.AccelStructs.BLAS.empty() && P.AccelStructs.TLAS.empty())
     return llvm::Error::success();
@@ -113,7 +115,7 @@ llvm::Error offloadtest::buildPipelineAccelerationStructures(
   // them through pointers stored in ASBuildItem.
   llvm::SmallVector<BLASBuildRequest> BLASRequests;
   BLASRequests.reserve(P.AccelStructs.BLAS.size());
-  llvm::StringMap<size_t> BLASIndex;
+  llvm::StringMap<AccelerationStructure *> BLASesByName;
 
   for (const auto &BD : P.AccelStructs.BLAS) {
     llvm::SmallVector<TriangleGeometryDesc> Triangles;
@@ -161,8 +163,8 @@ llvm::Error offloadtest::buildPipelineAccelerationStructures(
     Req.AS = ASOrErr->get();
     Req.Geometry = std::move(Triangles);
 
-    BLASIndex[BD.Name] = OutAS.size();
-    OutAS.push_back(std::move(*ASOrErr));
+    BLASesByName[BD.Name] = ASOrErr->get();
+    OutBLAS.push_back(std::move(*ASOrErr));
     BLASRequests.push_back(std::move(Req));
   }
 
@@ -174,16 +176,20 @@ llvm::Error offloadtest::buildPipelineAccelerationStructures(
     if (auto Err = Enc.batchBuildAS(BLASBatch))
       return Err;
 
-  // TLAS pass — references BLASes built in the previous batch.
+  // Separate `batchBuildAS()` from the BLAS batch so the BLAS-write →
+  // TLAS-read barrier between them is implicit.
   llvm::SmallVector<TLASBuildRequest> TLASRequests;
-  TLASRequests.reserve(P.AccelStructs.TLAS.size());
-
-  for (const auto &TD : P.AccelStructs.TLAS) {
+  TLASRequests.reserve(PreallocatedTLASes.size());
+  for (const TLASDesc &TD : P.AccelStructs.TLAS) {
+    auto ASIt = PreallocatedTLASes.find(TD.Name);
+    if (ASIt == PreallocatedTLASes.end())
+      continue; // TLAS declared but not bound to any resource.
     TLASBuildRequest Req;
+    Req.AS = ASIt->second.get();
     Req.Instances.reserve(TD.Instances.size());
     for (const auto &I : TD.Instances) {
-      auto It = BLASIndex.find(I.BLAS);
-      if (It == BLASIndex.end())
+      auto It = BLASesByName.find(I.BLAS);
+      if (It == BLASesByName.end())
         return llvm::createStringError(std::errc::invalid_argument,
                                        "TLAS '%s' references unknown BLAS '%s'",
                                        TD.Name.c_str(), I.BLAS.c_str());
@@ -194,21 +200,11 @@ llvm::Error offloadtest::buildPipelineAccelerationStructures(
       memcpy(Inst.Transform, I.Transform, sizeof(I.Transform));
       Inst.InstanceID = I.InstanceID;
       Inst.InstanceMask = I.InstanceMask;
-      Inst.BLAS = OutAS[It->second].get();
+      Inst.BLAS = It->second;
       Req.Instances.push_back(Inst);
     }
     if (auto Err = validateTLASBuildRequest(Req))
       return Err;
-    auto SizesOrErr =
-        Dev.getTLASBuildSizes(static_cast<uint32_t>(Req.Instances.size()));
-    if (!SizesOrErr)
-      return SizesOrErr.takeError();
-    auto ASOrErr = Dev.createTLAS(*SizesOrErr);
-    if (!ASOrErr)
-      return ASOrErr.takeError();
-
-    Req.AS = ASOrErr->get();
-    OutAS.push_back(std::move(*ASOrErr));
     TLASRequests.push_back(std::move(Req));
   }
 

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -17,6 +17,9 @@
 #define IR_PRIVATE_IMPLEMENTATION
 #include "metal_irconverter.h"
 #include "metal_irconverter_runtime.h"
+// ir_raytracing.h depends on types defined in metal_irconverter_runtime.h —
+// keep this include in its own block so clang-format won't sort it above.
+#include "ir_raytracing.h"
 
 #include "API/Device.h"
 #include "API/Encoder.h"
@@ -924,7 +927,10 @@ class MTLDevice : public offloadtest::Device {
 
   struct ResourceSet {
     MTLPtr<MTL::Resource> Resource;
-    ResourceSet(MTL::Resource *Resource) : Resource(Resource) {}
+    // AS-only; mutually exclusive with Resource above.
+    MetalAccelerationStructure *AS = nullptr;
+    explicit ResourceSet(MTL::Resource *Resource) : Resource(Resource) {}
+    explicit ResourceSet(MetalAccelerationStructure *AS) : AS(AS) {}
   };
 
   // ResourceBundle will contain one ResourceSet for a singular resource
@@ -953,11 +959,15 @@ class MTLDevice : public offloadtest::Device {
     llvm::SmallVector<DescriptorTable> DescTables;
     // TODO: Support RootResources?
 
-    // Built acceleration structures, kept alive for the pipeline lifetime.
+    // Parallel-indexed to `P.AccelStructs.BLAS`.
     llvm::SmallVector<std::unique_ptr<offloadtest::AccelerationStructure>>
-        AccelStructs;
+        BLASes;
+    // Keyed by `TLASDesc::Name`.
+    llvm::StringMap<std::unique_ptr<offloadtest::AccelerationStructure>> TLASes;
     // Vertex/index buffers consumed during AS builds; must outlive submission.
     llvm::SmallVector<std::unique_ptr<offloadtest::Buffer>> ASInputBuffers;
+    // Per-AS header + contributions buffers; resident at dispatch.
+    llvm::SmallVector<std::unique_ptr<offloadtest::Buffer>> ASDescriptorBuffers;
   };
 
   llvm::Error createRootSignature(
@@ -1292,11 +1302,35 @@ class MTLDevice : public offloadtest::Device {
     return HeapIdx;
   }
 
+  llvm::Expected<std::unique_ptr<AccelerationStructure>> createAS(Resource &R) {
+    assert(R.TLASPtr && "AS resource must be resolved to a TLAS");
+    assert(R.getArraySize() == 1 && "AS arrays not yet supported");
+    auto SizesOrErr =
+        getTLASBuildSizes(static_cast<uint32_t>(R.TLASPtr->Instances.size()));
+    if (!SizesOrErr)
+      return SizesOrErr.takeError();
+    return createTLAS(*SizesOrErr);
+  }
+
   llvm::Error createBuffers(Pipeline &P, InvocationState &IS) {
     auto CreateBuffer =
         [&IS,
          this](Resource &R,
                llvm::SmallVectorImpl<ResourcePair> &Resources) -> llvm::Error {
+      if (R.isAccelerationStructure()) {
+        auto ASOrErr = createAS(R);
+        if (!ASOrErr)
+          return ASOrErr.takeError();
+        ResourceBundle Bundle;
+        Bundle.emplace_back(
+            llvm::cast<MetalAccelerationStructure>(ASOrErr->get()));
+        auto Inserted =
+            IS.TLASes.try_emplace(R.TLASPtr->Name, std::move(*ASOrErr));
+        assert(Inserted.second && "TLAS bound to multiple resources NYI");
+        (void)Inserted;
+        Resources.emplace_back(&R, std::move(Bundle));
+        return llvm::Error::success();
+      }
       switch (getDescriptorKind(R.Kind)) {
       case DescriptorKind::SRV: {
         auto ExRes = createSRV(R, IS);
@@ -1339,6 +1373,46 @@ class MTLDevice : public offloadtest::Device {
     uint32_t HeapIndex = 0;
     for (auto &T : IS.DescTables) {
       for (auto &R : T.Resources) {
+        if (MetalAccelerationStructure *MTLAS = R.second[0].AS) {
+          // The Metal shader converter binds the AS indirectly through an
+          // `IRRaytracingAccelerationStructureGPUHeader` buffer carrying the
+          // AS's `gpuResourceID` and a pointer to an instance-contributions
+          // array (one `uint32` per instance, equivalent to D3D12's
+          // `InstanceContributionToHitGroupIndex`).
+          const uint32_t InstCount =
+              static_cast<uint32_t>(R.first->TLASPtr->Instances.size());
+          llvm::SmallVector<uint32_t> Contributions(InstCount, 0);
+          const BufferCreateDesc Desc{MemoryLocation::GpuToCpu,
+                                      BufferUsage::Storage};
+          auto ContribBufOrErr = createBufferWithData(
+              *IS.CB->Dev, "AS-Contributions", Desc, Contributions.data(),
+              InstCount * sizeof(uint32_t), nullptr, nullptr);
+          if (!ContribBufOrErr)
+            return ContribBufOrErr.takeError();
+          auto *MTLContrib = llvm::cast<MTLBuffer>(ContribBufOrErr->get());
+          auto HeaderBufOrErr = IS.CB->Dev->createBuffer(
+              "AS-Header", Desc,
+              sizeof(IRRaytracingAccelerationStructureGPUHeader));
+          if (!HeaderBufOrErr)
+            return HeaderBufOrErr.takeError();
+          auto *MTLHeader = llvm::cast<MTLBuffer>(HeaderBufOrErr->get());
+          IRRaytracingSetAccelerationStructure(
+              static_cast<uint8_t *>(MTLHeader->Buf->contents()),
+              MTLAS->AccelStruct->gpuResourceID(),
+              static_cast<uint8_t *>(MTLContrib->Buf->contents()),
+              MTLContrib->Buf->gpuAddress(), Contributions.data(), InstCount);
+
+          IRDescriptorTableSetAccelerationStructure(
+              IS.DescHeap->getEntryHandle(HeapIndex),
+              MTLHeader->Buf->gpuAddress());
+
+          // The shader dereferences the contributions buffer through the
+          // header, so both must be resident at dispatch.
+          IS.ASDescriptorBuffers.push_back(std::move(*HeaderBufOrErr));
+          IS.ASDescriptorBuffers.push_back(std::move(*ContribBufOrErr));
+          HeapIndex += R.first->getArraySize();
+          continue;
+        }
         switch (getDescriptorKind(R.first->Kind)) {
         case DescriptorKind::SRV:
           HeapIndex = bindSRV(*(R.first), IS, HeapIndex, R.second);
@@ -1398,6 +1472,19 @@ class MTLDevice : public offloadtest::Device {
           NativeEncoder->useResource(ResSet.Resource.get(),
                                      MTL::ResourceUsageRead |
                                          MTL::ResourceUsageWrite);
+    auto MarkASResident =
+        [&](const std::unique_ptr<AccelerationStructure> &AS) {
+          auto *MTLAS = llvm::cast<MetalAccelerationStructure>(AS.get());
+          NativeEncoder->useResource(MTLAS->AccelStruct,
+                                     MTL::ResourceUsageRead);
+        };
+    for (auto &AS : IS.BLASes)
+      MarkASResident(AS);
+    for (auto &Entry : IS.TLASes)
+      MarkASResident(Entry.second);
+    for (auto &B : IS.ASDescriptorBuffers)
+      NativeEncoder->useResource(llvm::cast<MTLBuffer>(B.get())->Buf,
+                                 MTL::ResourceUsageRead);
 
     if (auto Err = Encoder.dispatch(*IS.Pipeline.get(),
                                     P.DispatchParameters.DispatchGroupCount[0],
@@ -2152,21 +2239,21 @@ public:
     IS.CB = std::move(*CBOrErr);
     IS.CB->Dev = this;
 
-    if (!P.AccelStructs.BLAS.empty() || !P.AccelStructs.TLAS.empty()) {
-      auto EncOrErr = IS.CB->createComputeEncoder();
-      if (!EncOrErr)
-        return EncOrErr.takeError();
-      if (auto Err = offloadtest::buildPipelineAccelerationStructures(
-              *this, **EncOrErr, P, IS.AccelStructs, IS.ASInputBuffers))
-        return Err;
-      (*EncOrErr)->endEncoding();
-    }
-
     if (auto Err = createDescriptorHeap(P, IS))
       return Err;
 
     if (auto Err = createBuffers(P, IS))
       return Err;
+
+    if (!P.AccelStructs.BLAS.empty() || !P.AccelStructs.TLAS.empty()) {
+      auto EncOrErr = IS.CB->createComputeEncoder();
+      if (!EncOrErr)
+        return EncOrErr.takeError();
+      if (auto Err = offloadtest::buildPipelineAccelerationStructures(
+              *this, **EncOrErr, P, IS.BLASes, IS.TLASes, IS.ASInputBuffers))
+        return Err;
+      (*EncOrErr)->endEncoding();
+    }
 
     BindingsDesc Bindings = {};
     for (auto &S : P.Sets) {
@@ -2413,11 +2500,12 @@ llvm::Error MTLComputeEncoder::batchBuildAS(llvm::ArrayRef<ASBuildItem> Items) {
 
       // Pack instance descriptors. Layout differs from VK/DX12: 32-byte
       // entries with an index instead of a GPU address.
-      llvm::SmallVector<MTL::AccelerationStructureInstanceDescriptor> Native;
+      llvm::SmallVector<MTL::AccelerationStructureUserIDInstanceDescriptor>
+          Native;
       Native.reserve(TLAS->Instances.size());
       for (size_t I = 0; I < TLAS->Instances.size(); ++I) {
         const auto &Src = TLAS->Instances[I];
-        MTL::AccelerationStructureInstanceDescriptor D = {};
+        MTL::AccelerationStructureUserIDInstanceDescriptor D = {};
         // Metal stores transform as packed 4x3 column-major; our high-level
         // Transform[3][4] is row-major. Transpose into Metal's layout.
         for (int Row = 0; Row < 3; ++Row)
@@ -2427,10 +2515,12 @@ llvm::Error MTLComputeEncoder::batchBuildAS(llvm::ArrayRef<ASBuildItem> Items) {
         D.mask = Src.InstanceMask;
         D.intersectionFunctionTableOffset = 0;
         D.accelerationStructureIndex = InstanceASIdx[I];
+        D.userID = Src.InstanceID;
         Native.push_back(D);
       }
       const size_t InstByteSize =
-          Native.size() * sizeof(MTL::AccelerationStructureInstanceDescriptor);
+          Native.size() *
+          sizeof(MTL::AccelerationStructureUserIDInstanceDescriptor);
 
       const BufferCreateDesc UploadDesc{MemoryLocation::CpuToGpu,
                                         BufferUsage::Storage};
@@ -2445,6 +2535,8 @@ llvm::Error MTLComputeEncoder::batchBuildAS(llvm::ArrayRef<ASBuildItem> Items) {
       auto *ID = MTL::InstanceAccelerationStructureDescriptor::alloc()->init();
       ID->setInstanceDescriptorBuffer(MTLInstBuf->Buf);
       ID->setInstanceCount(TLAS->Instances.size());
+      ID->setInstanceDescriptorType(
+          MTL::AccelerationStructureInstanceDescriptorTypeUserID);
       NS::Array *BLASArr = NS::Array::array(
           reinterpret_cast<NS::Object *const *>(UniqueBLASes.data()),
           UniqueBLASes.size());

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -838,8 +838,11 @@ public:
                        uint32_t GroupCountX, uint32_t GroupCountY,
                        uint32_t GroupCountZ) override {
     const auto &VKPSO = llvm::cast<VulkanPipelineState>(PSO);
+    // Include AS_READ so dispatches that issue RayQuery against a TLAS get a
+    // proper hand-off from the prior AS-build's AS_WRITE.
     addDstBarrier(VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
-                  VK_ACCESS_SHADER_WRITE_BIT | VK_ACCESS_SHADER_READ_BIT);
+                  VK_ACCESS_SHADER_WRITE_BIT | VK_ACCESS_SHADER_READ_BIT |
+                      VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_KHR);
     insertDebugSignpost(llvm::formatv("Dispatch [{0},{1},{2}]", GroupCountX,
                                       GroupCountY, GroupCountZ)
                             .str());
@@ -1199,12 +1202,15 @@ private:
   };
 
   struct ResourceRef {
-    ResourceRef(BufferRef H, BufferRef D) : Host(H), Device(D) {}
-    ResourceRef(BufferRef H, ImageRef I) : Host(H), Image(I) {}
+    explicit ResourceRef(BufferRef H, BufferRef D) : Host(H), Device(D) {}
+    explicit ResourceRef(BufferRef H, ImageRef I) : Host(H), Image(I) {}
+    explicit ResourceRef(VulkanAccelerationStructure *AS) : AS(AS) {}
 
-    BufferRef Host;
-    BufferRef Device;
-    ImageRef Image;
+    BufferRef Host{};
+    BufferRef Device{};
+    ImageRef Image{};
+    // AS-only; mutually exclusive with the buffer/image fields above.
+    VulkanAccelerationStructure *AS = nullptr;
   };
 
   struct ResourceBundle {
@@ -1220,6 +1226,10 @@ private:
 
     bool isSampler() const {
       return DescriptorType == VK_DESCRIPTOR_TYPE_SAMPLER;
+    }
+
+    bool isAccelerationStructure() const {
+      return DescriptorType == VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR;
     }
 
     bool isBuffer() const {
@@ -1266,9 +1276,11 @@ private:
     llvm::SmallVector<VkBufferView> BufferViews;
     llvm::SmallVector<VkImageView> ImageViews;
 
-    // Built acceleration structures, kept alive for the pipeline lifetime.
+    // Parallel-indexed to `P.AccelStructs.BLAS`.
     llvm::SmallVector<std::unique_ptr<offloadtest::AccelerationStructure>>
-        AccelStructs;
+        BLASes;
+    // Keyed by `TLASDesc::Name`.
+    llvm::StringMap<std::unique_ptr<offloadtest::AccelerationStructure>> TLASes;
     // Vertex/index buffers consumed during AS builds; must outlive submission.
     llvm::SmallVector<std::unique_ptr<offloadtest::Buffer>> ASInputBuffers;
   };
@@ -1391,12 +1403,16 @@ public:
         (HasVulkan12 ||
          isExtensionSupported(AvailableDeviceExtensions,
                               VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME));
+    const bool HasRayQueryExt =
+        HasASExts && isExtensionSupported(AvailableDeviceExtensions,
+                                          VK_KHR_RAY_QUERY_EXTENSION_NAME);
 
     VkPhysicalDeviceAccelerationStructureFeaturesKHR ASFeatures{};
     // On Vulkan 1.1 we need a separate BDA features struct; on 1.2+
     // bufferDeviceAddress lives in VkPhysicalDeviceVulkan12Features which is
     // already in the chain, and adding a duplicate is a validation error.
     VkPhysicalDeviceBufferDeviceAddressFeatures BDAFeatures{};
+    VkPhysicalDeviceRayQueryFeaturesKHR RayQueryFeatures{};
     if (HasASExts) {
       ASFeatures.sType =
           VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR;
@@ -1407,6 +1423,12 @@ public:
             VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES;
         BDAFeatures.pNext = Features.pNext;
         Features.pNext = &BDAFeatures;
+      }
+      if (HasRayQueryExt) {
+        RayQueryFeatures.sType =
+            VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_QUERY_FEATURES_KHR;
+        RayQueryFeatures.pNext = Features.pNext;
+        Features.pNext = &RayQueryFeatures;
       }
     }
 
@@ -1480,6 +1502,14 @@ public:
       if (!HasVulkan12)
         EnabledDeviceExtensions.push_back(
             VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
+      if (HasRayQueryExt) {
+        if (!RayQueryFeatures.rayQuery)
+          return llvm::createStringError(
+              std::errc::not_supported,
+              "Device advertises %s but reports rayQuery=0",
+              VK_KHR_RAY_QUERY_EXTENSION_NAME);
+        EnabledDeviceExtensions.push_back(VK_KHR_RAY_QUERY_EXTENSION_NAME);
+      }
     }
 
     DeviceInfo.enabledExtensionCount =
@@ -2755,7 +2785,6 @@ private:
       vkFreeMemory(Device, BufOrErr->Memory, nullptr);
       return Err;
     }
-
     VkAccelerationStructureDeviceAddressInfoKHR AddrInfo = {};
     AddrInfo.sType =
         VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_DEVICE_ADDRESS_INFO_KHR;
@@ -2958,6 +2987,16 @@ public:
     return ResourceRef(Host, ImageRef{0, Sampler, 0});
   }
 
+  llvm::Expected<std::unique_ptr<AccelerationStructure>> createAS(Resource &R) {
+    assert(R.TLASPtr && "AS resource must be resolved to a TLAS");
+    assert(R.getArraySize() == 1 && "AS arrays not yet supported");
+    auto SizesOrErr =
+        getTLASBuildSizes(static_cast<uint32_t>(R.TLASPtr->Instances.size()));
+    if (!SizesOrErr)
+      return SizesOrErr.takeError();
+    return createTLAS(*SizesOrErr);
+  }
+
   llvm::Error createResource(Resource &R, InvocationState &IS) {
     // Samplers don't have backing data buffers, so handle them separately
     if (R.isSampler()) {
@@ -3074,6 +3113,20 @@ public:
   llvm::Error createResources(Pipeline &P, InvocationState &IS) {
     for (auto &D : P.Sets) {
       for (auto &R : D.Resources) {
+        if (R.isAccelerationStructure()) {
+          auto ASOrErr = createAS(R);
+          if (!ASOrErr)
+            return ASOrErr.takeError();
+          auto *VkAS = llvm::cast<VulkanAccelerationStructure>(ASOrErr->get());
+          ResourceBundle Bundle{getDescriptorType(R.Kind), 0, nullptr};
+          Bundle.ResourceRefs.push_back(ResourceRef{VkAS});
+          IS.Resources.push_back(std::move(Bundle));
+          auto Inserted =
+              IS.TLASes.try_emplace(R.TLASPtr->Name, std::move(*ASOrErr));
+          assert(Inserted.second && "TLAS bound to multiple resources NYI");
+          (void)Inserted;
+          continue;
+        }
         if (auto Err = createResource(R, IS))
           return Err;
       }
@@ -3120,8 +3173,15 @@ public:
     constexpr size_t DescriptorTypesSize =
         sizeof(DescriptorTypes) / sizeof(VkDescriptorType);
     uint32_t DescriptorCounts[DescriptorTypesSize] = {0};
+    // VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR has an out-of-range enum
+    // value (1000150000), so it can't share the indexed array above.
+    uint32_t ASDescriptorCount = 0;
     for (const auto &S : P.Sets) {
       for (const auto &R : S.Resources) {
+        if (R.isAccelerationStructure()) {
+          ASDescriptorCount += R.getArraySize();
+          continue;
+        }
         DescriptorCounts[getDescriptorType(R.Kind)] += R.getArraySize();
         if (R.HasCounter)
           DescriptorCounts[VK_DESCRIPTOR_TYPE_STORAGE_BUFFER] +=
@@ -3138,6 +3198,12 @@ public:
         PoolSize.descriptorCount = DescriptorCounts[Type];
         PoolSizes.push_back(PoolSize);
       }
+    }
+    if (ASDescriptorCount > 0) {
+      llvm::outs() << "Descriptors: { type = ACCELERATION_STRUCTURE_KHR"
+                   << ", count = " << ASDescriptorCount << " }\n";
+      PoolSizes.push_back(
+          {VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR, ASDescriptorCount});
     }
 
     if (P.Sets.size() > 0) {
@@ -3182,8 +3248,15 @@ public:
     uint32_t ImageInfoCount = 0;
     uint32_t BufferInfoCount = 0;
     uint32_t BufferViewCount = 0;
+    uint32_t ASInfoCount = 0;
+    uint32_t ASHandleCount = 0;
     for (auto &D : P.Sets) {
       for (auto &R : D.Resources) {
+        if (R.isAccelerationStructure()) {
+          ASInfoCount += 1;
+          ASHandleCount += R.getArraySize();
+          continue;
+        }
         if (R.isSampler()) {
           ImageInfoCount += 1;
           continue;
@@ -3205,13 +3278,17 @@ public:
     llvm::SmallVector<VkDescriptorImageInfo> ImageInfos;
     llvm::SmallVector<VkDescriptorBufferInfo> BufferInfos;
     llvm::SmallVector<VkBufferView> BufferViews;
+    llvm::SmallVector<VkWriteDescriptorSetAccelerationStructureKHR> ASInfos;
+    llvm::SmallVector<VkAccelerationStructureKHR> ASHandles;
     ImageInfos.reserve(ImageInfoCount);
     BufferInfos.reserve(BufferInfoCount);
     BufferViews.reserve(BufferViewCount);
+    ASInfos.reserve(ASInfoCount);
+    ASHandles.reserve(ASHandleCount);
 
     llvm::SmallVector<VkWriteDescriptorSet> WriteDescriptors;
     WriteDescriptors.reserve(ImageInfoCount + BufferInfoCount +
-                             BufferViewCount);
+                             BufferViewCount + ASInfoCount);
     assert(IS.BufferViews.empty());
 
     uint32_t OverallResIdx = 0;
@@ -3219,6 +3296,29 @@ public:
       for (uint32_t RIdx = 0; RIdx < P.Sets[SetIdx].Resources.size();
            ++RIdx, ++OverallResIdx) {
         const Resource &R = P.Sets[SetIdx].Resources[RIdx];
+        if (VulkanAccelerationStructure *VkAS =
+                IS.Resources[OverallResIdx].ResourceRefs[0].AS) {
+          const size_t HandleStart = ASHandles.size();
+          ASHandles.push_back(VkAS->AccelStruct);
+          VkWriteDescriptorSetAccelerationStructureKHR ASWrite = {};
+          ASWrite.sType =
+              VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET_ACCELERATION_STRUCTURE_KHR;
+          ASWrite.accelerationStructureCount = 1;
+          ASWrite.pAccelerationStructures = &ASHandles[HandleStart];
+          ASInfos.push_back(ASWrite);
+
+          VkWriteDescriptorSet WDS = {};
+          WDS.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+          WDS.pNext = &ASInfos.back();
+          WDS.dstSet = IS.DescriptorSets[SetIdx];
+          WDS.dstBinding = R.VKBinding->Binding;
+          WDS.descriptorCount = 1;
+          WDS.descriptorType = VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR;
+          llvm::outs() << "Updating AS Descriptor [" << OverallResIdx << "] { "
+                       << SetIdx << ", " << RIdx << " }\n";
+          WriteDescriptors.push_back(WDS);
+          continue;
+        }
         uint32_t IndexOfFirstBufferDataInArray;
         if (R.isSampler()) {
           IndexOfFirstBufferDataInArray = ImageInfos.size();
@@ -3492,7 +3592,7 @@ public:
   }
 
   void copyResourceDataToDevice(InvocationState &IS, ResourceBundle &R) {
-    if (R.isSampler())
+    if (R.isSampler() || R.isAccelerationStructure())
       return;
     if (R.isImage()) {
       const offloadtest::CPUBuffer &B = *R.BufferPtr;
@@ -3923,6 +4023,9 @@ public:
       vkDestroyImageView(Device, V, nullptr);
 
     for (auto &R : IS.Resources) {
+      // AS resources are owned by `IS.TLASes`; ResourceRef.AS is non-owning.
+      if (R.isAccelerationStructure())
+        continue;
       for (auto &ResRef : R.ResourceRefs) {
         if (R.isBuffer()) {
           vkDestroyBuffer(Device, ResRef.Device.Buffer, nullptr);
@@ -3973,18 +4076,19 @@ public:
     State.CB->Dev = this;
     llvm::outs() << "Command buffer created.\n";
 
+    if (auto Err = createResources(P, State))
+      return Err;
+
     if (!P.AccelStructs.BLAS.empty() || !P.AccelStructs.TLAS.empty()) {
       auto EncOrErr = State.CB->createComputeEncoder();
       if (!EncOrErr)
         return EncOrErr.takeError();
       if (auto Err = offloadtest::buildPipelineAccelerationStructures(
-              *this, **EncOrErr, P, State.AccelStructs, State.ASInputBuffers))
+              *this, **EncOrErr, P, State.BLASes, State.TLASes,
+              State.ASInputBuffers))
         return Err;
       (*EncOrErr)->endEncoding();
     }
-
-    if (auto Err = createResources(P, State))
-      return Err;
 
     BindingsDesc BindingsDesc = {};
     for (auto &S : P.Sets) {

--- a/test/Feature/InlineRT/indexed-triangle-setup.test
+++ b/test/Feature/InlineRT/indexed-triangle-setup.test
@@ -1,12 +1,19 @@
 #--- source.hlsl
 
-RaytracingAccelerationStructure Scene : register(t0);
-RWStructuredBuffer<uint> Output : register(u0);
+[[vk::binding(0, 0)]] RaytracingAccelerationStructure Scene : register(t0);
+[[vk::binding(1, 0)]] RWStructuredBuffer<uint> Output : register(u0);
 
 [numthreads(1,1,1)]
 void main() {
-  // Placeholder: will use TraceRayInline when available
-  Output[0] = 1;
+  RayDesc Ray;
+  Ray.Origin = float3(0, 0, 1);
+  Ray.Direction = float3(0, 0, -1);
+  Ray.TMin = 0.0;
+  Ray.TMax = 100.0;
+  RayQuery<RAY_FLAG_NONE> Q;
+  Q.TraceRayInline(Scene, RAY_FLAG_NONE, 0xFF, Ray);
+  Q.Proceed();
+  Output[0] = Q.CommittedStatus() == COMMITTED_TRIANGLE_HIT ? 1 : 0;
 }
 //--- pipeline.yaml
 ---
@@ -75,9 +82,6 @@ Results:
 
 # REQUIRES: acceleration-structure
 # XFAIL: Clang
-
-# Unimplemented: https://github.com/llvm/offload-test-suite/issues/1158
-# XFAIL: *
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/InlineRT/multi-instance.test
+++ b/test/Feature/InlineRT/multi-instance.test
@@ -1,12 +1,22 @@
 #--- source.hlsl
 
-RaytracingAccelerationStructure Scene : register(t0);
-RWStructuredBuffer<uint> Output : register(u0);
+[[vk::binding(0, 0)]] RaytracingAccelerationStructure Scene : register(t0);
+[[vk::binding(1, 0)]] RWStructuredBuffer<uint> Output : register(u0);
 
 [numthreads(1,1,1)]
 void main() {
-  // Placeholder: will use TraceRayInline when available
-  Output[0] = 1;
+  // Aim at the instance translated to x=5; expect InstanceID 1.
+  RayDesc Ray;
+  Ray.Origin = float3(5, 0, 1);
+  Ray.Direction = float3(0, 0, -1);
+  Ray.TMin = 0.0;
+  Ray.TMax = 100.0;
+  RayQuery<RAY_FLAG_NONE> Q;
+  Q.TraceRayInline(Scene, RAY_FLAG_NONE, 0xFF, Ray);
+  Q.Proceed();
+  Output[0] = Q.CommittedStatus() == COMMITTED_TRIANGLE_HIT
+                  ? Q.CommittedInstanceID()
+                  : 0xFFFFFFFF;
 }
 //--- pipeline.yaml
 ---
@@ -72,9 +82,6 @@ Results:
 
 # REQUIRES: acceleration-structure
 # XFAIL: Clang
-
-# Unimplemented: https://github.com/llvm/offload-test-suite/issues/1158
-# XFAIL: *
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/InlineRT/triangle-setup.test
+++ b/test/Feature/InlineRT/triangle-setup.test
@@ -1,12 +1,19 @@
 #--- source.hlsl
 
-RaytracingAccelerationStructure Scene : register(t0);
-RWStructuredBuffer<uint> Output : register(u0);
+[[vk::binding(0, 0)]] RaytracingAccelerationStructure Scene : register(t0);
+[[vk::binding(1, 0)]] RWStructuredBuffer<uint> Output : register(u0);
 
 [numthreads(1,1,1)]
 void main() {
-  // Placeholder: will use TraceRayInline when available
-  Output[0] = 1;
+  RayDesc Ray;
+  Ray.Origin = float3(0, 0, 1);
+  Ray.Direction = float3(0, 0, -1);
+  Ray.TMin = 0.0;
+  Ray.TMax = 100.0;
+  RayQuery<RAY_FLAG_NONE> Q;
+  Q.TraceRayInline(Scene, RAY_FLAG_NONE, 0xFF, Ray);
+  Q.Proceed();
+  Output[0] = Q.CommittedStatus() == COMMITTED_TRIANGLE_HIT ? 1 : 0;
 }
 //--- pipeline.yaml
 ---
@@ -64,9 +71,6 @@ Results:
 
 # REQUIRES: acceleration-structure
 # XFAIL: Clang
-
-# Unimplemented: https://github.com/llvm/offload-test-suite/issues/1158
-# XFAIL: *
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl


### PR DESCRIPTION
Closes https://github.com/llvm/offload-test-suite/issues/1158 🥳

## Summary
Wire up acceleration-structure descriptor binding end-to-end across all three backends so shaders can actually consume the TLAS that `buildPipelineAccelerationStructures()` produced — completing the stack and promoting the three InlineRT tests from XFAIL to passing.

Per-resource AS handling lands in a new per-backend `createAS()` (paired with `createSRV()` / `createUAV()` / `createCBV()`): a pure single-create that queries TLAS sizes via `Dev.getTLASBuildSizes()` and allocates the handle via `Dev.createTLAS()`, returning the `unique_ptr` to the caller. No `InvocationState` or `Pipeline` access — the multi-create (`createBuffers()` / `createResources()`) records the handle in `InvocationState::TLASes` (a `StringMap` keyed by `TLASDesc::Name`) and wires a non-owning AS pointer into the per-resource bundle the binding loop reads. The shared AS-build helper picks up that map and walks `P.AccelStructs.TLAS` to pair each YAML descriptor with its pre-allocated handle by name (TLASes without a map entry are skipped, i.e. declared but unbound). BLAS handles are still allocated by the helper itself since BLASes aren't user-bindable.

`executeProgram()` in each backend now runs as:

- `createBuffers` / `createResources` (`createAS()` allocates TLAS handles)
- open encoder → `buildPipelineAccelerationStructures()` → end

- **Vulkan**: `createDescriptorPool()` counts AS descriptors in a separate scalar (the KHR enum value `1000150000` doesn't fit in the indexed array used for the core types) and emits one `VkDescriptorPoolSize` for them. `createDescriptorSets()` reads the resolved `VulkanAccelerationStructure` handle from `ResourceRef.AS` (populated by `createResources()`) and writes it through a `VkWriteDescriptorSetAccelerationStructureKHR` chained on the descriptor write's `pNext`. The dispatch's pre-barrier dst access now includes `VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_KHR` so the prior AS-build's writes are visible to the shader's RayQuery reads. Device creation enables `VK_KHR_ray_query` using the same chain-pre-query + error-on-flag-mismatch pattern that #1232 set up for the AS / BDA extensions — without `VK_KHR_ray_query` enabled the shader's `OpRayQueryProceedKHR` instructions silently no-op and `Output` reads back zero. `copyResourceDataToDevice()` short-circuits AS bundles via a new `ResourceBundle::isAccelerationStructure()` predicate (no host buffer to barrier).
- **DX12**: writes a `D3D12_SRV_DIMENSION_RAYTRACING_ACCELERATION_STRUCTURE` SRV with the AS GPU virtual address as `Location` into the heap slot that `createBuffers()` reserved (`CreateShaderResourceView()` with a null resource — the AS data lives in the buffer pointed to by `Location`).
- **Metal**: the Metal shader converter doesn't bind the AS directly; the shader reads a buffer containing an `IRRaytracingAccelerationStructureGPUHeader` that holds the AS's `gpuResourceID` plus a pointer to an instance-contributions array. `createBuffers()` allocates and fills both buffers per AS-descriptor entry, then points the descriptor at the header buffer's GPU address. The TLAS itself is built with the `UserID` instance-descriptor variant so HLSL `CommittedInstanceID()` returns the YAML-specified per-instance ID instead of the array index.

The three InlineRT tests now actually exercise the AS end-to-end: `TraceRayInline()` issues a RayQuery against `Scene` and writes a hit-dependent value into `Output` (the instance ID for `multi-instance`, 1/0 otherwise). The catch-all `XFAIL: *` is dropped; `XFAIL: Clang` remains. The test shaders also gain explicit `[[vk::binding]]` annotations because dxc's default HLSL→SPIR-V binding mapping collides `Scene`'s `t0` with `Output`'s `u0` at binding 0, which VVL flags as a descriptor type mismatch.

## Test plan

Local on an NVIDIA RTX 3060:
- [x] Linux Vulkan (native `offloader`)
- [ ] Linux D3D12 (Wine + vkd3d-proton + cross-compiled `offloader.exe`)
- [ ] Windows Vulkan (native `offloader.exe`)
- [ ] Windows D3D12 (native `offloader.exe`)

CI (RT-capable runners):
- [ ] windows-nvidia D3D12 (`RaytracingTier 1.2`)
- [ ] windows-intel VK (`VK_KHR_ray_tracing_pipeline`)
- [ ] macOS Metal (`supportsRaytracing`)