### PR TITLE
Remove QuadReadAcross* XFails on intel machine

### DIFF
--- a/test/WaveOps/QuadReadAcrossDiagonal.32.test
+++ b/test/WaveOps/QuadReadAcrossDiagonal.32.test
@@ -340,9 +340,6 @@ DescriptorSets:
 # waiting on https://github.com/llvm/llvm-project/pull/187440 to be merged, so I can open a PR for it
 # XFAIL: Clang
 
-# Bug: https://github.com/llvm/offload-test-suite/issues/986
-# XFAIL: Intel && Vulkan && DXC
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o 

--- a/test/WaveOps/QuadReadAcrossDiagonal.convergence.test
+++ b/test/WaveOps/QuadReadAcrossDiagonal.convergence.test
@@ -66,9 +66,6 @@ DescriptorSets:
 # waiting on https://github.com/llvm/llvm-project/pull/187440 to be merged, so I can open a PR for it
 # XFAIL: Clang
 
-# Bug: https://github.com/llvm/offload-test-suite/issues/986
-# XFAIL: Intel && Vulkan && DXC
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/WaveOps/QuadReadAcrossDiagonal.fp16.test
+++ b/test/WaveOps/QuadReadAcrossDiagonal.fp16.test
@@ -128,9 +128,6 @@ DescriptorSets:
 # waiting on https://github.com/llvm/llvm-project/pull/187440 to be merged, so I can open a PR for it
 # XFAIL: Clang
 
-# Bug: https://github.com/llvm/offload-test-suite/issues/986
-# XFAIL: Intel && Vulkan && DXC
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/WaveOps/QuadReadAcrossDiagonal.fp64.test
+++ b/test/WaveOps/QuadReadAcrossDiagonal.fp64.test
@@ -128,9 +128,6 @@ DescriptorSets:
 # waiting on https://github.com/llvm/llvm-project/pull/187440 to be merged, so I can open a PR for it
 # XFAIL: Clang
 
-# Bug: https://github.com/llvm/offload-test-suite/issues/986
-# XFAIL: Intel && Vulkan && DXC
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/WaveOps/QuadReadAcrossDiagonal.int16.test
+++ b/test/WaveOps/QuadReadAcrossDiagonal.int16.test
@@ -236,9 +236,6 @@ DescriptorSets:
 # waiting on https://github.com/llvm/llvm-project/pull/187440 to be merged, so I can open a PR for it
 # XFAIL: Clang
 
-# Bug: https://github.com/llvm/offload-test-suite/issues/986
-# XFAIL: Intel && Vulkan && DXC
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/WaveOps/QuadReadAcrossDiagonal.int64.test
+++ b/test/WaveOps/QuadReadAcrossDiagonal.int64.test
@@ -236,9 +236,6 @@ DescriptorSets:
 # waiting on https://github.com/llvm/llvm-project/pull/187440 to be merged, so I can open a PR for it
 # XFAIL: Clang
 
-# Bug: https://github.com/llvm/offload-test-suite/issues/986
-# XFAIL: Intel && Vulkan && DXC
-
 # Bug: https://github.com/llvm/offload-test-suite/issues/988
 # XFAIL: Metal
 

--- a/test/WaveOps/QuadReadAcrossX.32.test
+++ b/test/WaveOps/QuadReadAcrossX.32.test
@@ -336,9 +336,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug: https://github.com/llvm/offload-test-suite/issues/986
-# XFAIL: Intel && Vulkan && DXC
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o 

--- a/test/WaveOps/QuadReadAcrossX.convergence.test
+++ b/test/WaveOps/QuadReadAcrossX.convergence.test
@@ -62,9 +62,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug: https://github.com/llvm/offload-test-suite/issues/986
-# XFAIL: Intel && Vulkan && DXC
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/WaveOps/QuadReadAcrossX.fp16.test
+++ b/test/WaveOps/QuadReadAcrossX.fp16.test
@@ -124,9 +124,6 @@ DescriptorSets:
 
 # REQUIRES: Half
 
