### PR TITLE
CBuffer/arrays.test: Match output buffer stride and size to the `Arrays` struct definition.

### DIFF
--- a/test/Feature/CBuffer/arrays.test
+++ b/test/Feature/CBuffer/arrays.test
@@ -49,11 +49,11 @@ Buffers:
     ]
   - Name: Out
     Format: Hex32
-    Stride: 144
-    FillSize: 144
+    Stride: 128
+    FillSize: 128
   - Name: ExpectedOut
     Format: Hex32
-    Stride: 144
+    Stride: 128
     Data: [
       0x3f800000,
       0x40800000,
@@ -66,7 +66,7 @@ Buffers:
       0x00000010, 0x00000011, 0x00000012,
       0x00000013, 0x00000014, 0x00000015,
       0x00000016, 0x00000017, 0x00000018,
-      0x00000019, 0x0000001A, 0x0000001B, 0x0, 0x0, 0x0, 0x0
+      0x00000019, 0x0000001A, 0x0000001B,
     ]
 Results:
   - Result: Test1


### PR DESCRIPTION
The output buffer in `Cbuffer/arrays.test` has 4 extra integers at the end that didn't match with the `Arrays` struct that is defined in the shader. The stride also did not match the one of the struct. By removing the padding and setting the stride to `128` we can fix this issue.