### PR TITLE
Add support for 64-bit formats.

### DIFF
--- a/include/API/FormatConversion.h
+++ b/include/API/FormatConversion.h
@@ -88,6 +88,7 @@ inline llvm::Expected<Format> toFormat(DataFormat Format, int Channels) {
       return Format::D32Float;
     break;
   case DataFormat::UInt64:
+    // Only 1 and 2 channels of 64-bit integers are supported.
     switch (Channels) {
     case 1:
       return Format::R64Uint;
@@ -96,6 +97,7 @@ inline llvm::Expected<Format> toFormat(DataFormat Format, int Channels) {
     }
     break;
   case DataFormat::Int64:
+    // Only 1 and 2 channels of 64-bit integers are supported.
     switch (Channels) {
     case 1:
       return Format::R64Sint;

--- a/include/API/FormatConversion.h
+++ b/include/API/FormatConversion.h
@@ -87,13 +87,27 @@ inline llvm::Expected<Format> toFormat(DataFormat Format, int Channels) {
     if (Channels == 1)
       return Format::D32Float;
     break;
+  case DataFormat::UInt64:
+    switch (Channels) {
+    case 1:
+      return Format::R64Uint;
+    case 2:
+      return Format::RG64Uint;
+    }
+    break;
+  case DataFormat::Int64:
+    switch (Channels) {
+    case 1:
+      return Format::R64Sint;
+    case 2:
+      return Format::RG64Sint;
+    }
+    break;
   // No Format mapping for these DataFormats.
   case DataFormat::Hex8:
   case DataFormat::Hex16:
   case DataFormat::Hex32:
   case DataFormat::Hex64:
-  case DataFormat::UInt64:
-  case DataFormat::Int64:
   case DataFormat::Float16:
   case DataFormat::Float64:
   case DataFormat::Bool:

--- a/include/API/Resources.h
+++ b/include/API/Resources.h
@@ -47,6 +47,10 @@ enum class Format {
   RGBA32Sint,
   RGBA32Uint,
   RGBA32Float,
+  R64Uint,
+  R64Sint,
+  RG64Uint,
+  RG64Sint,
   D32Float,
   D32FloatS8Uint,
 };
@@ -85,6 +89,14 @@ inline llvm::StringRef getFormatName(Format Format) {
     return "RGBA32Uint";
   case Format::RGBA32Float:
     return "RGBA32Float";
+  case Format::R64Uint:
+    return "R64Uint";
+  case Format::R64Sint:
+    return "R64Sint";
+  case Format::RG64Uint:
+    return "RG64Uint";
+  case Format::RG64Sint:
+    return "RG64Sint";
   case Format::D32Float:
     return "D32Float";
   case Format::D32FloatS8Uint:
@@ -112,12 +124,16 @@ inline uint32_t getFormatSizeInBytes(Format Format) {
   case Format::RG32Uint:
   case Format::RG32Float:
   case Format::D32FloatS8Uint:
+  case Format::R64Uint:
+  case Format::R64Sint:
     return 8;
   case Format::RGB32Float:
     return 12;
   case Format::RGBA32Sint:
   case Format::RGBA32Uint:
   case Format::RGBA32Float:
+  case Format::RG64Uint:
+  case Format::RG64Sint:
     return 16;
   }
   llvm_unreachable("All Format cases handled");
@@ -141,6 +157,10 @@ inline bool isDepthFormat(Format Format) {
   case Format::RGBA32Sint:
   case Format::RGBA32Uint:
   case Format::RGBA32Float:
+  case Format::R64Uint:
+  case Format::R64Sint:
+  case Format::RG64Uint:
+  case Format::RG64Sint:
     return false;
   case Format::D32Float:
   case Format::D32FloatS8Uint:
@@ -167,6 +187,10 @@ inline bool isStencilFormat(Format Format) {
   case Format::RGBA32Sint:
   case Format::RGBA32Uint:
   case Format::RGBA32Float:
+  case Format::R64Uint:
+  case Format::R64Sint:
+  case Format::RG64Uint:
+  case Format::RG64Sint:
   case Format::D32Float:
     return false;
   case Format::D32FloatS8Uint:
@@ -199,6 +223,11 @@ inline bool isTextureCompatible(Format Format) {
   case Format::RGBA32Float:
   case Format::D32Float:
   case Format::D32FloatS8Uint:
+  // Only for RWTextures
+  case Format::R64Uint:
+  case Format::R64Sint:
+  case Format::RG64Uint:
+  case Format::RG64Sint:
     return true;
   }
   llvm_unreachable("All Format cases handled");
@@ -224,6 +253,10 @@ inline bool isVertexCompatible(Format Format) {
   case Format::RGBA32Uint:
   case Format::RGBA32Float:
     return true;
+  case Format::R64Uint:
+  case Format::R64Sint:
+  case Format::RG64Uint:
+  case Format::RG64Sint:
   case Format::D32Float:
   case Format::D32FloatS8Uint:
     return false;
@@ -253,6 +286,10 @@ inline bool isPositionCompatible(Format Format) {
   case Format::RG32Uint:
   case Format::RGBA32Sint:
   case Format::RGBA32Uint:
+  case Format::R64Uint:
+  case Format::R64Sint:
+  case Format::RG64Uint:
+  case Format::RG64Sint:
   case Format::D32Float:
   case Format::D32FloatS8Uint:
     return false;

--- a/lib/API/DX/DXResources.h
+++ b/lib/API/DX/DXResources.h
@@ -66,13 +66,15 @@ inline DXGI_FORMAT getDXGIFormat(Format Fmt) {
   case Format::RGBA32Float:
     return DXGI_FORMAT_R32G32B32A32_FLOAT;
   case Format::R64Uint:
-    return DXGI_FORMAT_R32G32_UINT;
+    return DXGI_FORMAT_R32G32_UINT; // DXGI has no R64, DX12 expects R32G32
   case Format::R64Sint:
-    return DXGI_FORMAT_R32G32_SINT;
+    return DXGI_FORMAT_R32G32_SINT; // DXGI has no R64, DX12 expects R32G32
   case Format::RG64Uint:
-    return DXGI_FORMAT_R32G32B32A32_UINT;
+    return DXGI_FORMAT_R32G32B32A32_UINT; // DXGI has no R64G64, DX12 expects
+                                          // R32G32G32B32
   case Format::RG64Sint:
-    return DXGI_FORMAT_R32G32B32A32_SINT;
+    return DXGI_FORMAT_R32G32B32A32_SINT; // DXGI has no R64G64, DX12 expects
+                                          // R32G32G32B32
   case Format::D32Float:
     return DXGI_FORMAT_D32_FLOAT;
   case Format::D32FloatS8Uint:

--- a/lib/API/DX/DXResources.h
+++ b/lib/API/DX/DXResources.h
@@ -31,8 +31,8 @@ inline D3D12_HEAP_TYPE getDXHeapType(MemoryLocation Location) {
   llvm_unreachable("All MemoryLocation cases handled");
 }
 
-inline DXGI_FORMAT getDXGIFormat(Format Format) {
-  switch (Format) {
+inline DXGI_FORMAT getDXGIFormat(Format Fmt) {
+  switch (Fmt) {
   case Format::R16Sint:
     return DXGI_FORMAT_R16_SINT;
   case Format::R16Uint:
@@ -65,6 +65,14 @@ inline DXGI_FORMAT getDXGIFormat(Format Format) {
     return DXGI_FORMAT_R32G32B32A32_UINT;
   case Format::RGBA32Float:
     return DXGI_FORMAT_R32G32B32A32_FLOAT;
+  case Format::R64Uint:
+    return DXGI_FORMAT_R32G32_UINT;
+  case Format::R64Sint:
+    return DXGI_FORMAT_R32G32_SINT;
+  case Format::RG64Uint:
+    return DXGI_FORMAT_R32G32B32A32_UINT;
+  case Format::RG64Sint:
+    return DXGI_FORMAT_R32G32B32A32_SINT;
   case Format::D32Float:
     return DXGI_FORMAT_D32_FLOAT;
   case Format::D32FloatS8Uint:

--- a/lib/API/MTL/MTLResources.h
+++ b/lib/API/MTL/MTLResources.h
@@ -85,6 +85,12 @@ inline MTL::PixelFormat getMetalPixelFormat(Format Format) {
     return MTL::PixelFormatRGBA32Uint;
   case Format::RGBA32Float:
     return MTL::PixelFormatRGBA32Float;
+  // Metal has no 64-bit-per-channel pixel formats.
+  case Format::R64Uint:
+  case Format::R64Sint:
+  case Format::RG64Uint:
+  case Format::RG64Sint:
+    llvm_unreachable("64-bit formats have no Metal pixel format equivalent");
   case Format::D32Float:
     return MTL::PixelFormatDepth32Float;
   case Format::D32FloatS8Uint:
@@ -140,6 +146,12 @@ inline MTL::VertexFormat getMetalVertexFormat(Format Fmt) {
     return MTL::VertexFormatUInt4;
   case Format::RGBA32Float:
     return MTL::VertexFormatFloat4;
+  // Metal has no 64-bit-per-channel vertex formats.
+  case Format::R64Uint:
+  case Format::R64Sint:
+  case Format::RG64Uint:
+  case Format::RG64Sint:
+    llvm_unreachable("64-bit formats have no Metal vertex format equivalent");
   // Depth formats cannot be used as vertex attributes.
   case Format::D32Float:
   case Format::D32FloatS8Uint:

--- a/lib/API/VK/VKResources.h
+++ b/lib/API/VK/VKResources.h
@@ -66,6 +66,14 @@ inline VkFormat getVulkanFormat(Format Format) {
     return VK_FORMAT_R32G32B32A32_UINT;
   case Format::RGBA32Float:
     return VK_FORMAT_R32G32B32A32_SFLOAT;
+  case Format::R64Uint:
+    return VK_FORMAT_R64_UINT;
+  case Format::R64Sint:
+    return VK_FORMAT_R64_SINT;
+  case Format::RG64Uint:
+    return VK_FORMAT_R64G64_UINT;
+  case Format::RG64Sint:
+    return VK_FORMAT_R64G64_SINT;
   case Format::D32Float:
     return VK_FORMAT_D32_SFLOAT;
   case Format::D32FloatS8Uint:


### PR DESCRIPTION
DX12, Vulkan and Metal do support 64-bit formats for a couple of use cases like Storage(UAV) Textures.
This PR adds the 64-bit formats that are supported to the list of available formats and adds the necessary code to convert to API specific formats.
Note that 64-bit formats are not always supported for vertex inputs or sampled textures.