### PR TITLE
[VK] Fix EnabledDeviceExtensions redefinition and drop on macOS build

### DIFF
--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -1315,21 +1315,18 @@ public:
       Features.pNext = &MeshFeatures;
     }
 
+#ifdef VK_EXT_SHADER_IMAGE_ATOMIC_INT64_EXTENSION_NAME
+    if (HasShaderImageAtomicInt64Ext &&
+        FeaturesImageAtomicInt64.shaderImageInt64Atomics)
+      EnabledDeviceExtensions.push_back(
+          VK_EXT_SHADER_IMAGE_ATOMIC_INT64_EXTENSION_NAME);
+#endif
+
     DeviceInfo.enabledExtensionCount =
         static_cast<uint32_t>(EnabledDeviceExtensions.size());
     DeviceInfo.ppEnabledExtensionNames = EnabledDeviceExtensions.data();
     DeviceInfo.pEnabledFeatures = &Features.features;
     DeviceInfo.pNext = Features.pNext;
-
-#ifdef VK_EXT_SHADER_IMAGE_ATOMIC_INT64_EXTENSION_NAME
-    llvm::SmallVector<const char *, 1> EnabledDeviceExtensions;
-    if (HasShaderImageAtomicInt64Ext &&
-        FeaturesImageAtomicInt64.shaderImageInt64Atomics)
-      EnabledDeviceExtensions.push_back(
-          VK_EXT_SHADER_IMAGE_ATOMIC_INT64_EXTENSION_NAME);
-    DeviceInfo.enabledExtensionCount = EnabledDeviceExtensions.size();
-    DeviceInfo.ppEnabledExtensionNames = EnabledDeviceExtensions.data();
-#endif
 
     VkDevice Device = VK_NULL_HANDLE;
     if (auto Err = VK::toError(


### PR DESCRIPTION
Fixes a redefinition of `EnabledDeviceExtensions` in `VulkanDevice::create` introduced by the parallel merge of #1177 and #1195, plus a related silent drop of `VK_EXT_mesh_shader` when both extensions are enabled.

_Assisted by Claude Opus 4.7._