### PR TITLE
[DirectX] WaveReadLaneAt test is failing

### DIFF
--- a/test/WaveOps/WaveReadLaneAt.index.test
+++ b/test/WaveOps/WaveReadLaneAt.index.test
@@ -116,6 +116,9 @@ DescriptorSets:
 ...
 #--- end
 
+# Bug: https://github.com/llvm/llvm-project/issues/202481
+# XFAIL: Clang && (DirectX || Metal)
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
To get tests green we will disable this test for now.

see for more context:
 https://github.com/llvm/llvm-project/issues/202481