### PR TITLE
[NFC][offloader] Mark run() definition static to match its declaration

### DIFF
--- a/tools/offloader/offloader.cpp
+++ b/tools/offloader/offloader.cpp
@@ -96,7 +96,7 @@ static bool matchesRegexIgnoreCase(StringRef GPUDescription,
   return R.isValid() && R.match(GPUDescription);
 }
 
-int run() {
+static int run() {
   const ExitOnError ExitOnErr("gpu-exec: error: ");
   const DeviceConfig Config = {Debug, Validation};
   auto DevicesOrErr = initializeDevices(Config);


### PR DESCRIPTION
Minor nit: `run()` in `tools/offloader/offloader.cpp` is forward-declared `static` but the definition omits the specifier. Adding it matches the other two helpers in this file and the readability rationale in the [LLVM Coding Standards](https://llvm.org/docs/CodingStandards.html#restrict-visibility). NFC.

Assisted by Claude Opus 4.7.