### PR TITLE
[Support] Use explicit inline element count for AccelerationStructureDescs SmallVectors

### DIFF
--- a/include/Support/Pipeline.h
+++ b/include/Support/Pipeline.h
@@ -523,8 +523,8 @@ struct TLASDesc {
 };
 
 struct AccelerationStructureDescs {
-  llvm::SmallVector<BLASDesc> BLAS;
-  llvm::SmallVector<TLASDesc> TLAS;
+  llvm::SmallVector<BLASDesc, 1> BLAS;
+  llvm::SmallVector<TLASDesc, 1> TLAS;
 };
 
 struct Pipeline {


### PR DESCRIPTION
## Problem

`AccelerationStructureDescs` declares its lists with the default `SmallVector` inline element count:

```cpp
struct AccelerationStructureDescs {
  llvm::SmallVector<BLASDesc> BLAS;
  llvm::SmallVector<TLASDesc> TLAS;
};
```

`BLASDesc` holds a `std::string` plus two further default-inlined `SmallVector`s (`Triangles`, `AABBs`), so its size compounds. Under MSVC's debug STL (`/MDd`, `_ITERATOR_DEBUG_LEVEL=2`), `std::string` and the nested inline storage grow enough that `sizeof(BLASDesc)` exceeds 256 bytes, tripping LLVM's assertion in `CalculateSmallVectorDefaultInlinedElements`:

> You are trying to use a default number of inlined elements for `SmallVector<T>` but `sizeof(T)` is really big! Please use an explicit number of inlined elements with `SmallVector<T, N>` ...

This breaks any **Debug** build with MSVC on Windows (`Pipeline.h` is included widely). Release / RelWithDebInfo builds -- including CI -- keep the types under the limit, so the failure isn't visible there.

## Fix

Give the lists an explicit inline element count, as the assertion recommends. Only `BLASDesc` trips the assert today; `TLASDesc` has the same shape and sits just under the threshold, so it gets the same treatment for consistency and to avoid a latent break when fields are added. No functional change -- this only sets inline storage capacity.
