### PR TITLE
[VK] Gate debug utils messenger on runtime config instead of NDEBUG

### DIFF
--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -3864,10 +3864,13 @@ llvm::Error offloadtest::initializeVulkanDevices(
   }
   const llvm::SmallVector<VkExtensionProperties, 0> AvailableExtensions =
       queryInstanceExtensions(nullptr);
-  if (Config.EnableDebugLayer) {
+  bool DebugUtilsEnabled = false;
+  if (Config.EnableDebugLayer || Config.EnableValidationLayer) {
     const llvm::StringRef DebugUtilsExtensionName = "VK_EXT_debug_utils";
-    if (isExtensionSupported(AvailableExtensions, DebugUtilsExtensionName))
+    if (isExtensionSupported(AvailableExtensions, DebugUtilsExtensionName)) {
       EnabledInstanceExtensions.push_back(DebugUtilsExtensionName.data());
+      DebugUtilsEnabled = true;
+    }
   }
 
   CreateInfo.ppEnabledLayerNames = EnabledLayers.data();
@@ -3880,11 +3883,8 @@ llvm::Error offloadtest::initializeVulkanDevices(
                              "Failed to create Vulkan instance"))
     return Err;
 
-#ifndef NDEBUG
-  VkDebugUtilsMessengerEXT DebugMessenger = registerDebugUtilCallback(Instance);
-#else
-  VkDebugUtilsMessengerEXT DebugMessenger = VK_NULL_HANDLE;
-#endif
+  VkDebugUtilsMessengerEXT DebugMessenger =
+      DebugUtilsEnabled ? registerDebugUtilCallback(Instance) : VK_NULL_HANDLE;
 
   const std::shared_ptr<VulkanInstance> VulkanInstanceShPtr =
       std::make_shared<VulkanInstance>(Instance, DebugMessenger);


### PR DESCRIPTION
`registerDebugUtilCallback` was only invoked inside `#ifndef NDEBUG`, leaving the function unused (and triggering `-Wunused-function`) in `NDEBUG` builds. The extension registration itself had already been converted to runtime config flags in #382; the call site was missed.

Tie the callback to whether `VK_EXT_debug_utils` was actually enabled, and pull the extension in whenever either `EnableDebugLayer` or `EnableValidationLayer` is set — so validation messages route through the callback. This matches how the DX backend couples the two flags in `lib/API/DX/Device.cpp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)