### PR TITLE
Remove XFAIL from asuint_mat.64.test

### DIFF
--- a/test/Feature/HLSLLib/asuint_mat.64.test
+++ b/test/Feature/HLSLLib/asuint_mat.64.test
@@ -200,9 +200,6 @@ DescriptorSets:
 
 # REQUIRES: Double
 
-# Not Implemented: https://github.com/llvm/llvm-project/issues/199069
-# XFAIL: Clang
-
 # Bug: https://github.com/llvm/llvm-project/issues/186864
 # XFAIL: Clang && Vulkan
 


### PR DESCRIPTION
After https://github.com/llvm/llvm-project/issues/199069 got merged, this xfail can be removed.