### PR TITLE
[Intel] Add a means to check which intel gpu generation for vulkan and directX

### DIFF
--- a/include/API/Device.h
+++ b/include/API/Device.h
@@ -191,6 +191,7 @@ protected:
   std::string Description;
   std::string DriverName;
   std::string DriverVersion;
+  std::string GPUGeneration;
 
 public:
   virtual const Capabilities &getCapabilities() = 0;

--- a/include/API/Device.h
+++ b/include/API/Device.h
@@ -192,6 +192,7 @@ protected:
   std::string DriverName;
   std::string DriverVersion;
   std::string GPUGeneration;
+  uint16_t FamilyPrefix = 0;
 
 public:
   virtual const Capabilities &getCapabilities() = 0;
@@ -248,6 +249,8 @@ public:
   llvm::StringRef getDescription() const { return Description; }
   llvm::StringRef getDriverName() const { return DriverName; }
   llvm::StringRef getDriverVersion() const { return DriverVersion; }
+  llvm::StringRef getGPUGeneration() const { return GPUGeneration; }
+  uint16_t getFamilyPrefix() const { return FamilyPrefix; }
 };
 
 llvm::Error

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -1020,6 +1020,7 @@ public:
                                        &HardwareID))) {
       // 0x8086 is the Vendor ID for Intel
       if (HardwareID.vendorID == 0x8086) {
+        FamilyPrefix = static_cast<uint16_t>(HardwareID.deviceID) & 0xFF00;
         const IntelGpuEra Era =
             getIntelGpuEra(static_cast<uint16_t>(HardwareID.deviceID));
         if (Era == IntelGpuEra::Gen7_to_10)

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -1014,6 +1014,25 @@ public:
     Description = std::move(Desc);
     DriverVersion = std::move(DriverVer);
     DriverName = "DirectX";
+
+    DXCoreHardwareID HardwareID;
+    if (SUCCEEDED(Adapter->GetProperty(DXCoreAdapterProperty::HardwareID,
+                                       &HardwareID))) {
+      // 0x8086 is the Vendor ID for Intel
+      if (HardwareID.vendorID == 0x8086) {
+        const IntelGpuEra Era =
+            getIntelGpuEra(static_cast<uint16_t>(HardwareID.deviceID));
+        if (Era == IntelGpuEra::Gen7_to_10)
+          GPUGeneration = "Intel Gen7-10";
+        else if (Era == IntelGpuEra::Gen11_to_14_and_Xe)
+          GPUGeneration = "Intel Gen11-14/Xe";
+        else
+          GPUGeneration = "Intel Unknown";
+      } else {
+        // We don't have a need yet to identify other GPU vendors.
+        GPUGeneration = "Unknown";
+      }
+    }
   }
   DXDevice(const DXDevice &) = delete;
   DXDevice &operator=(const DXDevice &) = delete;

--- a/lib/API/Util.cpp
+++ b/lib/API/Util.cpp
@@ -47,3 +47,25 @@ llvm::Error offloadtest::findAndValidateRenderPassTextureSize(
 
   return llvm::Error::success();
 }
+
+offloadtest::IntelGpuEra offloadtest::getIntelGpuEra(uint16_t DeviceId) {
+  uint16_t FamilyPrefix = DeviceId & 0xFF00;
+  switch (FamilyPrefix) {
+  case 0x5900: // Kaby Lake (7th Gen)
+  case 0x3E00: // Coffee Lake / Whiskey Lake (8th/9th Gen)
+  case 0x9B00: // Comet Lake (10th Gen)
+  case 0x8A00: // Ice Lake (10th Gen)
+    return IntelGpuEra::Gen7_to_10;
+  case 0x9A00: // Tiger Lake (11th Gen)
+  case 0x4C00: // Rocket Lake (11th Gen Desktop)
+  case 0x4600: // Alder Lake (12th Gen)
+  case 0xA700: // Raptor Lake (13th Gen)
+  case 0x7D00: // Meteor Lake (14th Gen Core Ultra)
+  case 0x5600: // Arc Alchemist (Discrete Xe-HPG)
+  case 0x4F00: // DG1 (Discrete Xe-LP)
+  case 0x0B00: // Ponte Vecchio (Xe-HPC / Data Center Max)
+    return IntelGpuEra::Gen11_to_14_and_Xe;
+  default:
+    return IntelGpuEra::UnknownOrLegacy;
+  }
+}

--- a/lib/API/Util.cpp
+++ b/lib/API/Util.cpp
@@ -49,7 +49,7 @@ llvm::Error offloadtest::findAndValidateRenderPassTextureSize(
 }
 
 offloadtest::IntelGpuEra offloadtest::getIntelGpuEra(uint16_t DeviceId) {
-  uint16_t FamilyPrefix = DeviceId & 0xFF00;
+  const uint16_t FamilyPrefix = DeviceId & 0xFF00;
   switch (FamilyPrefix) {
   case 0x5900: // Kaby Lake (7th Gen)
   case 0x3E00: // Coffee Lake / Whiskey Lake (8th/9th Gen)

--- a/lib/API/Util.cpp
+++ b/lib/API/Util.cpp
@@ -64,6 +64,8 @@ offloadtest::IntelGpuEra offloadtest::getIntelGpuEra(uint16_t DeviceId) {
   case 0x5600: // Arc Alchemist (Discrete Xe-HPG)
   case 0x4F00: // DG1 (Discrete Xe-LP)
   case 0x0B00: // Ponte Vecchio (Xe-HPC / Data Center Max)
+  case 0xE200: // Battlemage Discrete
+  case 0x6400: // Lunar Lake Integrated
     return IntelGpuEra::Gen11_to_14_and_Xe;
   default:
     return IntelGpuEra::UnknownOrLegacy;

--- a/lib/API/Util.h
+++ b/lib/API/Util.h
@@ -25,6 +25,9 @@ llvm::Error findAndValidateRenderPassTextureSize(const RenderPassBeginDesc &,
                                                  uint32_t *OutWidth,
                                                  uint32_t *OutHeight);
 
+enum class IntelGpuEra { UnknownOrLegacy, Gen7_to_10, Gen11_to_14_and_Xe };
+
+IntelGpuEra getIntelGpuEra(uint16_t deviceId);
 } // namespace offloadtest
 
 #endif // OFFLOADTEST_API_UTIL_H

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -1522,6 +1522,21 @@ public:
     const uint64_t DriverInfoSz =
         strnlen(DriverProps.driverInfo, VK_MAX_DRIVER_INFO_SIZE);
     DriverVersion = std::string(DriverProps.driverInfo, DriverInfoSz);
+
+    // 0x8086 is the Vendor ID for Intel
+    if (Props.vendorID == 0x8086) {
+      const IntelGpuEra Era =
+          getIntelGpuEra(static_cast<uint16_t>(Props.deviceID));
+      if (Era == IntelGpuEra::Gen7_to_10)
+        GPUGeneration = "Intel Gen7-10";
+      else if (Era == IntelGpuEra::Gen11_to_14_and_Xe)
+        GPUGeneration = "Intel Gen11-14/Xe";
+      else
+        GPUGeneration = "Intel Unknown";
+    } else {
+      // We don't have a need yet to identify other GPU vendors.
+      GPUGeneration = "Unknown";
+    }
 #if defined(__APPLE__) && defined(__aarch64__)
     // Apple silicon Macs may have multiple Vulkan drivers sharing one device
     // name. Include the driver name in the description to enable
@@ -4284,6 +4299,7 @@ llvm::Error offloadtest::initializeVulkanDevices(
     return Err;
 
   for (const auto &PDev : PhysicalDevices) {
+
     auto DeviceOrErr = VulkanDevice::create(VulkanInstanceShPtr, PDev,
                                             AvailableInstanceLayers);
     if (!DeviceOrErr) {

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -1525,6 +1525,7 @@ public:
 
     // 0x8086 is the Vendor ID for Intel
     if (Props.vendorID == 0x8086) {
+      FamilyPrefix = static_cast<uint16_t>(Props.deviceID) & 0xFF00;
       const IntelGpuEra Era =
           getIntelGpuEra(static_cast<uint16_t>(Props.deviceID));
       if (Era == IntelGpuEra::Gen7_to_10)

--- a/test/Basic/Matrix/matrix_const_single_subscript.i2x3.test
+++ b/test/Basic/Matrix/matrix_const_single_subscript.i2x3.test
@@ -96,7 +96,7 @@ DescriptorSets:
 # XFAIL: Vulkan && Clang
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/696
-# XFAIL: Intel-Modern-GPU && DirectX && Clang
+# XFAIL:Intel-Gen-Current && DirectX && Clang
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl

--- a/test/Basic/Matrix/matrix_const_single_subscript.i2x3.test
+++ b/test/Basic/Matrix/matrix_const_single_subscript.i2x3.test
@@ -95,6 +95,9 @@ DescriptorSets:
 # Bug: https://github.com/llvm/offload-test-suite/issues/660
 # XFAIL: Vulkan && Clang
 
+# Bug: https://github.com/llvm/offload-test-suite/issues/696
+# XFAIL: Intel-Modern-GPU && DirectX && Clang
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Basic/Matrix/matrix_construct_by_sub_mat.test
+++ b/test/Basic/Matrix/matrix_construct_by_sub_mat.test
@@ -61,6 +61,9 @@ DescriptorSets:
 ...
 #--- end
 
+# Bug: https://github.com/llvm/offload-test-suite/issues/696
+# XFAIL: Intel-Modern-GPU && DirectX && Clang
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Basic/Matrix/matrix_construct_by_sub_mat.test
+++ b/test/Basic/Matrix/matrix_construct_by_sub_mat.test
@@ -62,7 +62,7 @@ DescriptorSets:
 #--- end
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/696
-# XFAIL: Intel-Modern-GPU && DirectX && Clang
+# XFAIL:Intel-Gen-Current && DirectX && Clang
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl

--- a/test/Basic/Matrix/matrix_elementwise_cast.test
+++ b/test/Basic/Matrix/matrix_elementwise_cast.test
@@ -100,7 +100,7 @@ DescriptorSets:
 #--- end
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/696
-# XFAIL: Intel-Modern-GPU && DirectX && Clang
+# XFAIL:Intel-Gen-Current && DirectX && Clang
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl

--- a/test/Basic/Matrix/matrix_elementwise_cast.test
+++ b/test/Basic/Matrix/matrix_elementwise_cast.test
@@ -98,6 +98,10 @@ DescriptorSets:
         Binding: 3
 ...
 #--- end
+
+# Bug: https://github.com/llvm/offload-test-suite/issues/696
+# XFAIL: Intel-Modern-GPU && DirectX && Clang
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Basic/Matrix/matrix_elementwise_vector_cast.test
+++ b/test/Basic/Matrix/matrix_elementwise_vector_cast.test
@@ -75,6 +75,9 @@ DescriptorSets:
 # Bug https://github.com/llvm/offload-test-suite/issues/599
 # XFAIL: Intel && Vulkan && Clang
 
+# Bug: https://github.com/llvm/offload-test-suite/issues/696
+# XFAIL: Intel-Modern-GPU && DirectX && Clang
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Basic/Matrix/matrix_elementwise_vector_cast.test
+++ b/test/Basic/Matrix/matrix_elementwise_vector_cast.test
@@ -76,7 +76,7 @@ DescriptorSets:
 # XFAIL: Intel && Vulkan && Clang
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/696
-# XFAIL: Intel-Modern-GPU && DirectX && Clang
+# XFAIL:Intel-Gen-Current && DirectX && Clang
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl

--- a/test/Basic/Matrix/matrix_elementwise_vector_cast.test
+++ b/test/Basic/Matrix/matrix_elementwise_vector_cast.test
@@ -73,7 +73,7 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/offload-test-suite/issues/599
-# XFAIL: Intel && Vulkan && Clang
+# XFAIL: Intel-Gen-10 && Vulkan && Clang
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/696
 # XFAIL:Intel-Gen-Current && DirectX && Clang

--- a/test/Basic/Matrix/matrix_scalar_arithmetic.test
+++ b/test/Basic/Matrix/matrix_scalar_arithmetic.test
@@ -82,6 +82,9 @@ DescriptorSets:
 ...
 #--- end
 
+# Bug: https://github.com/llvm/offload-test-suite/issues/696
+# XFAIL: Intel-Modern-GPU && DirectX && Clang
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s

--- a/test/Basic/Matrix/matrix_scalar_arithmetic.test
+++ b/test/Basic/Matrix/matrix_scalar_arithmetic.test
@@ -83,7 +83,7 @@ DescriptorSets:
 #--- end
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/696
-# XFAIL: Intel-Modern-GPU && DirectX && Clang
+# XFAIL:Intel-Gen-Current && DirectX && Clang
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl

--- a/test/Basic/Matrix/matrix_scalar_constructor.test
+++ b/test/Basic/Matrix/matrix_scalar_constructor.test
@@ -55,6 +55,9 @@ DescriptorSets:
 ...
 #--- end
 
+# Bug: https://github.com/llvm/offload-test-suite/issues/696
+# XFAIL: Intel-Modern-GPU && DirectX && Clang
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Basic/Matrix/matrix_scalar_constructor.test
+++ b/test/Basic/Matrix/matrix_scalar_constructor.test
@@ -56,7 +56,7 @@ DescriptorSets:
 #--- end
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/696
-# XFAIL: Intel-Modern-GPU && DirectX && Clang
+# XFAIL:Intel-Gen-Current && DirectX && Clang
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl

--- a/test/Basic/Matrix/matrix_single_subscript_basic.i2x3.test
+++ b/test/Basic/Matrix/matrix_single_subscript_basic.i2x3.test
@@ -96,7 +96,7 @@ DescriptorSets:
 # XFAIL: Vulkan && Clang
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/696
-# XFAIL: Intel-Modern-GPU && DirectX && Clang
+# XFAIL:Intel-Gen-Current && DirectX && Clang
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl

--- a/test/Basic/Matrix/matrix_single_subscript_basic.i2x3.test
+++ b/test/Basic/Matrix/matrix_single_subscript_basic.i2x3.test
@@ -95,6 +95,9 @@ DescriptorSets:
 # Bug: https://github.com/llvm/offload-test-suite/issues/660
 # XFAIL: Vulkan && Clang
 
+# Bug: https://github.com/llvm/offload-test-suite/issues/696
+# XFAIL: Intel-Modern-GPU && DirectX && Clang
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Basic/Matrix/matrix_single_subscript_basic.i3x2.test
+++ b/test/Basic/Matrix/matrix_single_subscript_basic.i3x2.test
@@ -99,6 +99,9 @@ DescriptorSets:
 # Bug: https://github.com/llvm/offload-test-suite/issues/660
 # XFAIL: Vulkan && Clang
 
+# Bug: https://github.com/llvm/offload-test-suite/issues/696
+# XFAIL: Intel-Modern-GPU && DirectX && Clang
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Basic/Matrix/matrix_single_subscript_basic.i3x2.test
+++ b/test/Basic/Matrix/matrix_single_subscript_basic.i3x2.test
@@ -100,7 +100,7 @@ DescriptorSets:
 # XFAIL: Vulkan && Clang
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/696
-# XFAIL: Intel-Modern-GPU && DirectX && Clang
+# XFAIL:Intel-Gen-Current && DirectX && Clang
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl

--- a/test/Basic/Matrix/matrix_single_subscript_basic.test
+++ b/test/Basic/Matrix/matrix_single_subscript_basic.test
@@ -102,7 +102,7 @@ DescriptorSets:
 # XFAIL: Vulkan && Clang
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/696
-# XFAIL: Intel-Modern-GPU && DirectX && Clang
+# XFAIL:Intel-Gen-Current && DirectX && Clang
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl

--- a/test/Basic/Matrix/matrix_single_subscript_basic.test
+++ b/test/Basic/Matrix/matrix_single_subscript_basic.test
@@ -101,6 +101,9 @@ DescriptorSets:
 # Bug: https://github.com/llvm/offload-test-suite/issues/660
 # XFAIL: Vulkan && Clang
 
+# Bug: https://github.com/llvm/offload-test-suite/issues/696
+# XFAIL: Intel-Modern-GPU && DirectX && Clang
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Basic/Matrix/matrix_trunc_cast.test
+++ b/test/Basic/Matrix/matrix_trunc_cast.test
@@ -58,6 +58,9 @@ DescriptorSets:
 # Bug https://github.com/llvm/offload-test-suite/issues/599
 # XFAIL: Intel && Vulkan && Clang
 
+# Bug: https://github.com/llvm/offload-test-suite/issues/696
+# XFAIL: Intel-Modern-GPU && DirectX && Clang
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Basic/Matrix/matrix_trunc_cast.test
+++ b/test/Basic/Matrix/matrix_trunc_cast.test
@@ -56,7 +56,7 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/offload-test-suite/issues/599
-# XFAIL: Intel && Vulkan && Clang
+# XFAIL: Intel-Gen-10 && Vulkan && Clang
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/696
 # XFAIL:Intel-Gen-Current && DirectX && Clang

--- a/test/Basic/Matrix/matrix_trunc_cast.test
+++ b/test/Basic/Matrix/matrix_trunc_cast.test
@@ -59,7 +59,7 @@ DescriptorSets:
 # XFAIL: Intel && Vulkan && Clang
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/696
-# XFAIL: Intel-Modern-GPU && DirectX && Clang
+# XFAIL:Intel-Gen-Current && DirectX && Clang
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl

--- a/test/Feature/CBuffer/Matrix/LayoutKeyword/transpose.test
+++ b/test/Feature/CBuffer/Matrix/LayoutKeyword/transpose.test
@@ -180,6 +180,9 @@ DescriptorSets:
 ...
 #--- end
 
+# Bug https://github.com/microsoft/DirectXShaderCompiler/issues/8473
+# XFAIL: Vulkan && DXC
+
 # Task: https://github.com/llvm/wg-hlsl/issues/305
 # XFAIL: Clang
 

--- a/test/Feature/CBuffer/Matrix/SingleSubscript/mat_cbuffer_threadgroup.f4x2.test
+++ b/test/Feature/CBuffer/Matrix/SingleSubscript/mat_cbuffer_threadgroup.f4x2.test
@@ -97,7 +97,7 @@ DescriptorSets:
 # XFAIL: Vulkan && QC && DXC
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/696
-# XFAIL: Intel-Modern-GPU && DirectX && Clang
+# XFAIL:Intel-Gen-Current && DirectX && Clang
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl

--- a/test/Feature/CBuffer/Matrix/SingleSubscript/mat_cbuffer_threadgroup.f4x2.test
+++ b/test/Feature/CBuffer/Matrix/SingleSubscript/mat_cbuffer_threadgroup.f4x2.test
@@ -96,6 +96,8 @@ DescriptorSets:
 # Results: [ 1.1, 2.2, 0, 0, 5.5, 6.6, 0, 0 ]
 # XFAIL: Vulkan && QC && DXC
 
+# Bug: https://github.com/llvm/offload-test-suite/issues/696
+# XFAIL: Intel-Modern-GPU && DirectX && Clang
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl

--- a/test/Feature/CBuffer/arrays-16bit.test
+++ b/test/Feature/CBuffer/arrays-16bit.test
@@ -82,7 +82,7 @@ DescriptorSets:
 # REQUIRES: Half, Int16
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/933
-# XFAIL: Intel && DirectX
+# XFAIL:  Intel-Legacy-GPU && DirectX
 
 # Unimplemented https://github.com/llvm/llvm-project/issues/159602
 # XFAIL: Clang && Vulkan

--- a/test/Feature/CBuffer/arrays-16bit.test
+++ b/test/Feature/CBuffer/arrays-16bit.test
@@ -82,7 +82,7 @@ DescriptorSets:
 # REQUIRES: Half, Int16
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/933
-# XFAIL:  Intel-Legacy-GPU && DirectX
+# XFAIL:  Intel-Gen-10 && DirectX
 
 # Unimplemented https://github.com/llvm/llvm-project/issues/159602
 # XFAIL: Clang && Vulkan

--- a/test/Feature/CBuffer/scalars-16bit.test
+++ b/test/Feature/CBuffer/scalars-16bit.test
@@ -58,7 +58,7 @@ DescriptorSets:
 # XFAIL: QC && Vulkan
 
 # Bug https://github.com/llvm/offload-test-suite/issues/932
-# XFAIL:  Intel-Legacy-GPU && DirectX
+# XFAIL: Intel-Gen-10 && DirectX
 
 # REQUIRES: Half, Int16
 

--- a/test/Feature/CBuffer/scalars-16bit.test
+++ b/test/Feature/CBuffer/scalars-16bit.test
@@ -58,7 +58,7 @@ DescriptorSets:
 # XFAIL: QC && Vulkan
 
 # Bug https://github.com/llvm/offload-test-suite/issues/932
-# XFAIL: Intel && DirectX
+# XFAIL:  Intel-Legacy-GPU && DirectX
 
 # REQUIRES: Half, Int16
 

--- a/test/Feature/CBuffer/vectors-64bit.test
+++ b/test/Feature/CBuffer/vectors-64bit.test
@@ -65,7 +65,7 @@ DescriptorSets:
 # REQUIRES: Double, Int64
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/471
-# XFAIL: Vulkan && Intel
+# XFAIL: Vulkan && Intel-Gen-10
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -fvk-use-dx-layout -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/any.fp64.test
+++ b/test/Feature/HLSLLib/any.fp64.test
@@ -56,7 +56,7 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/offload-test-suite/issues/370
-# XFAIL: DXC && DirectX && Intel
+# XFAIL: DXC && DirectX && Intel-Gen-10
 
 # REQUIRES: Double
 # RUN: split-file %s %t

--- a/test/Feature/HLSLLib/any.int64.test
+++ b/test/Feature/HLSLLib/any.int64.test
@@ -97,7 +97,7 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/offload-test-suite/issues/370
-# XFAIL: DXC && DirectX && Intel
+# XFAIL: DXC && DirectX && Intel-Gen-10
 
 # REQUIRES: Int64
 # RUN: split-file %s %t

--- a/test/Feature/HLSLLib/asin.16.test
+++ b/test/Feature/HLSLLib/asin.16.test
@@ -64,7 +64,7 @@ DescriptorSets:
 # so we will not investigate this.
 # only fails with DXC so once Gis spirv support is added to Clang I suspect it will
 # fail with clang as well.
-# XFAIL: Intel && Vulkan && DXC
+# XFAIL: Intel-Gen-10 && Vulkan && DXC
 
 # Unimplemented: support for the Gis flag generating the
 # SignedZeroInfNanPreserve capability needs to be added to clang

--- a/test/Feature/HLSLLib/asin.32.test
+++ b/test/Feature/HLSLLib/asin.32.test
@@ -64,7 +64,7 @@ DescriptorSets:
 # so we will not investigate this.
 # only fails with DXC so once Gis spirv support is added to Clang I suspect it will
 # fail with clang as well.
-# XFAIL: Intel && Vulkan && DXC
+# XFAIL: Intel-Gen-10 && Vulkan && DXC
 
 # Unimplemented: support for the Gis flag generating the
 # SignedZeroInfNanPreserve capability needs to be added to clang

--- a/test/Feature/HLSLLib/mul.fp16.test
+++ b/test/Feature/HLSLLib/mul.fp16.test
@@ -113,7 +113,7 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/offload-test-suite/issues/777
-# XFAIL: Intel-Legacy-GPU && DirectX
+# XFAIL: Intel-Gen-10 && DirectX
 
 # REQUIRES: Half
 # RUN: split-file %s %t

--- a/test/Feature/HLSLLib/mul.fp16.test
+++ b/test/Feature/HLSLLib/mul.fp16.test
@@ -113,7 +113,7 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/offload-test-suite/issues/777
-# XFAIL: Intel && DirectX
+# XFAIL: Intel-Legacy-GPU && DirectX
 
 # REQUIRES: Half
 # RUN: split-file %s %t

--- a/test/Feature/HLSLLib/mul.int16.test
+++ b/test/Feature/HLSLLib/mul.int16.test
@@ -110,7 +110,7 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/offload-test-suite/issues/777
-# XFAIL: Intel && DirectX
+# XFAIL: Intel-Legacy-GPU && DirectX
 
 # REQUIRES: Int16
 # RUN: split-file %s %t

--- a/test/Feature/HLSLLib/mul.int16.test
+++ b/test/Feature/HLSLLib/mul.int16.test
@@ -110,7 +110,7 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/offload-test-suite/issues/777
-# XFAIL: Intel-Legacy-GPU && DirectX
+# XFAIL: Intel-Gen-10 && DirectX
 
 # REQUIRES: Int16
 # RUN: split-file %s %t

--- a/test/Feature/HLSLLib/transpose.fp16.test
+++ b/test/Feature/HLSLLib/transpose.fp16.test
@@ -105,7 +105,7 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/offload-test-suite/issues/779
-# XFAIL: Intel && DirectX
+# XFAIL: Intel-Legacy-GPU && DirectX
 
 # REQUIRES: Half
 # RUN: split-file %s %t

--- a/test/Feature/HLSLLib/transpose.fp16.test
+++ b/test/Feature/HLSLLib/transpose.fp16.test
@@ -105,7 +105,7 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/offload-test-suite/issues/779
-# XFAIL: Intel-Legacy-GPU && DirectX
+# XFAIL: Intel-Gen-10 && DirectX
 
 # REQUIRES: Half
 # RUN: split-file %s %t

--- a/test/Feature/HLSLLib/transpose.int16.test
+++ b/test/Feature/HLSLLib/transpose.int16.test
@@ -102,7 +102,7 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/offload-test-suite/issues/779
-# XFAIL: Intel && DirectX
+# XFAIL: Intel-Legacy-GPU && DirectX
 
 # REQUIRES: Int16
 # RUN: split-file %s %t

--- a/test/Feature/HLSLLib/transpose.int16.test
+++ b/test/Feature/HLSLLib/transpose.int16.test
@@ -102,7 +102,7 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/offload-test-suite/issues/779
-# XFAIL: Intel-Legacy-GPU && DirectX
+# XFAIL:  Intel-Gen-10 && DirectX
 
 # REQUIRES: Int16
 # RUN: split-file %s %t

--- a/test/Feature/PushConstant/types_16bit.test
+++ b/test/Feature/PushConstant/types_16bit.test
@@ -49,6 +49,9 @@ DescriptorSets:
 #--- end
 # UNSUPPORTED: Metal || DirectX
 #
+# Bug https://github.com/llvm/offload-test-suite/issues/1294
+# XFAIL: Vulkan && DXC
+#
 # min16 not supported.
 # XFAIL: Clang
 

--- a/test/Feature/ResourcesInStructs/res-of-matrix-in-struct.test
+++ b/test/Feature/ResourcesInStructs/res-of-matrix-in-struct.test
@@ -62,6 +62,9 @@ DescriptorSets:
 # Unimplemented https://github.com/microsoft/DirectXShaderCompiler/issues/8302
 # XFAIL: Vulkan && DXC
 
+# Bug https://github.com/llvm/llvm-project/issues/202064
+# XFAIL: Vulkan && Clang
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/Textures/Texture2D.SRVToUAV.array.test.yaml
+++ b/test/Feature/Textures/Texture2D.SRVToUAV.array.test.yaml
@@ -90,6 +90,9 @@ DescriptorSets:
 # Unimplemented https://github.com/llvm/llvm-project/issues/133835
 # XFAIL: Clang
 
+# Bug https://github.com/llvm/offload-test-suite/issues/1295
+# XFAIL: DXC && Vulkan && Intel-Gen-Current
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/Textures/Texture2D.SRVToUAV.test.yaml
+++ b/test/Feature/Textures/Texture2D.SRVToUAV.test.yaml
@@ -71,6 +71,10 @@ DescriptorSets:
 
 # Unimplemented: https://github.com/llvm/llvm-project/issues/175630 (for SPIRV)
 # XFAIL: Clang
+
+# Bug https://github.com/llvm/offload-test-suite/issues/1295
+# XFAIL: DXC && Vulkan && Intel-Gen-Current
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/TypedBuffer/64bit-scalar.test
+++ b/test/Feature/TypedBuffer/64bit-scalar.test
@@ -123,7 +123,7 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/offload-test-suite/issues/1110
-# XFAIL: Intel && Vulkan
+# XFAIL: Intel-Gen-10 && Vulkan
 
 # REQUIRES: Int64
 # RUN: split-file %s %t

--- a/test/Feature/TypedBuffer/GetDimensions.test
+++ b/test/Feature/TypedBuffer/GetDimensions.test
@@ -82,7 +82,7 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/offload-test-suite/issues/469
-# XFAIL: Vulkan && Intel
+# XFAIL: Vulkan && Intel-Gen-10
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/WaveOps/ComponentAccumulationDataRace.test
+++ b/test/WaveOps/ComponentAccumulationDataRace.test
@@ -62,7 +62,7 @@ DescriptorSets:
 # XFAIL: Clang && Vulkan
 
 # Bug https://github.com/llvm/offload-test-suite/issues/445
-# XFAIL: DirectX && Intel
+# XFAIL: DirectX && Intel-Gen-10
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/WaveOps/ComponentAccumulationDataRace.test
+++ b/test/WaveOps/ComponentAccumulationDataRace.test
@@ -64,6 +64,9 @@ DescriptorSets:
 # Bug https://github.com/llvm/offload-test-suite/issues/445
 # XFAIL: DirectX && Intel-Gen-10
 
+# Bug https://github.com/llvm/offload-test-suite/issues/1293
+# XFAIL: DirectX && Clang && Intel-Gen-Current
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/WaveOps/ComponentDataRace.test
+++ b/test/WaveOps/ComponentDataRace.test
@@ -59,6 +59,9 @@ DescriptorSets:
 # Bug https://github.com/llvm/llvm-project/issues/172577
 # XFAIL: Clang && Vulkan
 
+# Bug https://github.com/llvm/offload-test-suite/issues/1293
+# XFAIL: DirectX && Clang && Intel-Gen-Current
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/WaveOps/GroupSharedMatrixEltComponentDataRace.test
+++ b/test/WaveOps/GroupSharedMatrixEltComponentDataRace.test
@@ -64,6 +64,9 @@ DescriptorSets:
 # Bug https://github.com/llvm/llvm-project/issues/172577
 # XFAIL: Clang && Vulkan
 
+# Bug https://github.com/llvm/offload-test-suite/issues/696
+# XFAIL: DirectX && Clang && Intel-Gen-Current
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/WaveOps/GroupSharedMatrixRowComponentDataRace.test
+++ b/test/WaveOps/GroupSharedMatrixRowComponentDataRace.test
@@ -66,6 +66,9 @@ DescriptorSets:
 # Bug https://github.com/llvm/llvm-project/issues/172577
 # XFAIL: Clang && Vulkan
 
+# Bug https://github.com/llvm/offload-test-suite/issues/696
+# XFAIL: DirectX && Clang && Intel-Gen-Current
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/WaveOps/WaveActiveAllEqual.fp64.test
+++ b/test/WaveOps/WaveActiveAllEqual.fp64.test
@@ -150,7 +150,7 @@ DescriptorSets:
 # XFAIL: WARP && (x64 || x86) && !AVX512
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/944
-# XFAIL: Intel && DirectX
+# XFAIL: Intel-Gen-10 && DirectX
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/981
 # XFAIL: Clang

--- a/test/WaveOps/WaveActiveAllEqual.int64.test
+++ b/test/WaveOps/WaveActiveAllEqual.int64.test
@@ -250,7 +250,7 @@ DescriptorSets:
 #--- end
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/944
-# XFAIL: Intel && DirectX
+# XFAIL: Intel-Gen-10 && DirectX
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/981
 # XFAIL: Clang

--- a/test/WaveOps/WaveActiveSum.fp16.test
+++ b/test/WaveOps/WaveActiveSum.fp16.test
@@ -173,6 +173,9 @@ DescriptorSets:
 # Bug https://github.com/llvm/offload-test-suite/issues/525
 # XFAIL: NV && Clang && DirectX
 
+# Bug https://github.com/llvm/offload-test-suite/issues/1293
+# XFAIL: Intel-Gen-Current && Clang && DirectX
+
 # Bug https://github.com/llvm/offload-test-suite/issues/393
 # XFAIL: Metal
 

--- a/test/WaveOps/WaveActiveSum.fp32.test
+++ b/test/WaveOps/WaveActiveSum.fp32.test
@@ -173,6 +173,9 @@ DescriptorSets:
 # Bug https://github.com/llvm/offload-test-suite/issues/525
 # XFAIL: NV && Clang && DirectX
 
+# Bug https://github.com/llvm/offload-test-suite/issues/1293
+# XFAIL: Intel-Gen-Current && Clang && DirectX
+
 # Bug https://github.com/llvm/offload-test-suite/issues/526
 # XFAIL: Metal && Clang
 

--- a/test/WaveOps/WaveActiveSum.fp64.test
+++ b/test/WaveOps/WaveActiveSum.fp64.test
@@ -173,6 +173,9 @@ DescriptorSets:
 # Bug https://github.com/llvm/offload-test-suite/issues/525
 # XFAIL: NV && Clang && DirectX
 
+# Bug https://github.com/llvm/offload-test-suite/issues/1293
+# XFAIL: Intel-Gen-Current && Clang && DirectX
+
 # REQUIRES: Double
 
 # RUN: split-file %s %t

--- a/test/WaveOps/WaveActiveSum.int16.test
+++ b/test/WaveOps/WaveActiveSum.int16.test
@@ -327,6 +327,9 @@ DescriptorSets:
 # Bug https://github.com/llvm/offload-test-suite/issues/525
 # XFAIL: NV && Clang && DirectX
 
+# Bug https://github.com/llvm/offload-test-suite/issues/1293
+# XFAIL: Intel-Gen-Current && Clang && DirectX
+
 # Bug https://github.com/llvm/offload-test-suite/issues/393
 # XFAIL: (Vulkan && MoltenVK)
 

--- a/test/WaveOps/WaveActiveSum.int32.test
+++ b/test/WaveOps/WaveActiveSum.int32.test
@@ -324,6 +324,9 @@ DescriptorSets:
 # Bug https://github.com/llvm/offload-test-suite/issues/525
 # XFAIL: NV && Clang && DirectX
 
+# Bug https://github.com/llvm/offload-test-suite/issues/1293
+# XFAIL: Intel-Gen-Current && Clang && DirectX
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o 

--- a/test/WaveOps/WaveActiveSum.int64.test
+++ b/test/WaveOps/WaveActiveSum.int64.test
@@ -327,6 +327,9 @@ DescriptorSets:
 # Bug https://github.com/llvm/offload-test-suite/issues/525
 # XFAIL: NV && Clang && DirectX
 
+# Bug https://github.com/llvm/offload-test-suite/issues/1293
+# XFAIL: Intel-Gen-Current && Clang && DirectX
+
 # Bug https://github.com/llvm/offload-test-suite/issues/355
 # XFAIL: Metal || (Vulkan && MoltenVK)
 

--- a/test/WaveOps/WavePrefixProduct.32.test
+++ b/test/WaveOps/WavePrefixProduct.32.test
@@ -476,6 +476,9 @@ DescriptorSets:
 # Bug: https://github.com/llvm/offload-test-suite/issues/1084
 # XFAIL: NV && Clang && DirectX
 
+# Bug https://github.com/llvm/offload-test-suite/issues/1293
+# XFAIL: Intel-Gen-Current && Clang && DirectX
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o 

--- a/test/WaveOps/WavePrefixProduct.fp16.test
+++ b/test/WaveOps/WavePrefixProduct.fp16.test
@@ -178,6 +178,9 @@ DescriptorSets:
 # Bug: https://github.com/llvm/offload-test-suite/issues/1084
 # XFAIL: NV && Clang && DirectX
 
+# Bug https://github.com/llvm/offload-test-suite/issues/1293
+# XFAIL: Intel-Gen-Current && Clang && DirectX
+
 # Bug: https://github.com/llvm/offload-test-suite/issues/1102
 # XFAIL: AMD && DirectX
 

--- a/test/WaveOps/WavePrefixProduct.fp64.test
+++ b/test/WaveOps/WavePrefixProduct.fp64.test
@@ -177,6 +177,9 @@ DescriptorSets:
 # Bug: https://github.com/llvm/offload-test-suite/issues/1084
 # XFAIL: NV && Clang && DirectX
 
+# Bug https://github.com/llvm/offload-test-suite/issues/1293
+# XFAIL: Intel-Gen-Current && Clang && DirectX
+
 # Bug: https://github.com/llvm/offload-test-suite/issues/1102
 # XFAIL: AMD && DirectX
 

--- a/test/WaveOps/WavePrefixProduct.int16.test
+++ b/test/WaveOps/WavePrefixProduct.int16.test
@@ -323,6 +323,9 @@ DescriptorSets:
 # Bug: https://github.com/llvm/offload-test-suite/issues/961
 # XFAIL: NV && Clang && DirectX
 
+# Bug https://github.com/llvm/offload-test-suite/issues/1293
+# XFAIL: Intel-Gen-Current && Clang && DirectX
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o 

--- a/test/WaveOps/WavePrefixProduct.int64.test
+++ b/test/WaveOps/WavePrefixProduct.int64.test
@@ -326,6 +326,9 @@ DescriptorSets:
 # Bug: https://github.com/llvm/offload-test-suite/issues/1084
 # XFAIL: NV && Clang && DirectX
 
+# Bug https://github.com/llvm/offload-test-suite/issues/1293
+# XFAIL: Intel-Gen-Current && Clang && DirectX
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o 

--- a/test/WaveOps/WavePrefixSum.32.test
+++ b/test/WaveOps/WavePrefixSum.32.test
@@ -474,6 +474,9 @@ DescriptorSets:
 # Bug: https://github.com/llvm/offload-test-suite/issues/961
 # XFAIL: NV && Clang && DirectX
 
+# Bug https://github.com/llvm/offload-test-suite/issues/1293
+# XFAIL: Intel-Gen-Current && Clang && DirectX
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o 

--- a/test/WaveOps/WavePrefixSum.fp16.test
+++ b/test/WaveOps/WavePrefixSum.fp16.test
@@ -175,6 +175,9 @@ DescriptorSets:
 # Bug: https://github.com/llvm/offload-test-suite/issues/961
 # XFAIL: NV && Clang && DirectX
 
+# Bug https://github.com/llvm/offload-test-suite/issues/1293
+# XFAIL: Intel-Gen-Current && Clang && DirectX
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/WaveOps/WavePrefixSum.fp64.test
+++ b/test/WaveOps/WavePrefixSum.fp64.test
@@ -172,6 +172,9 @@ DescriptorSets:
 # Bug: https://github.com/llvm/offload-test-suite/issues/961
 # XFAIL: NV && Clang && DirectX
 
+# Bug https://github.com/llvm/offload-test-suite/issues/1293
+# XFAIL: Intel-Gen-Current && Clang && DirectX
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o 

--- a/test/WaveOps/WavePrefixSum.int16.test
+++ b/test/WaveOps/WavePrefixSum.int16.test
@@ -323,6 +323,9 @@ DescriptorSets:
 # Bug: https://github.com/llvm/offload-test-suite/issues/961
 # XFAIL: NV && Clang && DirectX
 
+# Bug https://github.com/llvm/offload-test-suite/issues/1293
+# XFAIL: Intel-Gen-Current && Clang && DirectX
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o 

--- a/test/WaveOps/WavePrefixSum.int64.test
+++ b/test/WaveOps/WavePrefixSum.int64.test
@@ -326,6 +326,9 @@ DescriptorSets:
 # Bug: https://github.com/llvm/offload-test-suite/issues/961
 # XFAIL: NV && Clang && DirectX
 
+# Bug https://github.com/llvm/offload-test-suite/issues/1293
+# XFAIL: Intel-Gen-Current && Clang && DirectX
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o 

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -114,9 +114,9 @@ def setDeviceFeatures(config, device, compiler):
 
     if "Intel" in device["Description"]:
         if device["GPUGeneration"] == "Intel Gen11-14/Xe":
-            config.available_features.add("Intel-Modern-GPU")
+            config.available_features.add("Intel-Gen-Current")
         if device["GPUGeneration"] == "Intel Gen7-10":
-            config.available_features.add("Intel-Legacy-GPU")
+            config.available_features.add("Intel-Gen-10")
         config.available_features.add("Intel")
         if "UHD Graphics" in device["Description"] and API == "DirectX":
             # When Intel resolves the driver issue and tests XFAILing on the

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -113,6 +113,10 @@ def setDeviceFeatures(config, device, compiler):
         config.available_features.add(config.warp_arch)
 
     if "Intel" in device["Description"]:
+        if device["GPUGeneration"] == "Intel Gen11-14/Xe":
+            config.available_features.add("Intel-Modern-GPU")
+        if device["GPUGeneration"] == "Intel Gen7-10":
+            config.available_features.add("Intel-Legacy-GPU")
         config.available_features.add("Intel")
         if "UHD Graphics" in device["Description"] and API == "DirectX":
             # When Intel resolves the driver issue and tests XFAILing on the

--- a/tools/api-query/api-query.cpp
+++ b/tools/api-query/api-query.cpp
@@ -14,6 +14,7 @@
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/Error.h"
+#include "llvm/Support/Format.h"
 #include "llvm/Support/InitLLVM.h"
 
 using namespace llvm;
@@ -50,6 +51,8 @@ int main(int ArgC, char **ArgV) {
       outs() << C;
     }
     outs() << "\"\n";
+    outs() << "  GPUGeneration: " << D->getGPUGeneration() << "\n";
+    outs() << "  FamilyPrefix: " << format_hex(D->getFamilyPrefix(), 6) << "\n";
     outs() << "  Features: \n";
     for (const auto &C : D->getCapabilities()) {
       outs() << "    ";


### PR DESCRIPTION
This change fixes https://github.com/llvm/offload-test-suite/issues/709