-# Bug: https://github.com/llvm/offload-test-suite/issues/986
-# XFAIL: Intel && Vulkan && DXC
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/WaveOps/QuadReadAcrossX.fp64.test
+++ b/test/WaveOps/QuadReadAcrossX.fp64.test
@@ -124,9 +124,6 @@ DescriptorSets:
 
 # REQUIRES: Double
 
-# Bug: https://github.com/llvm/offload-test-suite/issues/986
-# XFAIL: Intel && Vulkan && DXC
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/WaveOps/QuadReadAcrossX.int16.test
+++ b/test/WaveOps/QuadReadAcrossX.int16.test
@@ -232,9 +232,6 @@ DescriptorSets:
 
 # REQUIRES: Int16
 
-# Bug: https://github.com/llvm/offload-test-suite/issues/986
-# XFAIL: Intel && Vulkan && DXC
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/WaveOps/QuadReadAcrossX.int64.test
+++ b/test/WaveOps/QuadReadAcrossX.int64.test
@@ -236,9 +236,6 @@ DescriptorSets:
 # Bug: https://github.com/llvm/offload-test-suite/issues/989
 # XFAIL: Metal
 
-# Bug: https://github.com/llvm/offload-test-suite/issues/986
-# XFAIL: Intel && Vulkan && DXC
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/WaveOps/QuadReadAcrossY.32.test
+++ b/test/WaveOps/QuadReadAcrossY.32.test
@@ -336,9 +336,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug: https://github.com/llvm/offload-test-suite/issues/986
-# XFAIL: Intel && Vulkan && DXC
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o 

--- a/test/WaveOps/QuadReadAcrossY.convergence.test
+++ b/test/WaveOps/QuadReadAcrossY.convergence.test
@@ -62,9 +62,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug: https://github.com/llvm/offload-test-suite/issues/986
-# XFAIL: Intel && Vulkan && DXC
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/WaveOps/QuadReadAcrossY.fp16.test
+++ b/test/WaveOps/QuadReadAcrossY.fp16.test
@@ -124,9 +124,6 @@ DescriptorSets:
 
 # REQUIRES: Half
 
-# Bug: https://github.com/llvm/offload-test-suite/issues/986
-# XFAIL: Intel && Vulkan && DXC
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/WaveOps/QuadReadAcrossY.fp64.test
+++ b/test/WaveOps/QuadReadAcrossY.fp64.test
@@ -124,9 +124,6 @@ DescriptorSets:
 
 # REQUIRES: Double
 
-# Bug: https://github.com/llvm/offload-test-suite/issues/986
-# XFAIL: Intel && Vulkan && DXC
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/WaveOps/QuadReadAcrossY.int16.test
+++ b/test/WaveOps/QuadReadAcrossY.int16.test
@@ -232,9 +232,6 @@ DescriptorSets:
 
 # REQUIRES: Int16
 
-# Bug: https://github.com/llvm/offload-test-suite/issues/986
-# XFAIL: Intel && Vulkan && DXC
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/WaveOps/QuadReadAcrossY.int64.test
+++ b/test/WaveOps/QuadReadAcrossY.int64.test
@@ -232,9 +232,6 @@ DescriptorSets:
 
 # REQUIRES: Int64
 
-# Bug: https://github.com/llvm/offload-test-suite/issues/986
-# XFAIL: Intel && Vulkan && DXC
-
 # Bug: https://github.com/llvm/offload-test-suite/issues/989
 # XFAIL: Metal
 


### PR DESCRIPTION
After upgrading the intel hardware (which includes a more modern driver version), all of the QuadReadAcross* tests started unexpectedly passing.
This PR removes the XFAIL, and the associated issue has been resolved.

Resolves https://github.com/llvm/offload-test-suite/issues/986
