### PR TITLE
Remove XFAIL for mat_cbuffer-swizzle.f32.test

### DIFF
--- a/test/Feature/CBuffer/Matrix/SingleSubscript/mat_cbuffer-swizzle.f32.test
+++ b/test/Feature/CBuffer/Matrix/SingleSubscript/mat_cbuffer-swizzle.f32.test
@@ -168,9 +168,6 @@ DescriptorSets:
       VulkanBinding:
         Binding: 7
 
-# BUG https://github.com/llvm/llvm-project/issues/191070
-# XFAIL: Clang && Vulkan
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -fvk-use-dx-layout -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
The XFAIL here seemed to be for the wrong issue, as this was actually failing SPIR-V validation like so:
```
error: line 276: Reached non-composite type while indexes still remain
                 to be traversed.
  %186 = OpCompositeInsert %float %185 %81 0
```

This is no longer occuring after llvm/llvm-project#198330, so it looks like this has been fixed.