### PR TITLE
[Utils] Add explicit encoding option to subprocess.run() for github API responses that are non-ASCII

### DIFF
--- a/utils/runner_status.py
+++ b/utils/runner_status.py
@@ -62,6 +62,7 @@ def api_get(path):
         ["gh", "api", "-H", "Accept: application/vnd.github+json", path],
         capture_output=True,
         text=True,
+        encoding="utf-8",
         check=True,
     )
     return json.loads(result.stdout)


### PR DESCRIPTION
This PR adds an explicit encoding option to subprocess.run() to process non-ASCII characters in Github API responses.
Improves reliability of the script.