### PR TITLE
[Vulkan] Fix xpass cases

### DIFF
--- a/test/Feature/MaximalReconvergence/loop_peeling.test
+++ b/test/Feature/MaximalReconvergence/loop_peeling.test
@@ -52,7 +52,7 @@ DescriptorSets:
 # XFAIL: Clang && !Vulkan
 
 # Bug https://github.com/llvm/offload-test-suite/issues/520
-# XFAIL: QC
+# XFAIL: QC && Clang
 
 # Bug https://github.com/llvm/offload-test-suite/issues/521
 # XFAIL: NV && DirectX

--- a/test/Feature/PushConstant/types_16bit.test
+++ b/test/Feature/PushConstant/types_16bit.test
@@ -50,7 +50,7 @@ DescriptorSets:
 # UNSUPPORTED: Metal || DirectX
 #
 # Bug https://github.com/llvm/offload-test-suite/issues/1294
-# XFAIL: Vulkan && DXC
+# XFAIL: Vulkan && DXC && Intel-Gen-Current
 #
 # min16 not supported.
 # XFAIL: Clang

--- a/test/Feature/ResourcesInStructs/res-of-matrix-in-struct.test
+++ b/test/Feature/ResourcesInStructs/res-of-matrix-in-struct.test
@@ -63,7 +63,7 @@ DescriptorSets:
 # XFAIL: Vulkan && DXC
 
 # Bug https://github.com/llvm/llvm-project/issues/202064
-# XFAIL: Vulkan && Clang
+# XFAIL: Vulkan && Clang && Intel-Gen-Current
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl


### PR DESCRIPTION
Suprisingly the spirv-val error impacting intel is not impacting QC,NV, or AMD. Also looks like QC loop peeling is fixed for dxc.