### PR TITLE
Support arrays of TLAS bindings

### DIFF
--- a/include/API/Device.h
+++ b/include/API/Device.h
@@ -455,9 +455,12 @@ createSparseTextureWithData(
 // TLAS handles come in pre-allocated because the caller's binding loop
 // stamps the AS pointer into descriptor bundles before this helper runs;
 // BLAS handles are allocated inline since BLASes aren't user-bindable.
-// BLAS and TLAS builds get separate `Enc.batchBuildAS()` calls so the
-// implicit BLAS-write → TLAS-read barrier sits between them. Outputs
-// (`OutBLAS`, `OutInputBuffers`) must outlive command-buffer submission.
+// `PreallocatedTLASes` is keyed by `TLASDesc::Name`; each map value is a
+// vector of `TLASDesc::ArraySize` handles (one per descriptor-array
+// element). BLAS and TLAS builds get separate `Enc.batchBuildAS()` calls
+// so the implicit BLAS-write → TLAS-read barrier sits between them.
+// Outputs (`OutBLAS`, `OutInputBuffers`) must outlive command-buffer
+// submission.
 //
 // TODO: `Pipeline` belongs to the test framework, not the rendering backend
 // API. This helper lives here only because `executeProgram` is still on
@@ -465,7 +468,8 @@ createSparseTextureWithData(
 llvm::Error buildPipelineAccelerationStructures(
     Device &Dev, ComputeEncoder &Enc, Pipeline &P,
     llvm::SmallVectorImpl<std::unique_ptr<AccelerationStructure>> &OutBLAS,
-    const llvm::StringMap<std::unique_ptr<AccelerationStructure>>
+    const llvm::StringMap<
+        llvm::SmallVector<std::unique_ptr<AccelerationStructure>>>
         &PreallocatedTLASes,
     llvm::SmallVectorImpl<std::unique_ptr<Buffer>> &OutInputBuffers);
 

--- a/include/Support/Pipeline.h
+++ b/include/Support/Pipeline.h
@@ -398,11 +398,7 @@ struct Resource {
     return isByteAddressBuffer() ? 4 : BufferPtr->getElementSize();
   }
 
-  uint32_t getArraySize() const {
-    if (isSampler() || isAccelerationStructure())
-      return 1;
-    return BufferPtr->ArraySize;
-  }
+  uint32_t getArraySize() const;
 
   uint32_t size() const {
     assert(!isSampler() && !isAccelerationStructure() &&
@@ -582,7 +578,11 @@ struct InstanceDesc {
 
 struct TLASDesc {
   std::string Name;
-  llvm::SmallVector<InstanceDesc> Instances;
+  uint32_t ArraySize = 1;
+  // Outer vector has ArraySize entries (one per descriptor-array element);
+  // inner vector lists the instances for that element. Mirrors
+  // CPUBuffer::Data's ArraySize-driven layout.
+  llvm::SmallVector<llvm::SmallVector<InstanceDesc>, 1> Instances;
 };
 
 struct AccelerationStructureDescs {
@@ -623,6 +623,14 @@ struct ShaderBindingTableDesc {
   llvm::SmallVector<SBTEntry> HitGroup;
   llvm::SmallVector<SBTEntry> Callable;
 };
+
+inline uint32_t Resource::getArraySize() const {
+  if (isSampler())
+    return 1;
+  if (isAccelerationStructure())
+    return TLASPtr->ArraySize;
+  return BufferPtr->ArraySize;
+}
 
 struct Pipeline {
   ShaderPipelineKind Kind;

--- a/lib/API/Device.cpp
+++ b/lib/API/Device.cpp
@@ -151,7 +151,8 @@ offloadtest::createRenderTargetFromCPUBuffer(Device &Dev,
 llvm::Error offloadtest::buildPipelineAccelerationStructures(
     Device &Dev, ComputeEncoder &Enc, Pipeline &P,
     llvm::SmallVectorImpl<std::unique_ptr<AccelerationStructure>> &OutBLAS,
-    const llvm::StringMap<std::unique_ptr<AccelerationStructure>>
+    const llvm::StringMap<
+        llvm::SmallVector<std::unique_ptr<AccelerationStructure>>>
         &PreallocatedTLASes,
     llvm::SmallVectorImpl<std::unique_ptr<Buffer>> &OutInputBuffers) {
   if (P.AccelStructs.BLAS.empty() && P.AccelStructs.TLAS.empty())
@@ -228,36 +229,44 @@ llvm::Error offloadtest::buildPipelineAccelerationStructures(
   // Separate `batchBuildAS()` from the BLAS batch so the BLAS-write →
   // TLAS-read barrier between them is implicit.
   llvm::SmallVector<TLASBuildRequest> TLASRequests;
-  TLASRequests.reserve(PreallocatedTLASes.size());
   for (const TLASDesc &TD : P.AccelStructs.TLAS) {
     auto ASIt = PreallocatedTLASes.find(TD.Name);
     if (ASIt == PreallocatedTLASes.end())
       continue; // TLAS declared but not bound to any resource.
-    TLASBuildRequest Req;
-    Req.AS = ASIt->second.get();
-    Req.Instances.reserve(TD.Instances.size());
-    for (const auto &I : TD.Instances) {
-      auto It = BLASesByName.find(I.BLAS);
-      if (It == BLASesByName.end())
-        return llvm::createStringError(std::errc::invalid_argument,
-                                       "TLAS '%s' references unknown BLAS '%s'",
-                                       TD.Name.c_str(), I.BLAS.c_str());
+    const auto &Handles = ASIt->second;
+    assert(Handles.size() == TD.ArraySize &&
+           "PreallocatedTLASes entry size must equal TLASDesc::ArraySize");
+    assert(TD.Instances.size() == TD.ArraySize &&
+           "TLASDesc::Instances must have ArraySize entries (one per element)");
+    for (uint32_t Elt = 0; Elt < TD.ArraySize; ++Elt) {
+      TLASBuildRequest Req;
+      Req.AS = Handles[Elt].get();
+      const auto &EltInstances = TD.Instances[Elt];
+      Req.Instances.reserve(EltInstances.size());
+      for (const auto &I : EltInstances) {
+        auto It = BLASesByName.find(I.BLAS);
+        if (It == BLASesByName.end())
+          return llvm::createStringError(
+              std::errc::invalid_argument,
+              "TLAS '%s' element %u references unknown BLAS '%s'",
+              TD.Name.c_str(), Elt, I.BLAS.c_str());
 
-      AccelerationStructureInstance Inst;
-      static_assert(sizeof(Inst.Transform) == sizeof(I.Transform),
-                    "Transform layout mismatch");
-      memcpy(Inst.Transform, I.Transform, sizeof(I.Transform));
-      Inst.InstanceID = I.InstanceID;
-      Inst.InstanceMask = I.InstanceMask;
-      Inst.InstanceContributionToHitGroupIndex =
-          I.InstanceContributionToHitGroupIndex;
-      Inst.Flags = I.Flags;
-      Inst.BLAS = It->second;
-      Req.Instances.push_back(Inst);
+        AccelerationStructureInstance Inst;
+        static_assert(sizeof(Inst.Transform) == sizeof(I.Transform),
+                      "Transform layout mismatch");
+        memcpy(Inst.Transform, I.Transform, sizeof(I.Transform));
+        Inst.InstanceID = I.InstanceID;
+        Inst.InstanceMask = I.InstanceMask;
+        Inst.InstanceContributionToHitGroupIndex =
+            I.InstanceContributionToHitGroupIndex;
+        Inst.Flags = I.Flags;
+        Inst.BLAS = It->second;
+        Req.Instances.push_back(Inst);
+      }
+      if (auto Err = validateTLASBuildRequest(Req))
+        return Err;
+      TLASRequests.push_back(std::move(Req));
     }
-    if (auto Err = validateTLASBuildRequest(Req))
-      return Err;
-    TLASRequests.push_back(std::move(Req));
   }
 
   llvm::SmallVector<ASBuildItem> TLASBatch;

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -1179,8 +1179,11 @@ public:
     // Parallel-indexed to `P.AccelStructs.BLAS`.
     llvm::SmallVector<std::unique_ptr<offloadtest::AccelerationStructure>>
         BLASes;
-    // Keyed by `TLASDesc::Name`.
-    llvm::StringMap<std::unique_ptr<offloadtest::AccelerationStructure>> TLASes;
+    // Keyed by `TLASDesc::Name`; each value holds `TLASDesc::ArraySize`
+    // handles (one per descriptor-array element).
+    llvm::StringMap<
+        llvm::SmallVector<std::unique_ptr<offloadtest::AccelerationStructure>>>
+        TLASes;
     // Vertex/index buffers consumed during AS builds; must outlive submission.
     llvm::SmallVector<std::unique_ptr<offloadtest::Buffer>> ASInputBuffers;
     // Per-AS header + contributions buffers; resident at dispatch.
@@ -1573,11 +1576,9 @@ public:
     return HeapIdx;
   }
 
-  llvm::Expected<std::unique_ptr<AccelerationStructure>> createAS(Resource &R) {
-    assert(R.TLASPtr && "AS resource must be resolved to a TLAS");
-    assert(R.getArraySize() == 1 && "AS arrays not yet supported");
-    auto SizesOrErr =
-        getTLASBuildSizes(static_cast<uint32_t>(R.TLASPtr->Instances.size()));
+  llvm::Expected<std::unique_ptr<AccelerationStructure>>
+  createAS(uint32_t InstanceCount) {
+    auto SizesOrErr = getTLASBuildSizes(InstanceCount);
     if (!SizesOrErr)
       return SizesOrErr.takeError();
     return createTLAS(*SizesOrErr);
@@ -1589,14 +1590,21 @@ public:
          this](Resource &R,
                llvm::SmallVectorImpl<ResourcePair> &Resources) -> llvm::Error {
       if (R.isAccelerationStructure()) {
-        auto ASOrErr = createAS(R);
-        if (!ASOrErr)
-          return ASOrErr.takeError();
+        assert(R.TLASPtr && "AS resource must be resolved to a TLAS");
+        const TLASDesc &TD = *R.TLASPtr;
         ResourceBundle Bundle;
-        Bundle.emplace_back(
-            llvm::cast<MetalAccelerationStructure>(ASOrErr->get()));
-        auto Inserted =
-            IS.TLASes.try_emplace(R.TLASPtr->Name, std::move(*ASOrErr));
+        llvm::SmallVector<std::unique_ptr<AccelerationStructure>> Handles;
+        Handles.reserve(TD.ArraySize);
+        for (uint32_t Elt = 0; Elt < TD.ArraySize; ++Elt) {
+          auto ASOrErr =
+              createAS(static_cast<uint32_t>(TD.Instances[Elt].size()));
+          if (!ASOrErr)
+            return ASOrErr.takeError();
+          Bundle.emplace_back(
+              llvm::cast<MetalAccelerationStructure>(ASOrErr->get()));
+          Handles.push_back(std::move(*ASOrErr));
+        }
+        auto Inserted = IS.TLASes.try_emplace(TD.Name, std::move(Handles));
         assert(Inserted.second && "TLAS bound to multiple resources NYI");
         (void)Inserted;
         Resources.emplace_back(&R, std::move(Bundle));
@@ -1644,46 +1652,54 @@ public:
     uint32_t HeapIndex = 0;
     for (auto &T : IS.DescTables) {
       for (auto &R : T.Resources) {
-        if (MetalAccelerationStructure *MTLAS = R.second[0].AS) {
+        if (R.first->isAccelerationStructure()) {
           // The Metal shader converter binds the AS indirectly through an
           // `IRRaytracingAccelerationStructureGPUHeader` buffer carrying the
           // AS's `gpuResourceID` and a pointer to an instance-contributions
           // array (one `uint32` per instance, equivalent to D3D12's
           // `InstanceContributionToHitGroupIndex`).
-          const uint32_t InstCount =
-              static_cast<uint32_t>(R.first->TLASPtr->Instances.size());
-          llvm::SmallVector<uint32_t> Contributions;
-          Contributions.reserve(InstCount);
-          for (const auto &Inst : R.first->TLASPtr->Instances)
-            Contributions.push_back(Inst.InstanceContributionToHitGroupIndex &
-                                    0xFFFFFFu);
-          const BufferCreateDesc Desc = BufferCreateDesc::uploadBuffer();
-          auto ContribBufOrErr = createBufferWithData(
-              *IS.CB->Dev, "AS-Contributions", Desc, Contributions.data(),
-              InstCount * sizeof(uint32_t), nullptr, nullptr);
-          if (!ContribBufOrErr)
-            return ContribBufOrErr.takeError();
-          auto *MTLContrib = llvm::cast<MTLBuffer>(ContribBufOrErr->get());
-          auto HeaderBufOrErr = IS.CB->Dev->createBuffer(
-              "AS-Header", Desc,
-              sizeof(IRRaytracingAccelerationStructureGPUHeader));
-          if (!HeaderBufOrErr)
-            return HeaderBufOrErr.takeError();
-          auto *MTLHeader = llvm::cast<MTLBuffer>(HeaderBufOrErr->get());
-          IRRaytracingSetAccelerationStructure(
-              static_cast<uint8_t *>(MTLHeader->Buf->contents()),
-              MTLAS->AccelStruct->gpuResourceID(),
-              static_cast<uint8_t *>(MTLContrib->Buf->contents()),
-              MTLContrib->Buf->gpuAddress(), Contributions.data(), InstCount);
+          const TLASDesc &TD = *R.first->TLASPtr;
+          assert(R.second.size() == TD.ArraySize &&
+                 "AS bundle must hold one ResourceSet per array element");
+          for (uint32_t Elt = 0; Elt < TD.ArraySize; ++Elt) {
+            auto *MTLAS =
+                llvm::cast<MetalAccelerationStructure>(R.second[Elt].AS);
+            const auto &EltInstances = TD.Instances[Elt];
+            const uint32_t InstCount =
+                static_cast<uint32_t>(EltInstances.size());
+            llvm::SmallVector<uint32_t> Contributions;
+            Contributions.reserve(InstCount);
+            for (const auto &Inst : EltInstances)
+              Contributions.push_back(Inst.InstanceContributionToHitGroupIndex &
+                                      0xFFFFFFu);
+            const BufferCreateDesc Desc = BufferCreateDesc::uploadBuffer();
+            auto ContribBufOrErr = createBufferWithData(
+                *IS.CB->Dev, "AS-Contributions", Desc, Contributions.data(),
+                InstCount * sizeof(uint32_t), nullptr, nullptr);
+            if (!ContribBufOrErr)
+              return ContribBufOrErr.takeError();
+            auto *MTLContrib = llvm::cast<MTLBuffer>(ContribBufOrErr->get());
+            auto HeaderBufOrErr = IS.CB->Dev->createBuffer(
+                "AS-Header", Desc,
+                sizeof(IRRaytracingAccelerationStructureGPUHeader));
+            if (!HeaderBufOrErr)
+              return HeaderBufOrErr.takeError();
+            auto *MTLHeader = llvm::cast<MTLBuffer>(HeaderBufOrErr->get());
+            IRRaytracingSetAccelerationStructure(
+                static_cast<uint8_t *>(MTLHeader->Buf->contents()),
+                MTLAS->AccelStruct->gpuResourceID(),
+                static_cast<uint8_t *>(MTLContrib->Buf->contents()),
+                MTLContrib->Buf->gpuAddress(), Contributions.data(), InstCount);
 
-          IRDescriptorTableSetAccelerationStructure(
-              IS.DescHeap->getEntryHandle(HeapIndex),
-              MTLHeader->Buf->gpuAddress());
+            IRDescriptorTableSetAccelerationStructure(
+                IS.DescHeap->getEntryHandle(HeapIndex + Elt),
+                MTLHeader->Buf->gpuAddress());
 
-          // The shader dereferences the contributions buffer through the
-          // header, so both must be resident at dispatch.
-          IS.ASDescriptorBuffers.push_back(std::move(*HeaderBufOrErr));
-          IS.ASDescriptorBuffers.push_back(std::move(*ContribBufOrErr));
+            // The shader dereferences the contributions buffer through the
+            // header, so both must be resident at dispatch.
+            IS.ASDescriptorBuffers.push_back(std::move(*HeaderBufOrErr));
+            IS.ASDescriptorBuffers.push_back(std::move(*ContribBufOrErr));
+          }
           HeapIndex += R.first->getArraySize();
           continue;
         }
@@ -1756,7 +1772,8 @@ public:
     for (auto &AS : IS.BLASes)
       MarkASResident(AS);
     for (auto &Entry : IS.TLASes)
-      MarkASResident(Entry.second);
+      for (auto &AS : Entry.second)
+        MarkASResident(AS);
     for (auto &B : IS.ASDescriptorBuffers)
       NativeEncoder->useResource(llvm::cast<MTLBuffer>(B.get())->Buf,
                                  MTL::ResourceUsageRead);

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -1482,8 +1482,11 @@ private:
     // Parallel-indexed to `P.AccelStructs.BLAS`.
     llvm::SmallVector<std::unique_ptr<offloadtest::AccelerationStructure>>
         BLASes;
-    // Keyed by `TLASDesc::Name`.
-    llvm::StringMap<std::unique_ptr<offloadtest::AccelerationStructure>> TLASes;
+    // Keyed by `TLASDesc::Name`; each value holds `TLASDesc::ArraySize`
+    // handles (one per descriptor-array element).
+    llvm::StringMap<
+        llvm::SmallVector<std::unique_ptr<offloadtest::AccelerationStructure>>>
+        TLASes;
     // Vertex/index buffers consumed during AS builds; must outlive submission.
     llvm::SmallVector<std::unique_ptr<offloadtest::Buffer>> ASInputBuffers;
   };
@@ -3363,11 +3366,9 @@ public:
     return ResourceRef(Host, ImageRef{0, Sampler, 0});
   }
 
-  llvm::Expected<std::unique_ptr<AccelerationStructure>> createAS(Resource &R) {
-    assert(R.TLASPtr && "AS resource must be resolved to a TLAS");
-    assert(R.getArraySize() == 1 && "AS arrays not yet supported");
-    auto SizesOrErr =
-        getTLASBuildSizes(static_cast<uint32_t>(R.TLASPtr->Instances.size()));
+  llvm::Expected<std::unique_ptr<AccelerationStructure>>
+  createAS(uint32_t InstanceCount) {
+    auto SizesOrErr = getTLASBuildSizes(InstanceCount);
     if (!SizesOrErr)
       return SizesOrErr.takeError();
     return createTLAS(*SizesOrErr);
@@ -3490,15 +3491,23 @@ public:
     for (auto &D : P.Sets) {
       for (auto &R : D.Resources) {
         if (R.isAccelerationStructure()) {
-          auto ASOrErr = createAS(R);
-          if (!ASOrErr)
-            return ASOrErr.takeError();
-          auto *VkAS = llvm::cast<VulkanAccelerationStructure>(ASOrErr->get());
+          assert(R.TLASPtr && "AS resource must be resolved to a TLAS");
+          const TLASDesc &TD = *R.TLASPtr;
           ResourceBundle Bundle{getDescriptorType(R.Kind), 0, nullptr};
-          Bundle.ResourceRefs.push_back(ResourceRef{VkAS});
+          llvm::SmallVector<std::unique_ptr<AccelerationStructure>> Handles;
+          Handles.reserve(TD.ArraySize);
+          for (uint32_t Elt = 0; Elt < TD.ArraySize; ++Elt) {
+            auto ASOrErr =
+                createAS(static_cast<uint32_t>(TD.Instances[Elt].size()));
+            if (!ASOrErr)
+              return ASOrErr.takeError();
+            auto *VkAS =
+                llvm::cast<VulkanAccelerationStructure>(ASOrErr->get());
+            Bundle.ResourceRefs.push_back(ResourceRef{VkAS});
+            Handles.push_back(std::move(*ASOrErr));
+          }
           IS.Resources.push_back(std::move(Bundle));
-          auto Inserted =
-              IS.TLASes.try_emplace(R.TLASPtr->Name, std::move(*ASOrErr));
+          auto Inserted = IS.TLASes.try_emplace(TD.Name, std::move(Handles));
           assert(Inserted.second && "TLAS bound to multiple resources NYI");
           (void)Inserted;
           continue;
@@ -3672,14 +3681,19 @@ public:
       for (uint32_t RIdx = 0; RIdx < P.Sets[SetIdx].Resources.size();
            ++RIdx, ++OverallResIdx) {
         const Resource &R = P.Sets[SetIdx].Resources[RIdx];
-        if (VulkanAccelerationStructure *VkAS =
-                IS.Resources[OverallResIdx].ResourceRefs[0].AS) {
+        if (R.isAccelerationStructure()) {
+          const auto &Refs = IS.Resources[OverallResIdx].ResourceRefs;
+          assert(Refs.size() == R.getArraySize() &&
+                 "AS bundle must hold one ResourceRef per array element");
           const size_t HandleStart = ASHandles.size();
-          ASHandles.push_back(VkAS->AccelStruct);
+          for (const auto &Ref : Refs) {
+            assert(Ref.AS && "AS ResourceRef missing AS handle");
+            ASHandles.push_back(Ref.AS->AccelStruct);
+          }
           VkWriteDescriptorSetAccelerationStructureKHR ASWrite = {};
           ASWrite.sType =
               VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET_ACCELERATION_STRUCTURE_KHR;
-          ASWrite.accelerationStructureCount = 1;
+          ASWrite.accelerationStructureCount = R.getArraySize();
           ASWrite.pAccelerationStructures = &ASHandles[HandleStart];
           ASInfos.push_back(ASWrite);
 
@@ -3688,10 +3702,11 @@ public:
           WDS.pNext = &ASInfos.back();
           WDS.dstSet = IS.DescriptorSets[SetIdx];
           WDS.dstBinding = R.VKBinding->Binding;
-          WDS.descriptorCount = 1;
+          WDS.descriptorCount = R.getArraySize();
           WDS.descriptorType = VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR;
           llvm::outs() << "Updating AS Descriptor [" << OverallResIdx << "] { "
-                       << SetIdx << ", " << RIdx << " }\n";
+                       << SetIdx << ", " << RIdx
+                       << " } count = " << R.getArraySize() << "\n";
           WriteDescriptors.push_back(WDS);
           continue;
         }

--- a/lib/Support/OffloadMigration.cpp
+++ b/lib/Support/OffloadMigration.cpp
@@ -64,11 +64,8 @@ static BufferShaderAccessType bufferShaderAccessTypeFromResourceKind(
 }
 
 static llvm::Expected<std::unique_ptr<AccelerationStructure>>
-createAS(Device &Dev, Resource &R) {
-  assert(R.TLASPtr && "AS resource must be resolved to a TLAS");
-  assert(R.getArraySize() == 1 && "AS arrays not yet supported");
-  auto SizesOrErr =
-      Dev.getTLASBuildSizes(static_cast<uint32_t>(R.TLASPtr->Instances.size()));
+createAS(Device &Dev, uint32_t InstanceCount) {
+  auto SizesOrErr = Dev.getTLASBuildSizes(InstanceCount);
   if (!SizesOrErr)
     return SizesOrErr.takeError();
   return Dev.createTLAS(*SizesOrErr);
@@ -317,12 +314,19 @@ llvm::Error createResources(Device &Dev, Pipeline &P,
         ResBundle.push_back(std::move(RSet));
       }
     } else if (R.isAccelerationStructure()) {
-      auto ASOrErr = createAS(Dev, R);
-      if (!ASOrErr)
-        return ASOrErr.takeError();
-      ResBundle.emplace_back(ASOrErr->get());
-      auto Inserted =
-          IS.TLASes.try_emplace(R.TLASPtr->Name, std::move(*ASOrErr));
+      assert(R.TLASPtr && "AS resource must be resolved to a TLAS");
+      const TLASDesc &TD = *R.TLASPtr;
+      llvm::SmallVector<std::unique_ptr<AccelerationStructure>> Handles;
+      Handles.reserve(TD.ArraySize);
+      for (uint32_t Elt = 0; Elt < TD.ArraySize; ++Elt) {
+        auto ASOrErr =
+            createAS(Dev, static_cast<uint32_t>(TD.Instances[Elt].size()));
+        if (!ASOrErr)
+          return ASOrErr.takeError();
+        ResBundle.emplace_back(ASOrErr->get());
+        Handles.push_back(std::move(*ASOrErr));
+      }
+      auto Inserted = IS.TLASes.try_emplace(TD.Name, std::move(Handles));
       assert(Inserted.second && "TLAS bound to multiple resources NYI");
       (void)Inserted;
     } else {

--- a/lib/Support/OffloadMigration.h
+++ b/lib/Support/OffloadMigration.h
@@ -103,8 +103,11 @@ struct SharedInvocationState {
 
   // Parallel-indexed to `P.AccelStructs.BLAS`.
   llvm::SmallVector<std::unique_ptr<offloadtest::AccelerationStructure>> BLASes;
-  // Keyed by `TLASDesc::Name`.
-  llvm::StringMap<std::unique_ptr<offloadtest::AccelerationStructure>> TLASes;
+  // Keyed by `TLASDesc::Name`; each value holds `TLASDesc::ArraySize`
+  // handles (one per descriptor-array element).
+  llvm::StringMap<
+      llvm::SmallVector<std::unique_ptr<offloadtest::AccelerationStructure>>>
+      TLASes;
   // Vertex/index buffers consumed during AS builds; must outlive submission.
   llvm::SmallVector<std::unique_ptr<offloadtest::Buffer>> ASInputBuffers;
 };

--- a/lib/Support/Pipeline.cpp
+++ b/lib/Support/Pipeline.cpp
@@ -196,16 +196,18 @@ void MappingTraits<offloadtest::Pipeline>::mapping(IO &I,
 
     // Resolve BLAS name references in TLAS instance descriptions.
     for (auto &T : P.AccelStructs.TLAS) {
-      for (auto &Inst : T.Instances) {
-        for (int Idx = 0, E = P.AccelStructs.BLAS.size(); Idx < E; ++Idx) {
-          if (P.AccelStructs.BLAS[Idx].Name == Inst.BLAS) {
-            Inst.BLASIdx = Idx;
-            break;
+      for (auto &Elt : T.Instances) {
+        for (auto &Inst : Elt) {
+          for (int Idx = 0, E = P.AccelStructs.BLAS.size(); Idx < E; ++Idx) {
+            if (P.AccelStructs.BLAS[Idx].Name == Inst.BLAS) {
+              Inst.BLASIdx = Idx;
+              break;
+            }
           }
+          if (Inst.BLASIdx < 0)
+            I.setError(Twine("TLAS '") + T.Name + "': referenced BLAS '" +
+                       Inst.BLAS + "' not found!");
         }
-        if (Inst.BLASIdx < 0)
-          I.setError(Twine("TLAS '") + T.Name + "': referenced BLAS '" +
-                     Inst.BLAS + "' not found!");
       }
     }
   }
@@ -694,7 +696,34 @@ void MappingTraits<offloadtest::InstanceDesc>::mapping(
 void MappingTraits<offloadtest::TLASDesc>::mapping(IO &I,
                                                    offloadtest::TLASDesc &D) {
   I.mapRequired("Name", D.Name);
+  I.mapOptional("ArraySize", D.ArraySize, 1u);
+
+  if (I.outputting()) {
+    if (D.ArraySize == 1) {
+      // single-element output: emit a flat `Instances:` list (parallel to
+      // CPUBuffer's single-element `Data: [...]` form).
+      I.mapRequired("Instances", D.Instances.front());
+    } else {
+      I.mapRequired("Instances", D.Instances);
+    }
+    return;
+  }
+
+  if (D.ArraySize == 1) {
+    // single-element input: read a flat `Instances:` list.
+    llvm::SmallVector<offloadtest::InstanceDesc> Insts;
+    I.mapRequired("Instances", Insts);
+    D.Instances.push_back(std::move(Insts));
+    return;
+  }
+
+  // array input: read a list-of-lists; validate length matches ArraySize.
   I.mapRequired("Instances", D.Instances);
+  if (D.Instances.size() != D.ArraySize) {
+    I.setError(llvm::Twine("Expected ") + llvm::Twine(D.ArraySize) +
+               " instance lists, found " + llvm::Twine(D.Instances.size()));
+    return;
+  }
 }
 
 void MappingTraits<offloadtest::AccelerationStructureDescs>::mapping(

--- a/test/Feature/InlineRT/tlas-array.test
+++ b/test/Feature/InlineRT/tlas-array.test
@@ -1,0 +1,92 @@
+#--- source.hlsl
+
+// Verifies binding an array of `RaytracingAccelerationStructure`s.
+// `Scenes[0]` and `Scenes[1]` each carry a single triangle instance with a
+// distinct `InstanceID`; the shader queries each in turn and writes the hit's
+// `CommittedInstanceID()` into the corresponding slot of `Output`.
+
+[[vk::binding(0, 0)]] RaytracingAccelerationStructure Scenes[2] : register(t0);
+[[vk::binding(1, 0)]] RWStructuredBuffer<uint> Output : register(u0);
+
+[numthreads(1,1,1)]
+void main() {
+  RayDesc Ray;
+  Ray.Origin = float3(0, 0, 1);
+  Ray.Direction = float3(0, 0, -1);
+  Ray.TMin = 0.0;
+  Ray.TMax = 100.0;
+  for (uint i = 0; i < 2; ++i) {
+    RayQuery<RAY_FLAG_NONE> Q;
+    Q.TraceRayInline(Scenes[i], RAY_FLAG_NONE, 0xFF, Ray);
+    Q.Proceed();
+    Output[i] = Q.CommittedStatus() == COMMITTED_TRIANGLE_HIT
+                    ? Q.CommittedInstanceID()
+                    : 0xFFFFFFFF;
+  }
+}
+//--- pipeline.yaml
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+Buffers:
+  - Name: Vertices
+    Format: Float32
+    Stride: 12
+    Data: [ 0.0, 1.0, 0.0, -1.0, -1.0, 0.0, 1.0, -1.0, 0.0 ]
+  - Name: Output
+    Format: UInt32
+    Stride: 4
+    FillSize: 8
+  - Name: Expected
+    Format: UInt32
+    Stride: 4
+    Data: [ 10, 20 ]
+AccelerationStructures:
+  BLAS:
+    - Name: TriangleBLAS
+      Triangles:
+        - VertexBuffer: Vertices
+          VertexFormat: RGB32Float
+          VertexStride: 12
+          VertexCount: 3
+  TLAS:
+    - Name: Scenes
+      ArraySize: 2
+      Instances:
+        - - BLAS: TriangleBLAS
+            InstanceID: 10
+            Transform: [1, 0, 0, 0,  0, 1, 0, 0,  0, 0, 1, 0]
+        - - BLAS: TriangleBLAS
+            InstanceID: 20
+            Transform: [1, 0, 0, 0,  0, 1, 0, 0,  0, 0, 1, 0]
+DescriptorSets:
+  - Resources:
+    - Name: Scenes
+      Kind: AccelerationStructure
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: Output
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+Results:
+  - Result: TLASArray
+    Rule: BufferExact
+    Actual: Output
+    Expected: Expected
+...
+#--- end
+
+# REQUIRES: acceleration-structure
+# XFAIL: Clang
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
Mirror the existing buffer/texture array pattern (`ArraySize` plus an `ArraySize`-driven YAML field) for top-level acceleration structures so shaders can declare `RaytracingAccelerationStructure Scenes[N]` and bind N distinct TLASes through a single resource entry.

- **Schema** (`Support/Pipeline.{h,cpp}`): `TLASDesc` gains `ArraySize` (default 1) and reshapes `Instances` from `SmallVector<InstanceDesc>` to `SmallVector<SmallVector<InstanceDesc>>`. `MappingTraits<TLASDesc>` dispatches on `ArraySize` exactly like `setData()` does for `CPUBuffer`: flat `Instances: [...]` for the scalar case, list-of-lists for arrays, with an `ActualSize != ArraySize` validation error on mismatch. `Resource::getArraySize()` returns `TLASPtr->ArraySize` for AS resources (moved out-of-line so it can dereference the still-forward-declared `TLASDesc`).
- **createAS()**: takes `uint32_t InstanceCount` directly — pure single-create that sizes and allocates one TLAS. No `Pipeline` / `Resource` / `InvocationState` parameters. The multi-create (`createBuffers` / `createResources`) loops `TD.ArraySize` and pushes one bundle entry per element plus N handles into `InvocationState::TLASes`, which becomes `StringMap<SmallVector<unique_ptr<AccelerationStructure>>>` (one vector per `TLASDesc::Name`, sized to `ArraySize`).
- **`buildPipelineAccelerationStructures()`** walks `P.AccelStructs.TLAS` and, for each name with a pre-allocated vector, builds one `TLASBuildRequest` per element using `TD.Instances[Elt]` and `Handles[Elt]`.
- **Vulkan**: descriptor write iterates the bundle's `ResourceRefs` to fill N entries of `pAccelerationStructures` and sets `descriptorCount = R.getArraySize()` so the descriptor set sees the full array. Pool sizing (`ASDescriptorCount`) and binding layout (`ResourceBinding.DescriptorCount`) already used `R.getArraySize()` for AS resources — they just start returning the right number once `TLASDesc::ArraySize` flows through.
- **DX12**: `bindSRV()`'s AS branch already loops `ResBundle`; with the new multi-entry bundle it now writes N `RAYTRACING_ACCELERATION_STRUCTURE` SRVs into consecutive heap slots automatically. Heap sizing already uses `getDescriptorCountWithFlattenedArrays()`.
- **Metal**: the AS descriptor-binding loop now builds one `IRRaytracingAccelerationStructureGPUHeader` + instance-contributions buffer pair per array element and writes one descriptor entry per element via `IRDescriptorTableSetAccelerationStructure()`. `MarkASResident` descends into the per-name vector.

New test `test/Feature/InlineRT/tlas-array.test` declares `Scenes[2]`, each TLAS carries one triangle instance with a distinct `InstanceID` (10 and 20), and the shader writes each `CommittedInstanceID()` into `Output[i]`. Gated on `acceleration-structure`, `XFAIL: Clang`.

## Test plan

Local on an NVIDIA RTX 3060:
- [x] Linux Vulkan (native `offloader`)
- [ ] Linux D3D12 (Wine + vkd3d-proton + cross-compiled `offloader.exe`)
- [ ] Windows Vulkan (native `offloader.exe`)
- [ ] Windows D3D12 (native `offloader.exe`)

CI (RT-capable runners):
- [ ] windows-nvidia D3D12 (`RaytracingTier 1.2`)
- [ ] windows-intel VK (`VK_KHR_ray_tracing_pipeline`)
- [ ] macOS Metal (`supportsRaytracing`)