### PR TITLE
Fix specified stride in the matrix_assign test on buffer InB: 24 -> 48.

### DIFF
--- a/test/Feature/StructuredBuffer/matrix_assign.test
+++ b/test/Feature/StructuredBuffer/matrix_assign.test
@@ -37,7 +37,7 @@ Buffers:
 
   - Name: InB
     Format: Float32
-    Stride: 24
+    Stride: 48
     Data: [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0 ]
 
   - Name: OutB


### PR DESCRIPTION
The stride specified for the `InB` test was incorrect (probably a copy-paste error).
This wasn't causing any issues since the stride was unused. However, we should prefer to use the specified stride since StructuredBuffers are untyped and don't have a format.