### PR TITLE
Fix stride and fill size of Out buffer in cbuffer/vectors-16bit.test.

### DIFF
--- a/test/Feature/CBuffer/vectors-16bit.test
+++ b/test/Feature/CBuffer/vectors-16bit.test
@@ -34,9 +34,8 @@ Buffers:
     ]
   - Name: Out
     Format: Hex16
-    # Warp doesn't seem to be able to handle a stride of 10 so we use 12 here
-    Stride: 12
-    FillSize: 12
+    Stride: 10
+    FillSize: 10
 DescriptorSets:
   - Resources:
     - Name: CBVectors


### PR DESCRIPTION
The stride and fill size were incorrect in the `Feature/CBuffer/vectors-16bit.test` test.

On my local machine (where I am doing lots of fixes on buffer and texture creation/management) this is not an issue on WARP either. If it fails CI on this I will convert it to draft and we can then merge it at a later point.