### PR TITLE
Add CommittedPrimitiveIndex test on a multi-triangle BLAS

### DIFF
--- a/test/Feature/InlineRT/primitive-index.test
+++ b/test/Feature/InlineRT/primitive-index.test
@@ -1,0 +1,85 @@
+#--- source.hlsl
+
+[[vk::binding(0, 0)]] RaytracingAccelerationStructure Scene : register(t0);
+[[vk::binding(1, 0)]] RWStructuredBuffer<uint> Output : register(u0);
+
+[numthreads(3,1,1)]
+void main(uint3 tid : SV_DispatchThreadID) {
+  // Three triangles tiled along x at x = -4, 0, 4. Each lane fires a ray
+  // straight down at its own triangle, so CommittedPrimitiveIndex() must
+  // be exactly the lane index. Also exercises divergent rays per thread.
+  RayDesc Ray;
+  Ray.Origin = float3((float(tid.x) - 1.0) * 4.0, 0, 1);
+  Ray.Direction = float3(0, 0, -1);
+  Ray.TMin = 0.0;
+  Ray.TMax = 100.0;
+  RayQuery<RAY_FLAG_NONE> Q;
+  Q.TraceRayInline(Scene, RAY_FLAG_NONE, 0xFF, Ray);
+  Q.Proceed();
+  Output[tid.x] = Q.CommittedStatus() == COMMITTED_TRIANGLE_HIT
+                      ? Q.CommittedPrimitiveIndex()
+                      : 0xFFFFFFFF;
+}
+//--- pipeline.yaml
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+Buffers:
+  - Name: Vertices
+    Format: Float32
+    Stride: 12
+    # Three triangles, one per lane, centered at x = -4, 0, +4.
+    Data: [ -4.0,  1.0, 0.0, -5.0, -1.0, 0.0, -3.0, -1.0, 0.0,
+             0.0,  1.0, 0.0, -1.0, -1.0, 0.0,  1.0, -1.0, 0.0,
+             4.0,  1.0, 0.0,  3.0, -1.0, 0.0,  5.0, -1.0, 0.0 ]
+  - Name: Output
+    Format: UInt32
+    Stride: 4
+    FillSize: 12
+  - Name: Expected
+    Format: UInt32
+    Stride: 4
+    Data: [ 0, 1, 2 ]
+AccelerationStructures:
+  BLAS:
+    - Name: MultiTriangleBLAS
+      Triangles:
+        - VertexBuffer: Vertices
+          VertexFormat: RGB32Float
+          VertexStride: 12
+          VertexCount: 9
+  TLAS:
+    - Name: Scene
+      Instances:
+        - BLAS: MultiTriangleBLAS
+DescriptorSets:
+  - Resources:
+    - Name: Scene
+      Kind: AccelerationStructure
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: Output
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+Results:
+  - Result: PrimitiveIndex
+    Rule: BufferExact
+    Actual: Output
+    Expected: Expected
+...
+#--- end
+
+# REQUIRES: acceleration-structure
+# XFAIL: Clang
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
## Summary

Stacks on top of #1232 / #1245. Adds the first InlineRT test with a non-trivial BLAS layout — three triangles tiled along x at `x = -4, 0, +4` — and a 3-lane dispatch that fires one ray per lane straight down at its own triangle. Each lane's `CommittedPrimitiveIndex()` must equal its lane index. Also exercises divergent rays per thread for free.

Seed test for the multi-primitive / multi-geometry BLAS bullets in the inline-RT coverage epic (#1258).

Independent of the other InlineRT test PRs (#1271, #1274) — only adds a new test file.

## Test plan

Local on an NVIDIA RTX 3060:
- [x] Linux Vulkan (native `offloader`)
- [x] Linux D3D12 (Wine + vkd3d-proton + cross-compiled `offloader.exe`)
- [ ] Windows Vulkan (native `offloader.exe`)
- [ ] Windows D3D12 (native `offloader.exe`)

CI (RT-capable runners):
- [ ] windows-nvidia D3D12 (`RaytracingTier 1.2`)
- [ ] windows-intel VK (`VK_KHR_ray_tracing_pipeline`)
- [x] macOS Metal (`supportsRaytracing`)
