### PR TITLE
[VK] Add ray tracing pipeline, SBT, and DispatchRays bring-up

### DIFF
--- a/include/API/Device.h
+++ b/include/API/Device.h
@@ -20,6 +20,7 @@
 #include "API/Capabilities.h"
 #include "API/CommandBuffer.h"
 #include "API/RenderPass.h"
+#include "API/ShaderBindingTable.h"
 #include "API/Texture.h"
 
 #include "Support/Pipeline.h"
@@ -82,6 +83,21 @@ struct ShaderContainer {
   std::string EntryPoint;
   const llvm::MemoryBuffer *Shader;
   llvm::SmallVector<SpecializationConstant> SpecializationConstants;
+};
+
+struct RayTracingShader {
+  Stages Stage;
+  std::string EntryPoint;
+};
+
+struct RayTracingPipelineCreateDesc {
+  // All RT shaders are compiled into a single DXIL library; every entry in
+  // `Shaders` references this same blob via the backend's library-loading
+  // path.
+  const llvm::MemoryBuffer *Library = nullptr;
+  llvm::SmallVector<RayTracingShader> Shaders;
+  llvm::SmallVector<HitGroup> HitGroups;
+  RayTracingPipelineConfig Config;
 };
 
 struct TraditionalRasterPipelineCreateDesc {
@@ -258,6 +274,14 @@ public:
   createMeshShaderRasterPipeline(
       llvm::StringRef Name, const BindingsDesc &BindingsDesc,
       const MeshShaderRasterPipelineCreateDesc &Desc) = 0;
+
+  virtual llvm::Expected<std::unique_ptr<PipelineState>>
+  createPipelineRT(llvm::StringRef Name, const BindingsDesc &BindingsDesc,
+                   const RayTracingPipelineCreateDesc &Desc) = 0;
+
+  virtual llvm::Expected<std::unique_ptr<ShaderBindingTable>>
+  createShaderBindingTable(const PipelineState &PSO,
+                           const ShaderBindingTableDesc &Desc) = 0;
 
   virtual llvm::Expected<std::unique_ptr<Fence>>
   createFence(llvm::StringRef Name) = 0;

--- a/include/API/Device.h
+++ b/include/API/Device.h
@@ -91,9 +91,9 @@ struct RayTracingShader {
 };
 
 struct RayTracingPipelineCreateDesc {
-  // All RT shaders are compiled into a single DXIL library; every entry in
-  // `Shaders` references this same blob via the backend's library-loading
-  // path.
+  // All RT shaders are compiled into a single shader library.
+  // Every entry in `Shaders` references this same blob via the backend's
+  // library-loading path.
   const llvm::MemoryBuffer *Library = nullptr;
   llvm::SmallVector<RayTracingShader> Shaders;
   llvm::SmallVector<HitGroup> HitGroups;

--- a/include/API/Encoder.h
+++ b/include/API/Encoder.h
@@ -25,6 +25,7 @@ class Buffer;
 class Texture;
 class PipelineState;
 class AccelerationStructure;
+class ShaderBindingTable;
 struct BLASBuildRequest;
 struct TLASBuildRequest;
 
@@ -110,6 +111,17 @@ public:
   /// Metal). A barrier covering AS-build writes is implicitly emitted before
   /// any subsequent command that reads from the freshly-built structures.
   virtual llvm::Error batchBuildAS(llvm::ArrayRef<ASBuildItem> Items) = 0;
+
+  /// Trace rays from a RayTracing pipeline. \p PSO must have been created via
+  /// Device::createPipelineRT and \p SBT via Device::createShaderBindingTable
+  /// on that same PSO. \p Width, \p Height, \p Depth are the dispatch
+  /// dimensions passed through to the backend's DispatchRays equivalent
+  /// (D3D12 DispatchRays, Vulkan vkCmdTraceRaysKHR, Metal compute dispatch
+  /// after metal_irconverter lowering).
+  virtual llvm::Error dispatchRays(const PipelineState &PSO,
+                                   const ShaderBindingTable &SBT,
+                                   uint32_t Width, uint32_t Height,
+                                   uint32_t Depth) = 0;
 };
 
 struct Viewport {

--- a/include/API/ShaderBindingTable.h
+++ b/include/API/ShaderBindingTable.h
@@ -1,0 +1,78 @@
+//===- ShaderBindingTable.h - Offload RT Shader Binding Table -------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef OFFLOADTEST_API_SHADERBINDINGTABLE_H
+#define OFFLOADTEST_API_SHADERBINDINGTABLE_H
+
+#include "API/API.h"
+
+#include <cstdint>
+
+namespace offloadtest {
+
+struct ShaderBindingTableDesc;
+
+/// Runtime shader binding table built from a RayTracing PipelineState plus a
+/// ShaderBindingTableDesc. Concrete subclasses (one per backend) hold the
+/// device-side records and any address ranges needed by the backend's
+/// DispatchRays call.
+class ShaderBindingTable {
+  GPUAPI API;
+
+public:
+  virtual ~ShaderBindingTable();
+  ShaderBindingTable(const ShaderBindingTable &) = delete;
+  ShaderBindingTable &operator=(const ShaderBindingTable &) = delete;
+
+  GPUAPI getAPI() const { return API; }
+
+protected:
+  explicit ShaderBindingTable(GPUAPI API) : API(API) {}
+};
+
+/// Per-region SBT layout numbers.
+///
+/// Every backend lays an SBT out as four concatenated regions (raygen, miss,
+/// hit-group, callable). Within a region every record is
+/// `[shader-identifier][LocalRootData][padding-to-stride]`, where stride is
+/// `align(identifierSize + max-LocalRootData-in-region, RecordAlign)` and
+/// the region itself is aligned to `BaseAlign`. The numbers match the
+/// alignment rules of both D3D12
+/// (`D3D12_SHADER_IDENTIFIER_SIZE_IN_BYTES` / `…_RECORD_BYTE_ALIGNMENT` /
+/// `…_TABLE_BYTE_ALIGNMENT`) and Vulkan
+/// (`shaderGroupHandleSize` / `shaderGroupHandleAlignment` /
+/// `shaderGroupBaseAlignment`); backend-specific constants are passed in.
+struct SBTRegionLayout {
+  uint32_t Stride = 0;
+  uint32_t Size = 0;
+  uint32_t Offset = 0; // byte offset from the start of the SBT buffer
+};
+
+struct SBTLayout {
+  SBTRegionLayout RayGen;
+  SBTRegionLayout Miss;
+  SBTRegionLayout HitGroup;
+  SBTRegionLayout Callable;
+  uint32_t TotalSize = 0;
+};
+
+/// Compute the per-region layout for an SBT description.
+///
+/// \p IdentifierSize is the size of one shader identifier (32 bytes on
+/// D3D12; `shaderGroupHandleSize` on Vulkan).
+/// \p RecordAlign is the per-record alignment (D3D12: 32 bytes; Vulkan:
+/// `shaderGroupHandleAlignment`).
+/// \p BaseAlign is the per-region alignment (D3D12: 64 bytes; Vulkan:
+/// `shaderGroupBaseAlignment`).
+SBTLayout computeSBTLayout(uint32_t IdentifierSize, uint32_t RecordAlign,
+                           uint32_t BaseAlign,
+                           const ShaderBindingTableDesc &Desc);
+
+} // namespace offloadtest
+
+#endif // OFFLOADTEST_API_SHADERBINDINGTABLE_H

--- a/include/Support/Pipeline.h
+++ b/include/Support/Pipeline.h
@@ -593,7 +593,7 @@ struct SBTEntry {
   llvm::SmallVector<uint8_t> LocalRootData;
 };
 
-struct ShaderBindingTable {
+struct ShaderBindingTableDesc {
   SBTEntry RayGen;
   llvm::SmallVector<SBTEntry> Miss;
   llvm::SmallVector<SBTEntry> HitGroup;
@@ -615,7 +615,7 @@ struct Pipeline {
   AccelerationStructureDescs AccelStructs;
   std::optional<RayTracingPipelineConfig> RTConfig;
   llvm::SmallVector<HitGroup> HitGroups;
-  std::optional<ShaderBindingTable> SBT;
+  std::optional<ShaderBindingTableDesc> SBT;
 
   uint32_t getVertexCount() const {
     if (DispatchParameters.VertexCount)
@@ -826,8 +826,8 @@ template <> struct MappingTraits<offloadtest::SBTEntry> {
   static void mapping(IO &I, offloadtest::SBTEntry &E);
 };
 
-template <> struct MappingTraits<offloadtest::ShaderBindingTable> {
-  static void mapping(IO &I, offloadtest::ShaderBindingTable &S);
+template <> struct MappingTraits<offloadtest::ShaderBindingTableDesc> {
+  static void mapping(IO &I, offloadtest::ShaderBindingTableDesc &S);
 };
 
 template <> struct ScalarEnumerationTraits<offloadtest::Rule> {

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -846,6 +846,12 @@ public:
   // ID3D12Device5 entry point and helper allocators.
   llvm::Error batchBuildAS(llvm::ArrayRef<ASBuildItem> Items) override;
 
+  llvm::Error dispatchRays(const PipelineState &, const ShaderBindingTable &,
+                           uint32_t, uint32_t, uint32_t) override {
+    return llvm::createStringError(
+        "RayTracing dispatchRays not yet supported on DirectX");
+  }
+
   void endEncodingImpl() override { popDebugGroup(); }
 };
 
@@ -1530,6 +1536,20 @@ public:
       return Err;
 
     return std::make_unique<DXPipelineState>(Name, RootSig, PSO, std::nullopt);
+  }
+
+  llvm::Expected<std::unique_ptr<PipelineState>>
+  createPipelineRT(llvm::StringRef, const BindingsDesc &,
+                   const RayTracingPipelineCreateDesc &) override {
+    return llvm::createStringError(
+        "RayTracing pipeline state not yet supported on DirectX");
+  }
+
+  llvm::Expected<std::unique_ptr<ShaderBindingTable>>
+  createShaderBindingTable(const PipelineState &,
+                           const ShaderBindingTableDesc &) override {
+    return llvm::createStringError(
+        "RayTracing shader binding table not yet supported on DirectX");
   }
 
   llvm::Expected<std::unique_ptr<offloadtest::Fence>>

--- a/lib/API/Device.cpp
+++ b/lib/API/Device.cpp
@@ -12,6 +12,7 @@
 #include "API/Device.h"
 #include "API/Encoder.h"
 #include "API/FormatConversion.h"
+#include "API/ShaderBindingTable.h"
 
 #include "Config.h"
 
@@ -38,6 +39,56 @@ Texture::~Texture() {}
 RenderPass::~RenderPass() {}
 
 AccelerationStructure::~AccelerationStructure() {}
+
+ShaderBindingTable::~ShaderBindingTable() {}
+
+static uint32_t alignUp(uint32_t Value, uint32_t Alignment) {
+  return (Value + Alignment - 1) & ~(Alignment - 1);
+}
+
+SBTLayout offloadtest::computeSBTLayout(uint32_t IdentifierSize,
+                                        uint32_t RecordAlign,
+                                        uint32_t BaseAlign,
+                                        const ShaderBindingTableDesc &Desc) {
+  auto StrideFor = [&](llvm::ArrayRef<SBTEntry> Entries) {
+    size_t MaxLocal = 0;
+    for (const auto &E : Entries)
+      MaxLocal = std::max<size_t>(MaxLocal, E.LocalRootData.size());
+    return alignUp(IdentifierSize + static_cast<uint32_t>(MaxLocal),
+                   RecordAlign);
+  };
+  auto RegionSize = [&](uint32_t Count, uint32_t Stride) {
+    return Count == 0 ? 0u : alignUp(Count * Stride, BaseAlign);
+  };
+
+  // Vulkan dispatches exactly one raygen per vkCmdTraceRaysKHR and D3D12's
+  // RayGenerationShaderRecord field is a single record; the descriptor only
+  // carries one raygen entry.
+  const llvm::ArrayRef<SBTEntry> RGEntries(&Desc.RayGen, 1);
+
+  SBTLayout L;
+  L.RayGen.Stride = StrideFor(RGEntries);
+  L.RayGen.Size = RegionSize(1, L.RayGen.Stride);
+  L.RayGen.Offset = 0;
+
+  L.Miss.Stride = StrideFor(Desc.Miss);
+  L.Miss.Size =
+      RegionSize(static_cast<uint32_t>(Desc.Miss.size()), L.Miss.Stride);
+  L.Miss.Offset = L.RayGen.Offset + L.RayGen.Size;
+
+  L.HitGroup.Stride = StrideFor(Desc.HitGroup);
+  L.HitGroup.Size = RegionSize(static_cast<uint32_t>(Desc.HitGroup.size()),
+                               L.HitGroup.Stride);
+  L.HitGroup.Offset = L.Miss.Offset + L.Miss.Size;
+
+  L.Callable.Stride = StrideFor(Desc.Callable);
+  L.Callable.Size = RegionSize(static_cast<uint32_t>(Desc.Callable.size()),
+                               L.Callable.Stride);
+  L.Callable.Offset = L.HitGroup.Offset + L.HitGroup.Size;
+
+  L.TotalSize = L.Callable.Offset + L.Callable.Size;
+  return L;
+}
 
 Device::~Device() {}
 

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -625,6 +625,12 @@ public:
   // MTL::Device handle (used to allocate scratch and instance buffers).
   llvm::Error batchBuildAS(llvm::ArrayRef<ASBuildItem> Items) override;
 
+  llvm::Error dispatchRays(const PipelineState &, const ShaderBindingTable &,
+                           uint32_t, uint32_t, uint32_t) override {
+    return llvm::createStringError(
+        "RayTracing dispatchRays not yet supported on Metal");
+  }
+
   /// Lazily transition into an AccelerationStructureCommandEncoder; mirrors
   /// the existing compute↔blit lazy switch.
   llvm::Error ensureASEncoder() {
@@ -1710,6 +1716,20 @@ public:
   GPUAPI getAPI() const override { return GPUAPI::Metal; };
 
   Queue &getGraphicsQueue() override { return GraphicsQueue; }
+
+  llvm::Expected<std::unique_ptr<PipelineState>>
+  createPipelineRT(llvm::StringRef, const BindingsDesc &,
+                   const RayTracingPipelineCreateDesc &) override {
+    return llvm::createStringError(
+        "RayTracing pipeline state not yet supported on Metal");
+  }
+
+  llvm::Expected<std::unique_ptr<ShaderBindingTable>>
+  createShaderBindingTable(const PipelineState &,
+                           const ShaderBindingTableDesc &) override {
+    return llvm::createStringError(
+        "RayTracing shader binding table not yet supported on Metal");
+  }
 
   llvm::Expected<std::unique_ptr<offloadtest::Fence>>
   createFence(llvm::StringRef Name) override {

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -837,12 +837,17 @@ public:
   VkPipeline Pipeline;
   VkPipelineLayout Layout;
   llvm::SmallVector<VkDescriptorSetLayout> SetLayouts;
+  // True for pipelines created via createPipelineRT — used by SBT / dispatch
+  // code to safely downcast to VKRayTracingPipelineState.
+  bool IsRayTracing = false;
 
   VulkanPipelineState(llvm::StringRef Name, VkDevice Dev, VkPipeline Pipeline,
                       VkPipelineLayout Layout,
-                      llvm::SmallVector<VkDescriptorSetLayout> SetLayouts)
+                      llvm::SmallVector<VkDescriptorSetLayout> SetLayouts,
+                      bool IsRT = false)
       : offloadtest::PipelineState(GPUAPI::Vulkan), Name(Name.str()), Dev(Dev),
-        Pipeline(Pipeline), Layout(Layout), SetLayouts(std::move(SetLayouts)) {}
+        Pipeline(Pipeline), Layout(Layout), SetLayouts(std::move(SetLayouts)),
+        IsRayTracing(IsRT) {}
 
   ~VulkanPipelineState() override {
     vkDestroyPipeline(Dev, Pipeline, nullptr);
@@ -853,6 +858,71 @@ public:
 
   static bool classof(const offloadtest::PipelineState *B) {
     return B->getAPI() == GPUAPI::Vulkan;
+  }
+};
+
+/// RT pipeline state with the extra metadata needed to build a shader binding
+/// table — the group-index mapping resolves SBT-record `ShaderName`s to the
+/// shader-group index in this pipeline, and the per-bucket counts allow the
+/// SBT builder to slice the contiguous handle blob returned by
+/// `vkGetRayTracingShaderGroupHandlesKHR` into raygen / miss / hit / callable
+/// regions.
+class VKRayTracingPipelineState : public VulkanPipelineState {
+public:
+  // Maps each raygen / miss / callable shader's `EntryPoint` and each
+  // hit group's `Name` to its index in the pipeline's
+  // `VkRayTracingShaderGroupCreateInfoKHR[]`.
+  llvm::StringMap<uint32_t> ShaderGroupIndices;
+
+  // Group counts laid out in pipeline order: raygen, miss, hit, callable.
+  uint32_t NumRaygenGroups = 0;
+  uint32_t NumMissGroups = 0;
+  uint32_t NumHitGroups = 0;
+  uint32_t NumCallableGroups = 0;
+
+  uint32_t totalGroupCount() const {
+    return NumRaygenGroups + NumMissGroups + NumHitGroups + NumCallableGroups;
+  }
+
+  VKRayTracingPipelineState(llvm::StringRef Name, VkDevice Dev,
+                            VkPipeline Pipeline, VkPipelineLayout Layout,
+                            llvm::SmallVector<VkDescriptorSetLayout> SetLayouts)
+      : VulkanPipelineState(Name, Dev, Pipeline, Layout, std::move(SetLayouts),
+                            /*IsRT=*/true) {}
+
+  static bool classof(const offloadtest::PipelineState *B) {
+    if (B->getAPI() != GPUAPI::Vulkan)
+      return false;
+    return static_cast<const VulkanPipelineState *>(B)->IsRayTracing;
+  }
+};
+
+class VKShaderBindingTable : public offloadtest::ShaderBindingTable {
+public:
+  VkDevice Dev;
+  VkBuffer Buffer;
+  VkDeviceMemory Memory;
+  VkStridedDeviceAddressRegionKHR RaygenRegion{};
+  VkStridedDeviceAddressRegionKHR MissRegion{};
+  VkStridedDeviceAddressRegionKHR HitRegion{};
+  VkStridedDeviceAddressRegionKHR CallableRegion{};
+
+  VKShaderBindingTable(VkDevice Dev, VkBuffer Buffer, VkDeviceMemory Memory,
+                       VkStridedDeviceAddressRegionKHR Raygen,
+                       VkStridedDeviceAddressRegionKHR Miss,
+                       VkStridedDeviceAddressRegionKHR Hit,
+                       VkStridedDeviceAddressRegionKHR Callable)
+      : offloadtest::ShaderBindingTable(GPUAPI::Vulkan), Dev(Dev),
+        Buffer(Buffer), Memory(Memory), RaygenRegion(Raygen), MissRegion(Miss),
+        HitRegion(Hit), CallableRegion(Callable) {}
+
+  ~VKShaderBindingTable() override {
+    vkDestroyBuffer(Dev, Buffer, nullptr);
+    vkFreeMemory(Dev, Memory, nullptr);
+  }
+
+  static bool classof(const offloadtest::ShaderBindingTable *S) {
+    return S->getAPI() == GPUAPI::Vulkan;
   }
 };
 
@@ -950,6 +1020,12 @@ public:
   // Defined out-of-line below — needs VulkanDevice's full type for access to
   // the device-loaded ray-tracing entry points and helpers.
   llvm::Error batchBuildAS(llvm::ArrayRef<ASBuildItem> Items) override;
+
+  // Defined out-of-line below — needs VulkanDevice for the RT pipeline
+  // entry points and VKRayTracingPipelineState's full type.
+  llvm::Error dispatchRays(const PipelineState &PSO,
+                           const ShaderBindingTable &SBT, uint32_t Width,
+                           uint32_t Height, uint32_t Depth) override;
 
   void endEncodingImpl() override { popDebugGroup(); }
 };
@@ -1313,15 +1389,23 @@ private:
   PFN_vkCmdInsertDebugUtilsLabelEXT CmdInsertDebugUtilsLabel = nullptr;
   MeshShaderFunctions MeshShaderFns;
 
-  bool HasRayTracingSupport = false;
-  struct RaytracingFunctions {
-    PFN_vkCreateAccelerationStructureKHR CreateAS = nullptr;
-    PFN_vkDestroyAccelerationStructureKHR DestroyAS = nullptr;
+  bool HasASSupport = false;
+  bool HasRTPipelineSupport = false;
+  struct ASFunctions {
+    PFN_vkCreateAccelerationStructureKHR Create = nullptr;
+    PFN_vkDestroyAccelerationStructureKHR Destroy = nullptr;
     PFN_vkGetAccelerationStructureBuildSizesKHR GetBuildSizes = nullptr;
     PFN_vkGetAccelerationStructureDeviceAddressKHR GetDeviceAddress = nullptr;
     PFN_vkCmdBuildAccelerationStructuresKHR CmdBuild = nullptr;
   };
-  RaytracingFunctions RT;
+  ASFunctions AS;
+  struct RTPipelineFunctions {
+    PFN_vkCreateRayTracingPipelinesKHR CreatePipelines = nullptr;
+    PFN_vkGetRayTracingShaderGroupHandlesKHR GetGroupHandles = nullptr;
+    PFN_vkCmdTraceRaysKHR CmdTraceRays = nullptr;
+  };
+  RTPipelineFunctions RT;
+  VkPhysicalDeviceRayTracingPipelinePropertiesKHR RTPipelineProps{};
 
   struct BufferRef {
     VkBuffer Buffer;
@@ -1393,6 +1477,8 @@ private:
     VkDescriptorPool Pool = VK_NULL_HANDLE;
 
     std::unique_ptr<PipelineState> Pipeline;
+    // Lifetime-tied to the pipeline; only set for RT pipelines.
+    std::unique_ptr<offloadtest::ShaderBindingTable> SBT;
 
     // FrameBuffer associated data for offscreen rendering.
     VkFramebuffer FrameBuffer = VK_NULL_HANDLE;
@@ -1539,6 +1625,10 @@ public:
     const bool HasRayQueryExt =
         HasASExts && isExtensionSupported(AvailableDeviceExtensions,
                                           VK_KHR_RAY_QUERY_EXTENSION_NAME);
+    const bool HasRayTracingPipelineExt =
+        HasASExts &&
+        isExtensionSupported(AvailableDeviceExtensions,
+                             VK_KHR_RAY_TRACING_PIPELINE_EXTENSION_NAME);
 
     VkPhysicalDeviceAccelerationStructureFeaturesKHR ASFeatures{};
     // On Vulkan 1.1 we need a separate BDA features struct; on 1.2+
@@ -1546,6 +1636,7 @@ public:
     // already in the chain, and adding a duplicate is a validation error.
     VkPhysicalDeviceBufferDeviceAddressFeatures BDAFeatures{};
     VkPhysicalDeviceRayQueryFeaturesKHR RayQueryFeatures{};
+    VkPhysicalDeviceRayTracingPipelineFeaturesKHR RTPipelineFeatures{};
     if (HasASExts) {
       ASFeatures.sType =
           VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR;
@@ -1562,6 +1653,12 @@ public:
             VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_QUERY_FEATURES_KHR;
         RayQueryFeatures.pNext = Features.pNext;
         Features.pNext = &RayQueryFeatures;
+      }
+      if (HasRayTracingPipelineExt) {
+        RTPipelineFeatures.sType =
+            VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_FEATURES_KHR;
+        RTPipelineFeatures.pNext = Features.pNext;
+        Features.pNext = &RTPipelineFeatures;
       }
     }
 
@@ -1643,6 +1740,22 @@ public:
               VK_KHR_RAY_QUERY_EXTENSION_NAME);
         EnabledDeviceExtensions.push_back(VK_KHR_RAY_QUERY_EXTENSION_NAME);
       }
+      if (HasRayTracingPipelineExt) {
+        if (!RTPipelineFeatures.rayTracingPipeline)
+          return llvm::createStringError(
+              std::errc::not_supported,
+              "Device advertises %s but reports rayTracingPipeline=0",
+              VK_KHR_RAY_TRACING_PIPELINE_EXTENSION_NAME);
+        // Only the base feature is needed for DispatchRays. Capture-replay /
+        // trace-rays-indirect / chained-mode aren't used.
+        RTPipelineFeatures.rayTracingPipelineShaderGroupHandleCaptureReplay = 0;
+        RTPipelineFeatures
+            .rayTracingPipelineShaderGroupHandleCaptureReplayMixed = 0;
+        RTPipelineFeatures.rayTracingPipelineTraceRaysIndirect = 0;
+        RTPipelineFeatures.rayTraversalPrimitiveCulling = 0;
+        EnabledDeviceExtensions.push_back(
+            VK_KHR_RAY_TRACING_PIPELINE_EXTENSION_NAME);
+      }
     }
 
     DeviceInfo.enabledExtensionCount =
@@ -1669,26 +1782,48 @@ public:
         Instance, PhysicalDevice, Props, Device, std::move(GraphicsQueue),
         std::move(InstanceLayers), std::move(AvailableDeviceExtensions));
 
-    // Load ray tracing function pointers after device creation.
+    // Load acceleration-structure and ray-tracing-pipeline function pointers
+    // after device creation. These two feature sets are independent; the RT
+    // pipeline path needs AS as a prerequisite, but AS-only support (ray
+    // query in compute) is a complete configuration on its own.
     if (HasASExts) {
-      Dev->HasRayTracingSupport = true;
-      Dev->RT.CreateAS = reinterpret_cast<PFN_vkCreateAccelerationStructureKHR>(
+      Dev->HasASSupport = true;
+      Dev->AS.Create = reinterpret_cast<PFN_vkCreateAccelerationStructureKHR>(
           vkGetDeviceProcAddr(Device, "vkCreateAccelerationStructureKHR"));
-      Dev->RT.DestroyAS =
-          reinterpret_cast<PFN_vkDestroyAccelerationStructureKHR>(
-              vkGetDeviceProcAddr(Device, "vkDestroyAccelerationStructureKHR"));
-      Dev->RT.GetBuildSizes =
+      Dev->AS.Destroy = reinterpret_cast<PFN_vkDestroyAccelerationStructureKHR>(
+          vkGetDeviceProcAddr(Device, "vkDestroyAccelerationStructureKHR"));
+      Dev->AS.GetBuildSizes =
           reinterpret_cast<PFN_vkGetAccelerationStructureBuildSizesKHR>(
               vkGetDeviceProcAddr(Device,
                                   "vkGetAccelerationStructureBuildSizesKHR"));
-      Dev->RT.GetDeviceAddress =
+      Dev->AS.GetDeviceAddress =
           reinterpret_cast<PFN_vkGetAccelerationStructureDeviceAddressKHR>(
               vkGetDeviceProcAddr(
                   Device, "vkGetAccelerationStructureDeviceAddressKHR"));
-      Dev->RT.CmdBuild =
+      Dev->AS.CmdBuild =
           reinterpret_cast<PFN_vkCmdBuildAccelerationStructuresKHR>(
               vkGetDeviceProcAddr(Device,
                                   "vkCmdBuildAccelerationStructuresKHR"));
+      if (HasRayTracingPipelineExt) {
+        Dev->HasRTPipelineSupport = true;
+        Dev->RT.CreatePipelines =
+            reinterpret_cast<PFN_vkCreateRayTracingPipelinesKHR>(
+                vkGetDeviceProcAddr(Device, "vkCreateRayTracingPipelinesKHR"));
+        Dev->RT.GetGroupHandles =
+            reinterpret_cast<PFN_vkGetRayTracingShaderGroupHandlesKHR>(
+                vkGetDeviceProcAddr(Device,
+                                    "vkGetRayTracingShaderGroupHandlesKHR"));
+        Dev->RT.CmdTraceRays = reinterpret_cast<PFN_vkCmdTraceRaysKHR>(
+            vkGetDeviceProcAddr(Device, "vkCmdTraceRaysKHR"));
+
+        // Cache SBT handle size / alignments for the lifetime of the device.
+        VkPhysicalDeviceProperties2 Props2{};
+        Props2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2;
+        Dev->RTPipelineProps.sType =
+            VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_PROPERTIES_KHR;
+        Props2.pNext = &Dev->RTPipelineProps;
+        vkGetPhysicalDeviceProperties2(PhysicalDevice, &Props2);
+      }
     }
 
     return Dev;
@@ -2412,6 +2547,16 @@ public:
         Name, Device, Pipeline, PipelineLayout, std::move(SetLayouts));
   }
 
+  // Defined out-of-line below — needs VKRayTracingPipelineState's full type
+  // and the device-loaded ray-tracing pipeline entry points.
+  llvm::Expected<std::unique_ptr<PipelineState>>
+  createPipelineRT(llvm::StringRef Name, const BindingsDesc &BndDesc,
+                   const RayTracingPipelineCreateDesc &Desc) override;
+
+  llvm::Expected<std::unique_ptr<ShaderBindingTable>>
+  createShaderBindingTable(const PipelineState &PSO,
+                           const ShaderBindingTableDesc &Desc) override;
+
   llvm::Expected<std::unique_ptr<offloadtest::Fence>>
   createFence(llvm::StringRef Name) override {
     return VulkanFence::create(Device, Name);
@@ -2452,7 +2597,7 @@ public:
     // When ray tracing is supported, every buffer is eligible to act as an
     // acceleration-structure build input and to expose a device address. The
     // shared AS build helper assumes Storage buffers carry these flags.
-    if (HasRayTracingSupport)
+    if (HasASSupport)
       BufInfo.usage |=
           VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT |
           VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR;
@@ -2473,7 +2618,7 @@ public:
 
     VkMemoryAllocateInfo AllocInfo = {};
     AllocInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
-    if (HasRayTracingSupport)
+    if (HasASSupport)
       AllocInfo.pNext = &AllocFlagsInfo;
     AllocInfo.allocationSize = MemReqs.size;
     auto MemIdx = getMemoryIndex(PhysicalDevice, MemReqs.memoryTypeBits,
@@ -2546,7 +2691,7 @@ public:
     }
 
     VkDeviceAddress DevAddr = 0;
-    if (HasRayTracingSupport) {
+    if (HasASSupport) {
       VkBufferDeviceAddressInfo AddrInfo = {};
       AddrInfo.sType = VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO;
       AddrInfo.buffer = BufferObject;
@@ -2978,7 +3123,7 @@ private:
     SizesInfo.sType =
         VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_BUILD_SIZES_INFO_KHR;
 
-    RT.GetBuildSizes(Device, VK_ACCELERATION_STRUCTURE_BUILD_TYPE_DEVICE_KHR,
+    AS.GetBuildSizes(Device, VK_ACCELERATION_STRUCTURE_BUILD_TYPE_DEVICE_KHR,
                      &BuildInfo, MaxPrimCounts.data(), &SizesInfo);
 
     return {SizesInfo.accelerationStructureSize, SizesInfo.buildScratchSize,
@@ -2988,7 +3133,7 @@ private:
   llvm::Expected<std::unique_ptr<offloadtest::AccelerationStructure>>
   allocateAS(const AccelerationStructureSizes &Sizes,
              VkAccelerationStructureTypeKHR Type, const char *Kind) {
-    if (!HasRayTracingSupport)
+    if (!HasASSupport)
       return llvm::createStringError(
           std::errc::not_supported,
           "Ray tracing is not supported on this device.");
@@ -3007,7 +3152,7 @@ private:
 
     VkAccelerationStructureKHR AccelStruct = VK_NULL_HANDLE;
     if (auto Err =
-            VK::toError(RT.CreateAS(Device, &CreateInfo, nullptr, &AccelStruct),
+            VK::toError(AS.Create(Device, &CreateInfo, nullptr, &AccelStruct),
                         "Failed to create " + llvm::Twine(Kind) + ".")) {
       vkDestroyBuffer(Device, BufOrErr->Buffer, nullptr);
       vkFreeMemory(Device, BufOrErr->Memory, nullptr);
@@ -3017,11 +3162,11 @@ private:
     AddrInfo.sType =
         VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_DEVICE_ADDRESS_INFO_KHR;
     AddrInfo.accelerationStructure = AccelStruct;
-    const VkDeviceAddress DevAddr = RT.GetDeviceAddress(Device, &AddrInfo);
+    const VkDeviceAddress DevAddr = AS.GetDeviceAddress(Device, &AddrInfo);
 
     return std::make_unique<VulkanAccelerationStructure>(
         Device, AccelStruct, BufOrErr->Buffer, BufOrErr->Memory, DevAddr,
-        RT.DestroyAS, Sizes);
+        AS.Destroy, Sizes);
   }
 
 public:
@@ -3044,7 +3189,7 @@ public:
     SizesInfo.sType =
         VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_BUILD_SIZES_INFO_KHR;
 
-    RT.GetBuildSizes(Device, VK_ACCELERATION_STRUCTURE_BUILD_TYPE_DEVICE_KHR,
+    AS.GetBuildSizes(Device, VK_ACCELERATION_STRUCTURE_BUILD_TYPE_DEVICE_KHR,
                      &BuildInfo, &InstanceCount, &SizesInfo);
 
     return AccelerationStructureSizes{SizesInfo.accelerationStructureSize,
@@ -4089,9 +4234,10 @@ public:
     for (auto &R : IS.Resources)
       copyResourceDataToDevice(IS, R);
 
-    const VkPipelineBindPoint BindPoint = P.isTraditionalRaster()
-                                              ? VK_PIPELINE_BIND_POINT_GRAPHICS
-                                              : VK_PIPELINE_BIND_POINT_COMPUTE;
+    const VkPipelineBindPoint BindPoint =
+        P.isTraditionalRaster() ? VK_PIPELINE_BIND_POINT_GRAPHICS
+        : P.isRayTracing()      ? VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR
+                                : VK_PIPELINE_BIND_POINT_COMPUTE;
     const VulkanPipelineState &VulkanPipeline =
         llvm::cast<VulkanPipelineState>(*IS.Pipeline.get());
     if (IS.DescriptorSets.size() > 0)
@@ -4119,6 +4265,21 @@ public:
         return Err;
       Encoder.endEncoding();
       llvm::outs() << "Dispatched compute shader: { "
+                   << P.DispatchParameters.DispatchGroupCount[0] << ", "
+                   << P.DispatchParameters.DispatchGroupCount[1] << ", "
+                   << P.DispatchParameters.DispatchGroupCount[2] << " }\n";
+    } else if (P.isRayTracing()) {
+      auto EncoderOrErr = IS.CB->createComputeEncoder();
+      if (!EncoderOrErr)
+        return EncoderOrErr.takeError();
+      auto &Encoder = *EncoderOrErr.get();
+      if (auto Err = Encoder.dispatchRays(
+              *IS.Pipeline, *IS.SBT, P.DispatchParameters.DispatchGroupCount[0],
+              P.DispatchParameters.DispatchGroupCount[1],
+              P.DispatchParameters.DispatchGroupCount[2]))
+        return Err;
+      Encoder.endEncoding();
+      llvm::outs() << "DispatchRays: { "
                    << P.DispatchParameters.DispatchGroupCount[0] << ", "
                    << P.DispatchParameters.DispatchGroupCount[1] << ", "
                    << P.DispatchParameters.DispatchGroupCount[2] << " }\n";
@@ -4463,8 +4624,35 @@ public:
         return Err;
       llvm::outs() << "Frame buffer created.\n";
     } else if (P.isRayTracing()) {
-      return llvm::createStringError(
-          "RayTracing pipeline not yet supported on Vulkan");
+      if (P.Shaders.empty() || !P.SBT || !P.RTConfig)
+        return llvm::createStringError(
+            std::errc::invalid_argument,
+            "RayTracing pipeline requires Shaders, "
+            "ShaderBindingTable, and RayTracingPipelineConfig.");
+
+      RayTracingPipelineCreateDesc RTDesc{};
+      // All RT shader entries share the single DXIL library blob loaded by
+      // the offloader. validatePipelineKind already enforced ≥1 RayGen and
+      // rejected mixing RT with compute/vertex/mesh stages.
+      RTDesc.Library = P.Shaders.front().Shader.get();
+      RTDesc.HitGroups = P.HitGroups;
+      RTDesc.Config = *P.RTConfig;
+      RTDesc.Shaders.reserve(P.Shaders.size());
+      for (const auto &Sh : P.Shaders)
+        RTDesc.Shaders.push_back({Sh.Stage, Sh.Entry});
+
+      auto PSOOrErr =
+          createPipelineRT("RayTracing Pipeline State", BindingsDesc, RTDesc);
+      if (!PSOOrErr)
+        return PSOOrErr.takeError();
+      State.Pipeline = std::move(*PSOOrErr);
+      llvm::outs() << "RayTracing Pipeline created.\n";
+
+      auto SBTOrErr = createShaderBindingTable(*State.Pipeline, *P.SBT);
+      if (!SBTOrErr)
+        return SBTOrErr.takeError();
+      State.SBT = std::move(*SBTOrErr);
+      llvm::outs() << "Shader Binding Table created.\n";
     } else {
       return llvm::createStringError(
           "Pipeline was neither Compute nor Traditional Raster");
@@ -4511,7 +4699,7 @@ public:
 llvm::Error VKComputeEncoder::batchBuildAS(llvm::ArrayRef<ASBuildItem> Items) {
   if (Items.empty())
     return llvm::Error::success();
-  if (!CB.Dev || !CB.Dev->RT.CmdBuild)
+  if (!CB.Dev || !CB.Dev->AS.CmdBuild)
     return llvm::createStringError(
         std::errc::not_supported,
         "Ray tracing not supported on this command buffer's device.");
@@ -4527,7 +4715,7 @@ llvm::Error VKComputeEncoder::batchBuildAS(llvm::ArrayRef<ASBuildItem> Items) {
                     VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_KHR);
 
   const size_t N = Items.size();
-  // Per-item arrays must outlive the RT.CmdBuild() call.
+  // Per-item arrays must outlive the AS.CmdBuild() call.
   llvm::SmallVector<llvm::SmallVector<VkAccelerationStructureGeometryKHR>>
       Geoms(N);
   llvm::SmallVector<llvm::SmallVector<VkAccelerationStructureBuildRangeInfoKHR>>
@@ -4683,8 +4871,330 @@ llvm::Error VKComputeEncoder::batchBuildAS(llvm::ArrayRef<ASBuildItem> Items) {
 
   insertDebugSignpost(
       llvm::formatv("BuildAccelerationStructures x{0}", N).str());
-  Dev->RT.CmdBuild(CB.CmdBuffer, static_cast<uint32_t>(N), BuildInfos.data(),
+  Dev->AS.CmdBuild(CB.CmdBuffer, static_cast<uint32_t>(N), BuildInfos.data(),
                    RangePtrs.data());
+  return llvm::Error::success();
+}
+
+// === Ray tracing pipeline + SBT + DispatchRays ============================
+
+static VkRayTracingShaderGroupTypeKHR getRTGroupType(HitGroupType T) {
+  switch (T) {
+  case HitGroupType::Triangles:
+    return VK_RAY_TRACING_SHADER_GROUP_TYPE_TRIANGLES_HIT_GROUP_KHR;
+  case HitGroupType::Procedural:
+    return VK_RAY_TRACING_SHADER_GROUP_TYPE_PROCEDURAL_HIT_GROUP_KHR;
+  }
+  llvm_unreachable("All HitGroupType cases handled");
+}
+
+llvm::Expected<std::unique_ptr<PipelineState>>
+VulkanDevice::createPipelineRT(llvm::StringRef Name, const BindingsDesc &BD,
+                               const RayTracingPipelineCreateDesc &Desc) {
+  if (!HasRTPipelineSupport)
+    return llvm::createStringError(
+        std::errc::not_supported,
+        "Device does not support VK_KHR_ray_tracing_pipeline");
+  if (!Desc.Library)
+    return llvm::createStringError(std::errc::invalid_argument,
+                                   "RayTracingPipelineCreateDesc.Library is "
+                                   "null — backend needs a DXIL/SPIR-V blob.");
+
+  // Single shader module backs every RT entry point — the DXIL library
+  // compiles to one SPIR-V module with multiple OpEntryPoints.
+  auto ModOrErr = createShaderModule(Desc.Library, "raytracing library");
+  if (!ModOrErr)
+    return ModOrErr.takeError();
+  VkShaderModule Module = *ModOrErr;
+  auto ModuleCleanup =
+      llvm::scope_exit([&] { vkDestroyShaderModule(Device, Module, nullptr); });
+
+  // Pipeline layout: every RT stage may consume any binding from the global
+  // descriptor sets (mirrors a DX12 global root signature).
+  const VkShaderStageFlags AllRTStages =
+      VK_SHADER_STAGE_RAYGEN_BIT_KHR | VK_SHADER_STAGE_MISS_BIT_KHR |
+      VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR | VK_SHADER_STAGE_ANY_HIT_BIT_KHR |
+      VK_SHADER_STAGE_INTERSECTION_BIT_KHR | VK_SHADER_STAGE_CALLABLE_BIT_KHR;
+  llvm::SmallVector<VkDescriptorSetLayout> SetLayouts;
+  VkPipelineLayout Layout = VK_NULL_HANDLE;
+  if (auto Err = createPipelineLayout(BD, AllRTStages, SetLayouts, Layout))
+    return Err;
+  auto LayoutCleanup = llvm::scope_exit([&] {
+    if (Layout != VK_NULL_HANDLE)
+      vkDestroyPipelineLayout(Device, Layout, nullptr);
+    for (auto *L : SetLayouts)
+      vkDestroyDescriptorSetLayout(Device, L, nullptr);
+  });
+
+  llvm::SmallVector<VkPipelineShaderStageCreateInfo> StageCIs;
+  StageCIs.reserve(Desc.Shaders.size());
+  llvm::StringMap<uint32_t> EntryToStageIdx;
+  for (const auto &Sh : Desc.Shaders) {
+    VkPipelineShaderStageCreateInfo CI{};
+    CI.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+    CI.stage = getShaderStageFlag(Sh.Stage);
+    CI.module = Module;
+    CI.pName = Sh.EntryPoint.c_str();
+    EntryToStageIdx[Sh.EntryPoint] = static_cast<uint32_t>(StageCIs.size());
+    StageCIs.push_back(CI);
+  }
+
+  llvm::SmallVector<VkRayTracingShaderGroupCreateInfoKHR> Groups;
+  llvm::StringMap<uint32_t> NameToGroup;
+  auto AddGeneralGroup = [&](llvm::StringRef Key, uint32_t StageIdx) {
+    VkRayTracingShaderGroupCreateInfoKHR G{};
+    G.sType = VK_STRUCTURE_TYPE_RAY_TRACING_SHADER_GROUP_CREATE_INFO_KHR;
+    G.type = VK_RAY_TRACING_SHADER_GROUP_TYPE_GENERAL_KHR;
+    G.generalShader = StageIdx;
+    G.closestHitShader = VK_SHADER_UNUSED_KHR;
+    G.anyHitShader = VK_SHADER_UNUSED_KHR;
+    G.intersectionShader = VK_SHADER_UNUSED_KHR;
+    NameToGroup[Key] = static_cast<uint32_t>(Groups.size());
+    Groups.push_back(G);
+  };
+
+  uint32_t NumRG = 0, NumMS = 0, NumHG = 0, NumCL = 0;
+  for (const auto &Sh : Desc.Shaders)
+    if (Sh.Stage == Stages::RayGeneration) {
+      AddGeneralGroup(Sh.EntryPoint, EntryToStageIdx[Sh.EntryPoint]);
+      ++NumRG;
+    }
+  for (const auto &Sh : Desc.Shaders)
+    if (Sh.Stage == Stages::Miss) {
+      AddGeneralGroup(Sh.EntryPoint, EntryToStageIdx[Sh.EntryPoint]);
+      ++NumMS;
+    }
+  for (const auto &HG : Desc.HitGroups) {
+    VkRayTracingShaderGroupCreateInfoKHR G{};
+    G.sType = VK_STRUCTURE_TYPE_RAY_TRACING_SHADER_GROUP_CREATE_INFO_KHR;
+    G.type = getRTGroupType(HG.Type);
+    G.generalShader = VK_SHADER_UNUSED_KHR;
+    auto FindIdx = [&](const std::string &Entry) -> uint32_t {
+      auto It = EntryToStageIdx.find(Entry);
+      return It == EntryToStageIdx.end() ? VK_SHADER_UNUSED_KHR : It->second;
+    };
+    G.closestHitShader = FindIdx(HG.ClosestHit);
+    G.anyHitShader = HG.AnyHit ? FindIdx(*HG.AnyHit) : VK_SHADER_UNUSED_KHR;
+    G.intersectionShader =
+        HG.Intersection ? FindIdx(*HG.Intersection) : VK_SHADER_UNUSED_KHR;
+    NameToGroup[HG.Name] = static_cast<uint32_t>(Groups.size());
+    Groups.push_back(G);
+    ++NumHG;
+  }
+  for (const auto &Sh : Desc.Shaders)
+    if (Sh.Stage == Stages::Callable) {
+      AddGeneralGroup(Sh.EntryPoint, EntryToStageIdx[Sh.EntryPoint]);
+      ++NumCL;
+    }
+
+  VkRayTracingPipelineCreateInfoKHR PipelineCI{};
+  PipelineCI.sType = VK_STRUCTURE_TYPE_RAY_TRACING_PIPELINE_CREATE_INFO_KHR;
+  PipelineCI.stageCount = static_cast<uint32_t>(StageCIs.size());
+  PipelineCI.pStages = StageCIs.data();
+  PipelineCI.groupCount = static_cast<uint32_t>(Groups.size());
+  PipelineCI.pGroups = Groups.data();
+  PipelineCI.maxPipelineRayRecursionDepth = Desc.Config.MaxTraceRecursionDepth;
+  PipelineCI.layout = Layout;
+
+  VkPipeline Pipeline = VK_NULL_HANDLE;
+  if (auto Err =
+          VK::toError(RT.CreatePipelines(Device, VK_NULL_HANDLE, VK_NULL_HANDLE,
+                                         1, &PipelineCI, nullptr, &Pipeline),
+                      "Failed to create ray tracing pipeline."))
+    return Err;
+
+  auto State = std::make_unique<VKRayTracingPipelineState>(
+      Name, Device, Pipeline, Layout, std::move(SetLayouts));
+  State->ShaderGroupIndices = std::move(NameToGroup);
+  State->NumRaygenGroups = NumRG;
+  State->NumMissGroups = NumMS;
+  State->NumHitGroups = NumHG;
+  State->NumCallableGroups = NumCL;
+  // Ownership transferred — disable cleanup.
+  Layout = VK_NULL_HANDLE;
+  SetLayouts.clear();
+  return State;
+}
+
+llvm::Expected<std::unique_ptr<ShaderBindingTable>>
+VulkanDevice::createShaderBindingTable(const PipelineState &PSO,
+                                       const ShaderBindingTableDesc &Desc) {
+  if (!HasRTPipelineSupport)
+    return llvm::createStringError(
+        std::errc::not_supported,
+        "Device does not support VK_KHR_ray_tracing_pipeline");
+  if (!llvm::isa<VKRayTracingPipelineState>(&PSO))
+    return llvm::createStringError(
+        std::errc::invalid_argument,
+        "createShaderBindingTable requires a RayTracing PipelineState");
+  const auto &VKPSO = llvm::cast<VKRayTracingPipelineState>(PSO);
+
+  const uint32_t HandleSize = RTPipelineProps.shaderGroupHandleSize;
+  const SBTLayout Layout =
+      computeSBTLayout(HandleSize, RTPipelineProps.shaderGroupHandleAlignment,
+                       RTPipelineProps.shaderGroupBaseAlignment, Desc);
+  const VkDeviceSize TotalSize = Layout.TotalSize;
+  // Vulkan dispatches a single raygen per vkCmdTraceRaysKHR; the descriptor
+  // only carries one raygen entry, so its region holds exactly one record.
+  const llvm::ArrayRef<SBTEntry> RGEntries(&Desc.RayGen, 1);
+
+  // Pull all shader group handles at once. Vulkan returns them in pipeline
+  // order matching the order groups were given to vkCreateRayTracingPipelines.
+  llvm::SmallVector<uint8_t> AllHandles(VKPSO.totalGroupCount() * HandleSize);
+  if (auto Err = VK::toError(
+          RT.GetGroupHandles(Device, VKPSO.Pipeline, 0, VKPSO.totalGroupCount(),
+                             AllHandles.size(), AllHandles.data()),
+          "vkGetRayTracingShaderGroupHandlesKHR failed."))
+    return Err;
+
+  // Allocate the SBT in a host-visible coherent buffer (PR2 simplification —
+  // a staging-copy to a device-local buffer is a follow-up optimization).
+  VkBufferCreateInfo BufInfo{};
+  BufInfo.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+  BufInfo.size = TotalSize;
+  BufInfo.usage = VK_BUFFER_USAGE_SHADER_BINDING_TABLE_BIT_KHR |
+                  VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT |
+                  VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
+  BufInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+  VkBuffer Buffer = VK_NULL_HANDLE;
+  if (auto Err = VK::toError(vkCreateBuffer(Device, &BufInfo, nullptr, &Buffer),
+                             "Failed to create SBT buffer."))
+    return Err;
+
+  VkMemoryRequirements MemReqs;
+  vkGetBufferMemoryRequirements(Device, Buffer, &MemReqs);
+  VkMemoryAllocateFlagsInfo AllocFlagsInfo{};
+  AllocFlagsInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_FLAGS_INFO;
+  AllocFlagsInfo.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT;
+  VkMemoryAllocateInfo AllocInfo{};
+  AllocInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+  AllocInfo.pNext = &AllocFlagsInfo;
+  AllocInfo.allocationSize = MemReqs.size;
+  auto MemIdx = getMemoryIndex(PhysicalDevice, MemReqs.memoryTypeBits,
+                               VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
+                                   VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+  if (!MemIdx) {
+    vkDestroyBuffer(Device, Buffer, nullptr);
+    return MemIdx.takeError();
+  }
+  AllocInfo.memoryTypeIndex = *MemIdx;
+  VkDeviceMemory Memory = VK_NULL_HANDLE;
+  if (auto Err =
+          VK::toError(vkAllocateMemory(Device, &AllocInfo, nullptr, &Memory),
+                      "Failed to allocate SBT memory.")) {
+    vkDestroyBuffer(Device, Buffer, nullptr);
+    return Err;
+  }
+  if (auto Err = VK::toError(vkBindBufferMemory(Device, Buffer, Memory, 0),
+                             "Failed to bind SBT memory.")) {
+    vkFreeMemory(Device, Memory, nullptr);
+    vkDestroyBuffer(Device, Buffer, nullptr);
+    return Err;
+  }
+
+  void *MappedRaw = nullptr;
+  if (auto Err = VK::toError(
+          vkMapMemory(Device, Memory, 0, VK_WHOLE_SIZE, 0, &MappedRaw),
+          "Failed to map SBT memory.")) {
+    vkFreeMemory(Device, Memory, nullptr);
+    vkDestroyBuffer(Device, Buffer, nullptr);
+    return Err;
+  }
+  auto *Mapped = static_cast<uint8_t *>(MappedRaw);
+  std::memset(Mapped, 0, TotalSize);
+
+  // Resolve each SBT entry's ShaderName → shader-group index, then write
+  // [handle][localRootData][pad] into the region at the right offset.
+  auto WriteEntries = [&](uint8_t *Region, llvm::ArrayRef<SBTEntry> Entries,
+                          uint32_t Stride) -> llvm::Error {
+    for (size_t I = 0; I < Entries.size(); ++I) {
+      const auto &E = Entries[I];
+      auto It = VKPSO.ShaderGroupIndices.find(E.ShaderName);
+      if (It == VKPSO.ShaderGroupIndices.end())
+        return llvm::createStringError(
+            std::errc::invalid_argument,
+            "SBT references unknown shader/hit-group name: '%s'",
+            E.ShaderName.c_str());
+      uint8_t *Dst = Region + I * Stride;
+      std::memcpy(Dst, AllHandles.data() + It->second * HandleSize, HandleSize);
+      if (!E.LocalRootData.empty())
+        std::memcpy(Dst + HandleSize, E.LocalRootData.data(),
+                    E.LocalRootData.size());
+    }
+    return llvm::Error::success();
+  };
+
+  auto WriteRegion = [&](const SBTRegionLayout &R,
+                         llvm::ArrayRef<SBTEntry> Entries) -> llvm::Error {
+    return WriteEntries(Mapped + R.Offset, Entries, R.Stride);
+  };
+  auto CleanupAndReturn = [&](llvm::Error Err) {
+    vkUnmapMemory(Device, Memory);
+    vkFreeMemory(Device, Memory, nullptr);
+    vkDestroyBuffer(Device, Buffer, nullptr);
+    return Err;
+  };
+  if (auto Err = WriteRegion(Layout.RayGen, RGEntries))
+    return CleanupAndReturn(std::move(Err));
+  if (auto Err = WriteRegion(Layout.Miss, Desc.Miss))
+    return CleanupAndReturn(std::move(Err));
+  if (auto Err = WriteRegion(Layout.HitGroup, Desc.HitGroup))
+    return CleanupAndReturn(std::move(Err));
+  if (auto Err = WriteRegion(Layout.Callable, Desc.Callable))
+    return CleanupAndReturn(std::move(Err));
+  vkUnmapMemory(Device, Memory);
+
+  VkBufferDeviceAddressInfo AddrInfo{};
+  AddrInfo.sType = VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO;
+  AddrInfo.buffer = Buffer;
+  const VkDeviceAddress Base = vkGetBufferDeviceAddress(Device, &AddrInfo);
+
+  // VkStridedDeviceAddressRegionKHR uses a zero deviceAddress to signal an
+  // empty region — matching what the SBT layout helper records as Size == 0.
+  auto MakeRegion = [&](const SBTRegionLayout &R) {
+    return VkStridedDeviceAddressRegionKHR{R.Size ? Base + R.Offset : 0,
+                                           R.Stride, R.Size};
+  };
+  const VkStridedDeviceAddressRegionKHR RG = MakeRegion(Layout.RayGen);
+  const VkStridedDeviceAddressRegionKHR MS = MakeRegion(Layout.Miss);
+  const VkStridedDeviceAddressRegionKHR HG = MakeRegion(Layout.HitGroup);
+  const VkStridedDeviceAddressRegionKHR CL = MakeRegion(Layout.Callable);
+  return std::make_unique<VKShaderBindingTable>(Device, Buffer, Memory, RG, MS,
+                                                HG, CL);
+}
+
+llvm::Error VKComputeEncoder::dispatchRays(const PipelineState &PSO,
+                                           const ShaderBindingTable &SBT,
+                                           uint32_t Width, uint32_t Height,
+                                           uint32_t Depth) {
+  if (!CB.Dev || !CB.Dev->RT.CmdTraceRays)
+    return llvm::createStringError(
+        std::errc::not_supported,
+        "vkCmdTraceRaysKHR entry point not loaded on this device.");
+  if (!llvm::isa<VKRayTracingPipelineState>(&PSO))
+    return llvm::createStringError(
+        std::errc::invalid_argument,
+        "dispatchRays requires a RayTracing PipelineState.");
+  if (!llvm::isa<VKShaderBindingTable>(&SBT))
+    return llvm::createStringError(
+        std::errc::invalid_argument,
+        "dispatchRays requires a Vulkan ShaderBindingTable.");
+  const auto &VKPSO = llvm::cast<VKRayTracingPipelineState>(PSO);
+  const auto &VKSBT = llvm::cast<VKShaderBindingTable>(SBT);
+
+  // Outgoing access from prior pipeline stages must complete before the RT
+  // pipeline reads the AS, SBT, and bound resources.
+  addDstBarrier(VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR,
+                VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_KHR |
+                    VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_SHADER_WRITE_BIT);
+
+  insertDebugSignpost(
+      llvm::formatv("TraceRays {0}x{1}x{2}", Width, Height, Depth).str());
+  vkCmdBindPipeline(CB.CmdBuffer, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR,
+                    VKPSO.Pipeline);
+  CB.Dev->RT.CmdTraceRays(CB.CmdBuffer, &VKSBT.RaygenRegion, &VKSBT.MissRegion,
+                          &VKSBT.HitRegion, &VKSBT.CallableRegion, Width,
+                          Height, Depth);
   return llvm::Error::success();
 }
 } // namespace

--- a/lib/Support/Pipeline.cpp
+++ b/lib/Support/Pipeline.cpp
@@ -721,8 +721,8 @@ void MappingTraits<offloadtest::SBTEntry>::mapping(IO &I,
   }
 }
 
-void MappingTraits<offloadtest::ShaderBindingTable>::mapping(
-    IO &I, offloadtest::ShaderBindingTable &S) {
+void MappingTraits<offloadtest::ShaderBindingTableDesc>::mapping(
+    IO &I, offloadtest::ShaderBindingTableDesc &S) {
   I.mapRequired("RayGen", S.RayGen);
   I.mapOptional("Miss", S.Miss);
   I.mapOptional("HitGroup", S.HitGroup);

--- a/test/Feature/RT/raygen-roundtrip.test
+++ b/test/Feature/RT/raygen-roundtrip.test
@@ -106,7 +106,7 @@ Results:
 
 # REQUIRES: raytracing-pipeline
 # Unimplemented https://github.com/llvm/offload-test-suite/issues/1268
-# XFAIL: *
+# XFAIL: Clang, DirectX, Metal
 
 # RUN: split-file %s %t
 # RUN: %dxc_target_lib -T lib_6_5 -Fo %t.o %t/source.hlsl

--- a/tools/offloader/offloader.cpp
+++ b/tools/offloader/offloader.cpp
@@ -113,16 +113,27 @@ static int run() {
   YIn >> PipelineDesc;
   ExitOnErr(llvm::errorCodeToError(YIn.error()));
 
-  // Read in the shaders
-  for (size_t I = 0; I < InputShader.size(); ++I) {
-    PipelineDesc.Shaders[I].Shader = readFile(InputShader[I]);
+  // Read in the shaders. Ray tracing PSOs compile every entry point into a
+  // single library blob, so one input file backs all Shaders[] entries; the
+  // backend reads the blob from Shaders.front() and uses the rest only for
+  // their (Stage, Entry) metadata. Other pipelines expect one object file per
+  // stage.
+  if (PipelineDesc.isRayTracing()) {
+    if (InputShader.size() != 1)
+      ExitOnErr(createStringError(
+          std::errc::invalid_argument,
+          "RayTracing pipeline expects a single shader library, %d provided",
+          InputShader.size()));
+    PipelineDesc.Shaders.front().Shader = readFile(InputShader[0]);
+  } else {
+    if (InputShader.size() != PipelineDesc.Shaders.size())
+      ExitOnErr(createStringError(
+          std::errc::invalid_argument,
+          "Pipeline description expects %d shader(s) %d provided",
+          PipelineDesc.Shaders.size(), InputShader.size()));
+    for (size_t I = 0; I < InputShader.size(); ++I)
+      PipelineDesc.Shaders[I].Shader = readFile(InputShader[I]);
   }
-
-  if (InputShader.size() != PipelineDesc.Shaders.size())
-    ExitOnErr(createStringError(
-        std::errc::invalid_argument,
-        "Pipeline description expects %d shader(s) %d provided",
-        PipelineDesc.Shaders.size(), InputShader.size()));
 
   // Try to guess the API by reading the shader binary.
   const StringRef Binary = PipelineDesc.Shaders[0].Shader->getBuffer();


### PR DESCRIPTION
## Summary

First per-backend bring-up in the PSO raytracing series (#1268). Stacks on top of #1270 (foundational schema + lit infrastructure + XFAILed test). Adds the API surface needed by the upcoming D3D12 and Metal PRs plus the Vulkan implementation behind it.

API surface:

- `ComputeEncoder::dispatchRays(PSO, SBT, W, H, D)` virtual on the existing compute encoder (no separate `RayTracingEncoder`).
- `Device::createPipelineRT` + `Device::createShaderBindingTable` virtuals with a new `RayTracingPipelineCreateDesc` carrying the DXIL library blob, the shader entry points (Stage + EntryPoint), the hit-group list, and the `RayTracingPipelineConfig`.
- `include/API/ShaderBindingTable.h` holding the abstract runtime base; backend SBT classes derive from it with LLVM-style `classof` / `cast<>`.
- Rename: PR #1270's YAML struct `ShaderBindingTable` → `ShaderBindingTableDesc` so the bare name is free for the runtime class (parallel to `BLASDesc` / `TLASDesc` vs `AccelerationStructure`). YAML key stays `ShaderBindingTable:`.
- D3D12 and Metal stub the new methods with not-yet-supported errors; their bring-up lands in follow-up PRs.

Vulkan implementation:

- The pre-existing `RaytracingFunctions RT` struct lumped AS and RT-pipeline entry points together; they split into `ASFunctions AS` + `RTPipelineFunctions RT` so the names match the actual feature-gate split (AS + ray-query is a complete configuration; RT pipeline layers on top). `HasRayTracingSupport` renames to `HasASSupport`; `HasRTPipelineSupport` tracks the new extension.
- `VK_KHR_ray_tracing_pipeline` is requested when reported, with `VkPhysicalDeviceRayTracingPipelineFeaturesKHR` chained pre-query and the gating `rayTracingPipeline` bool checked post-query (matches the AS / BDA pattern from #1232). Sub-features the tests don't exercise (capture-replay / indirect-trace / traversal-primitive-culling) are cleared.
- Function pointers `vkCreateRayTracingPipelinesKHR`, `vkGetRayTracingShaderGroupHandlesKHR`, `vkCmdTraceRaysKHR` resolve once at device creation. `VkPhysicalDeviceRayTracingPipelinePropertiesKHR` is cached at the same time for SBT handle size / alignment / base alignment.
- `VKRayTracingPipelineState` derives from `VulkanPipelineState`; an `IsRayTracing` flag on the base lets the existing Vulkan `cast<>` path stay polymorphic without adding a new `GPUAPI` value. The derived class also carries a `StringMap<uint32_t>` resolving each shader `EntryPoint` or hit-group `Name` to its index in the pipeline's group array, plus per-bucket counts so the SBT builder can slice the contiguous handle blob into raygen / miss / hit / callable regions.
- `createPipelineRT` builds a single `VkShaderModule` (the DXIL library compiles to one SPIR-V module with multiple `OpEntryPoint`s), one `VkPipelineShaderStageCreateInfo` per `Shader` entry, and one `VkRayTracingShaderGroupCreateInfoKHR` per general shader / hit group. Pipeline layout uses the same `createPipelineLayout` helper as the compute path, gated on all six RT stage flags so any binding can be consumed from any RT shader.
- `createShaderBindingTable` allocates a host-visible coherent buffer big enough for four regions, then lays out each entry as `[handle bytes][LocalRootData bytes][padding-to-stride]`. Per-region stride = `align(handleSize + max-LocalRootData-in-region, handleAlignment)`; per-region size = `align(count * stride, baseAlignment)`. LocalRootData support comes for free from PR #1270's SBT schema; the test doesn't exercise it yet. Each region's `VkStridedDeviceAddressRegionKHR` derives from the buffer's `vkGetBufferDeviceAddress`.
- `dispatchRays` binds the pipeline at `VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR`, emits a pre-barrier with `ACCELERATION_STRUCTURE_READ_BIT_KHR | SHADER_READ_BIT | SHADER_WRITE_BIT` dst access into `RAY_TRACING_SHADER_BIT_KHR`, then calls `vkCmdTraceRaysKHR` with the SBT's four region structs.
- `createCommands` picks the new bind point for RT pipelines so `vkCmdBindDescriptorSets` binds to the right point. `executeProgram`'s `isRayTracing` branch builds a `RayTracingPipelineCreateDesc` from the `Pipeline`, calls `createPipelineRT` then `createShaderBindingTable`, and keeps both on `InvocationState` for the dispatch.

Test side: `raygen-roundtrip.test`'s `XFAIL` becomes `Clang, DirectX, Metal`. On a DXC + Vulkan combo with the device reporting `VK_KHR_ray_tracing_pipeline` this should PASS; the Clang token still catches the compile failure on the Linux + `clang-dxc` loop where `[shader("raygeneration")]` doesn't yet lower to SPIR-V.

## Test plan

Local on an NVIDIA RTX 3060:
- [x] Linux Vulkan (native `offloader`)
- [ ] Linux D3D12 (Wine + vkd3d-proton + cross-compiled `offloader.exe`)
- [ ] Windows Vulkan (native `offloader.exe`)
- [ ] Windows D3D12 (native `offloader.exe`)

CI (RT-capable runners):
- [ ] windows-nvidia D3D12 (`RaytracingTier 1.2`)
- [ ] windows-intel VK (`VK_KHR_ray_tracing_pipeline`)
- [x] macOS Metal (`supportsRaytracing`)
