### PR TITLE
Improve buffer creation API to cover all needed current use cases.

### DIFF
--- a/include/API/Buffer.h
+++ b/include/API/Buffer.h
@@ -20,24 +20,61 @@
 
 namespace offloadtest {
 
-enum class BufferUsage {
+enum class BufferShaderAccessType : uint32_t {
+  Raw,
+  Typed,
+  Structured,
+};
+
+union BufferShaderAccessTypeParams {
+  Format Fmt;               // Typed Only
+  uint32_t StructureStride; // Structured Only
+};
+
+enum class BufferUsage : uint32_t {
   // Generic storage buffer (UAV/SSBO). Also covers acceleration-structure
   // build inputs (vertex/index/instance buffers): backends widen this with
   // any native AS-input flags they need.
   Storage,
+  ConstantBuffer,
+  IndexBuffer,
   VertexBuffer,
+  IndirectArgs,
 };
 
 struct BufferCreateDesc {
   MemoryLocation Location;
+  MemoryBacking Backing;
   BufferUsage Usage;
+  BufferShaderAccessType AccessType;
+  BufferShaderAccessTypeParams AccessTypeParams;
+  bool HasCounter;
 
   static BufferCreateDesc uploadBuffer() {
-    return BufferCreateDesc{MemoryLocation::CpuToGpu, BufferUsage::Storage};
+    return BufferCreateDesc{MemoryLocation::CpuToGpu,
+                            MemoryBacking::Automatic,
+                            BufferUsage::Storage,
+                            BufferShaderAccessType::Raw,
+                            {},
+                            false};
   }
 
   static BufferCreateDesc readbackBuffer() {
-    return BufferCreateDesc{MemoryLocation::GpuToCpu, BufferUsage::Storage};
+    return BufferCreateDesc{MemoryLocation::GpuToCpu,
+                            MemoryBacking::Automatic,
+                            BufferUsage::Storage,
+                            BufferShaderAccessType::Raw,
+                            {},
+                            false};
+  }
+
+  static BufferCreateDesc scratchBuffer() {
+    return BufferCreateDesc{MemoryLocation::GpuOnly,
+                            MemoryBacking::Automatic,
+                            BufferUsage::Storage,
+                            BufferShaderAccessType::Raw,
+                            {},
+                            false};
   }
 };
 

--- a/include/API/Resources.h
+++ b/include/API/Resources.h
@@ -33,7 +33,7 @@ enum class MemoryBacking {
   // DX: CreateReservedResource + UpdateTileMappings.
   // VK: VK_IMAGE_CREATE_SPARSE_BINDING_BIT + vkQueueBindSparse.
   // Metal: MTLTextureDescriptor.sparseLevel + heap tile mapping
-  // (requires Apple Silicon).
+  //        (requires Apple Silicon).
   Sparse,
 };
 

--- a/include/API/Resources.h
+++ b/include/API/Resources.h
@@ -25,6 +25,18 @@ enum class MemoryLocation {
   GpuToCpu,
 };
 
+enum class MemoryBacking {
+  // Allocates all memory for this resource.
+  Automatic,
+
+  // No memory allocated; physical pages mapped manually on demand.
+  // DX: CreateReservedResource + UpdateTileMappings.
+  // VK: VK_IMAGE_CREATE_SPARSE_BINDING_BIT + vkQueueBindSparse.
+  // Metal: MTLTextureDescriptor.sparseLevel + heap tile mapping
+  // (requires Apple Silicon).
+  Sparse,
+};
+
 enum class IndexFormat { Uint16, Uint32 };
 
 // TODO: Add Unorm types (e.g. R8Unorm, RGBA8Unorm) which can be sampled as

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -360,6 +360,7 @@ public:
   std::string Name;
   BufferCreateDesc Desc;
   size_t SizeInBytes;
+  uint64_t CounterOffsetInBytes;
 
   // Contract: If a command on the command buffer needs a resource to be in a
   // different state it should always transition it back to the PreferredState
@@ -368,11 +369,25 @@ public:
   // tracking.
   D3D12_RESOURCE_STATES PreferredState;
 
+  D3D12_CPU_DESCRIPTOR_HANDLE SRVHandle;
+  D3D12_CPU_DESCRIPTOR_HANDLE UAVHandle;
+  D3D12_CPU_DESCRIPTOR_HANDLE CBVHandle;
+
   DXBuffer(ComPtr<ID3D12Resource> Buffer, llvm::StringRef Name,
            BufferCreateDesc Desc, size_t SizeInBytes,
-           D3D12_RESOURCE_STATES PreferredState)
+           uint64_t CounterOffsetInBytes, D3D12_RESOURCE_STATES PreferredState,
+           D3D12_CPU_DESCRIPTOR_HANDLE SRVHandle,
+           D3D12_CPU_DESCRIPTOR_HANDLE UAVHandle,
+           D3D12_CPU_DESCRIPTOR_HANDLE CBVHandle)
       : offloadtest::Buffer(GPUAPI::DirectX), Buffer(Buffer), Name(Name),
-        Desc(Desc), SizeInBytes(SizeInBytes), PreferredState(PreferredState) {}
+        Desc(Desc), SizeInBytes(SizeInBytes),
+        CounterOffsetInBytes(CounterOffsetInBytes),
+        PreferredState(PreferredState), SRVHandle(SRVHandle),
+        UAVHandle(UAVHandle), CBVHandle(CBVHandle) {}
+  DXBuffer(const DXBuffer &) = delete;
+  DXBuffer(DXBuffer &&) = delete;
+  DXBuffer &operator=(const DXBuffer &) = delete;
+  DXBuffer &operator=(DXBuffer &&) = delete;
 
   size_t getSizeInBytes() const override { return SizeInBytes; }
 
@@ -1072,6 +1087,7 @@ private:
   Capabilities Caps;
   DescriptorAllocator RTVAllocator;
   DescriptorAllocator DSVAllocator;
+  DescriptorAllocator CSUAllocator;
 
   struct ResourceSet {
     ComPtr<ID3D12Resource> Upload;
@@ -1131,10 +1147,12 @@ private:
 public:
   DXDevice(ComPtr<IDXCoreAdapter> A, ComPtr<ID3D12DeviceX> D, DXQueue Q,
            DescriptorAllocator RTVAllocator, DescriptorAllocator DSVAllocator,
-           std::string Desc, std::string DriverVer)
+           DescriptorAllocator CSUAllocator, std::string Desc,
+           std::string DriverVer)
       : Adapter(A), Device(D), GraphicsQueue(std::move(Q)),
         RTVAllocator(std::move(RTVAllocator)),
-        DSVAllocator(std::move(DSVAllocator)) {
+        DSVAllocator(std::move(DSVAllocator)),
+        CSUAllocator(std::move(CSUAllocator)) {
     Description = std::move(Desc);
     DriverVersion = std::move(DriverVer);
     DriverName = "DirectX";
@@ -1480,36 +1498,159 @@ public:
   createBuffer(std::string Name, const BufferCreateDesc &Desc,
                size_t SizeInBytes) override {
     const D3D12_HEAP_TYPE HeapType = getDXHeapType(Desc.Location);
-
+    // This flag is only allowed on GpuOnly memory.
     const D3D12_RESOURCE_FLAGS Flags =
-        HeapType == D3D12_HEAP_TYPE_DEFAULT
+        Desc.Location == MemoryLocation::GpuOnly
             ? D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS
             : D3D12_RESOURCE_FLAG_NONE;
 
+    // Modify the size if needed
+    UINT64 CounterOffsetInBytes = 0;
+    UINT64 BufferSizeInBytes = SizeInBytes;
+    if (Desc.Usage == BufferUsage::ConstantBuffer) {
+      if (Desc.HasCounter)
+        return llvm::createStringError(
+            "Constant Buffers are not allowed to have a counter.");
+
+      BufferSizeInBytes = getCBVSize(BufferSizeInBytes);
+    } else if (Desc.HasCounter) {
+      if (Desc.AccessType == BufferShaderAccessType::Raw)
+        return llvm::createStringError(
+            "Raw Resources are not allowed to have a counter.");
+
+      CounterOffsetInBytes = llvm::alignTo(
+          BufferSizeInBytes, D3D12_UAV_COUNTER_PLACEMENT_ALIGNMENT);
+      BufferSizeInBytes = CounterOffsetInBytes + sizeof(uint32_t);
+    }
+
     const D3D12_HEAP_PROPERTIES HeapProps = CD3DX12_HEAP_PROPERTIES(HeapType);
     const D3D12_RESOURCE_DESC BufferDesc =
-        CD3DX12_RESOURCE_DESC::Buffer(SizeInBytes, Flags);
+        CD3DX12_RESOURCE_DESC::Buffer(BufferSizeInBytes, Flags);
 
-    D3D12_RESOURCE_STATES InitialState = D3D12_RESOURCE_STATE_COMMON;
-    if (HeapType == D3D12_HEAP_TYPE_UPLOAD)
-      InitialState = D3D12_RESOURCE_STATE_GENERIC_READ;
-    else if (HeapType == D3D12_HEAP_TYPE_READBACK)
-      // As per the readback heap docs
-      // > Resources in this heap must be created with
-      // > D3D12_RESOURCE_STATE_COPY_DEST, and cannot be changed away from this.
-      InitialState = D3D12_RESOURCE_STATE_COPY_DEST;
+    D3D12_RESOURCE_STATES PreferredState = D3D12_RESOURCE_STATE_COMMON;
+    ComPtr<ID3D12Resource> BufferObject;
+    if (Desc.Backing == MemoryBacking::Sparse) {
+      if (auto Err = HR::toError(Device->CreateReservedResource(
+                                     &BufferDesc, D3D12_RESOURCE_STATE_COMMON,
+                                     nullptr, IID_PPV_ARGS(&BufferObject)),
+                                 "Failed to create reserved buffer."))
+        return Err;
+    } else {
+      D3D12_RESOURCE_STATES InitialState = D3D12_RESOURCE_STATE_COMMON;
+      if (HeapType == D3D12_HEAP_TYPE_UPLOAD)
+        InitialState = D3D12_RESOURCE_STATE_GENERIC_READ;
+      else if (HeapType == D3D12_HEAP_TYPE_READBACK)
+        // As per the readback heap docs
+        // > Resources in this heap must be created with
+        // > D3D12_RESOURCE_STATE_COPY_DEST, and cannot be changed away from
+        // this.
+        InitialState = D3D12_RESOURCE_STATE_COPY_DEST;
+      PreferredState = InitialState;
+      if (auto Err = HR::toError(Device->CreateCommittedResource(
+                                     &HeapProps, D3D12_HEAP_FLAG_NONE,
+                                     &BufferDesc, InitialState, nullptr,
+                                     IID_PPV_ARGS(&BufferObject)),
+                                 "Failed to create buffer."))
+        return Err;
+    }
 
-    ComPtr<ID3D12Resource> DeviceBuffer;
-    if (auto Err =
-            HR::toError(Device->CreateCommittedResource(
-                            &HeapProps, D3D12_HEAP_FLAG_NONE, &BufferDesc,
-                            InitialState, nullptr, IID_PPV_ARGS(&DeviceBuffer)),
-                        "Failed to create buffer."))
-      return Err;
+    const std::wstring WStr(Name.begin(), Name.end());
+    BufferObject->SetName(WStr.c_str());
 
-    const D3D12_RESOURCE_STATES PreferredState = InitialState;
-    return std::make_unique<DXBuffer>(DeviceBuffer, Name, Desc, SizeInBytes,
-                                      PreferredState);
+    D3D12_CPU_DESCRIPTOR_HANDLE SRVHandle = {};
+    {
+      auto SRVHandleOrErr = CSUAllocator.allocate();
+      if (!SRVHandleOrErr)
+        return SRVHandleOrErr.takeError();
+      SRVHandle = *SRVHandleOrErr;
+
+      D3D12_SHADER_RESOURCE_VIEW_DESC SRVDesc = {};
+      SRVDesc.ViewDimension = D3D12_SRV_DIMENSION_BUFFER;
+      SRVDesc.Shader4ComponentMapping =
+          D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+      switch (Desc.AccessType) {
+      case BufferShaderAccessType::Raw:
+        SRVDesc.Format = DXGI_FORMAT_R32_TYPELESS;
+        SRVDesc.Buffer.NumElements = static_cast<uint32_t>(SizeInBytes / 4);
+        SRVDesc.Buffer.Flags = D3D12_BUFFER_SRV_FLAG_RAW;
+        break;
+      case BufferShaderAccessType::Typed:
+        SRVDesc.Format = getDXGIFormat(Desc.AccessTypeParams.Fmt);
+        SRVDesc.Buffer.NumElements = static_cast<uint32_t>(
+            SizeInBytes / getFormatSizeInBytes(Desc.AccessTypeParams.Fmt));
+        break;
+      case BufferShaderAccessType::Structured:
+        assert(Desc.AccessTypeParams.StructureStride > 0 &&
+               "Structured buffers must have a Structure Stride.");
+        SRVDesc.Format = DXGI_FORMAT_UNKNOWN;
+        SRVDesc.Buffer.NumElements = static_cast<uint32_t>(
+            SizeInBytes / Desc.AccessTypeParams.StructureStride);
+        SRVDesc.Buffer.StructureByteStride =
+            Desc.AccessTypeParams.StructureStride;
+        break;
+      }
+
+      Device->CreateShaderResourceView(BufferObject.Get(), &SRVDesc, SRVHandle);
+    }
+
+    D3D12_CPU_DESCRIPTOR_HANDLE UAVHandle = {};
+    if ((Flags & D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS) != 0) {
+      auto UAVHandleOrErr = CSUAllocator.allocate();
+      if (!UAVHandleOrErr)
+        return UAVHandleOrErr.takeError();
+      UAVHandle = *UAVHandleOrErr;
+
+      D3D12_UNORDERED_ACCESS_VIEW_DESC UAVDesc = {};
+      UAVDesc.ViewDimension = D3D12_UAV_DIMENSION_BUFFER;
+      switch (Desc.AccessType) {
+      case BufferShaderAccessType::Raw:
+        UAVDesc.Format = DXGI_FORMAT_R32_TYPELESS;
+        UAVDesc.Buffer.NumElements = static_cast<uint32_t>(SizeInBytes / 4);
+        UAVDesc.Buffer.Flags = D3D12_BUFFER_UAV_FLAG_RAW;
+        break;
+      case BufferShaderAccessType::Typed:
+        UAVDesc.Format = getDXGIFormat(Desc.AccessTypeParams.Fmt);
+        UAVDesc.Buffer.NumElements = static_cast<uint32_t>(
+            SizeInBytes / getFormatSizeInBytes(Desc.AccessTypeParams.Fmt));
+        break;
+      case BufferShaderAccessType::Structured:
+        assert(Desc.AccessTypeParams.StructureStride > 0 &&
+               "Structured buffers must have a Structure Stride.");
+        UAVDesc.Format = DXGI_FORMAT_UNKNOWN;
+        UAVDesc.Buffer.NumElements = static_cast<uint32_t>(
+            SizeInBytes / Desc.AccessTypeParams.StructureStride);
+        UAVDesc.Buffer.StructureByteStride =
+            Desc.AccessTypeParams.StructureStride;
+        break;
+      }
+
+      ID3D12Resource *CounterObject = nullptr;
+      if (Desc.HasCounter) {
+        UAVDesc.Buffer.CounterOffsetInBytes = CounterOffsetInBytes;
+        CounterObject = BufferObject.Get();
+      }
+
+      Device->CreateUnorderedAccessView(BufferObject.Get(), CounterObject,
+                                        &UAVDesc, UAVHandle);
+    }
+
+    D3D12_CPU_DESCRIPTOR_HANDLE CBVHandle = {};
+    if (Desc.Usage == BufferUsage::ConstantBuffer) {
+      auto CBVHandleOrErr = CSUAllocator.allocate();
+      if (!CBVHandleOrErr)
+        return CBVHandleOrErr.takeError();
+      CBVHandle = *CBVHandleOrErr;
+
+      D3D12_CONSTANT_BUFFER_VIEW_DESC CBVDesc = {};
+      CBVDesc.BufferLocation = BufferObject->GetGPUVirtualAddress();
+      CBVDesc.SizeInBytes = BufferSizeInBytes;
+
+      Device->CreateConstantBufferView(&CBVDesc, CBVHandle);
+    }
+
+    return std::make_unique<DXBuffer>(BufferObject, Name, Desc, SizeInBytes,
+                                      CounterOffsetInBytes, PreferredState,
+                                      SRVHandle, UAVHandle, CBVHandle);
   }
 
   llvm::Expected<std::unique_ptr<offloadtest::Texture>>
@@ -1652,10 +1793,16 @@ public:
     if (!DSVHeapOrErr)
       return DSVHeapOrErr.takeError();
 
+    auto CSUHeapOrErr = DescriptorAllocator::create(
+        Device.Get(), D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, 4096);
+    if (!CSUHeapOrErr)
+      return CSUHeapOrErr.takeError();
+
     return std::make_unique<DXDevice>(
         Adapter, Device, std::move(*GraphicsQueueOrErr),
         std::move(*RTVHeapOrErr), std::move(*DSVHeapOrErr),
-        std::string(DescVec.data()), std::move(DriverVer));
+        std::move(*CSUHeapOrErr), std::string(DescVec.data()),
+        std::move(DriverVer));
   }
 
   const Capabilities &getCapabilities() override {
@@ -3023,8 +3170,7 @@ llvm::Error DXComputeEncoder::batchBuildAS(llvm::ArrayRef<ASBuildItem> Items) {
       const size_t Bytes =
           Native.size() * sizeof(D3D12_RAYTRACING_INSTANCE_DESC);
 
-      const BufferCreateDesc UploadDesc{MemoryLocation::CpuToGpu,
-                                        BufferUsage::Storage};
+      const BufferCreateDesc UploadDesc = BufferCreateDesc::uploadBuffer();
       auto InstBufOrErr = offloadtest::createBufferWithData(
           *Dev, "TLAS-Instances", UploadDesc, Native.data(), Bytes, nullptr,
           nullptr);
@@ -3037,12 +3183,7 @@ llvm::Error DXComputeEncoder::batchBuildAS(llvm::ArrayRef<ASBuildItem> Items) {
       ScratchSize = TLAS->AS->getSizes().ScratchDataSizeInBytes;
     }
 
-    // Allocate scratch in the default heap; createBuffer() applies
-    // ALLOW_UNORDERED_ACCESS for default-heap allocations and creates the
-    // resource in COMMON state, which D3D12 implicitly promotes to
-    // UNORDERED_ACCESS on first GPU access during the AS build.
-    const BufferCreateDesc ScratchDesc{MemoryLocation::GpuOnly,
-                                       BufferUsage::Storage};
+    const BufferCreateDesc ScratchDesc = BufferCreateDesc::scratchBuffer();
     auto ScratchOrErr =
         Dev->createBuffer("AS-Scratch", ScratchDesc, ScratchSize);
     if (!ScratchOrErr)

--- a/lib/API/Device.cpp
+++ b/lib/API/Device.cpp
@@ -102,12 +102,7 @@ llvm::Error offloadtest::buildPipelineAccelerationStructures(
   if (P.AccelStructs.BLAS.empty() && P.AccelStructs.TLAS.empty())
     return llvm::Error::success();
 
-  // `BufferUsage::Storage` is the usage to pick for acceleration structure
-  // build inputs. Backends widen it with the native AS-input flags
-  // (e.g. Vulkan `SHADER_DEVICE_ADDRESS` + `ACCEL_BUILD_INPUT_READ_ONLY`)
-  // implicitly when ray tracing is supported.
-  const BufferCreateDesc UploadDesc{MemoryLocation::CpuToGpu,
-                                    BufferUsage::Storage};
+  const BufferCreateDesc UploadDesc = BufferCreateDesc::uploadBuffer();
 
   // Stash the request structs while we build them up — the encoder reads
   // them through pointers stored in ASBuildItem.

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -1422,9 +1422,7 @@ class MTLDevice : public offloadtest::Device {
     IS.RenderTarget = std::move(*TexOrErr);
 
     // Create a readback buffer for copying render target data to the CPU.
-    BufferCreateDesc BufDesc = {};
-    BufDesc.Location = MemoryLocation::GpuToCpu;
-    BufDesc.Usage = BufferUsage::Storage;
+    BufferCreateDesc BufDesc = BufferCreateDesc::readbackBuffer();
     auto BufOrErr = createBuffer("RTReadback", BufDesc, OutBuf.size());
     if (!BufOrErr)
       return BufOrErr.takeError();
@@ -2432,8 +2430,7 @@ llvm::Error MTLComputeEncoder::batchBuildAS(llvm::ArrayRef<ASBuildItem> Items) {
       const size_t InstByteSize =
           Native.size() * sizeof(MTL::AccelerationStructureInstanceDescriptor);
 
-      const BufferCreateDesc UploadDesc{MemoryLocation::CpuToGpu,
-                                        BufferUsage::Storage};
+      const BufferCreateDesc UploadDesc = BufferCreateDesc::uploadBuffer();
       auto InstBufOrErr = offloadtest::createBufferWithData(
           *CB->Dev, "TLAS-Instances", UploadDesc, Native.data(), InstByteSize,
           nullptr, nullptr);
@@ -2453,8 +2450,7 @@ llvm::Error MTLComputeEncoder::batchBuildAS(llvm::ArrayRef<ASBuildItem> Items) {
       ScratchSize = TLAS->AS->getSizes().ScratchDataSizeInBytes;
     }
 
-    const BufferCreateDesc ScratchDesc{MemoryLocation::GpuOnly,
-                                       BufferUsage::Storage};
+    const BufferCreateDesc ScratchDesc = BufferCreateDesc::scratchBuffer();
     auto ScratchOrErr =
         CB->Dev->createBuffer("AS-Scratch", ScratchDesc, ScratchSize);
     if (!ScratchOrErr) {

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -427,17 +427,19 @@ class VulkanBuffer : public offloadtest::Buffer {
 public:
   VkDevice Dev; // Needed for clean-up
   VkBuffer Buffer;
+  VkBuffer CounterBuffer;
   VkDeviceMemory Memory;
   VkDeviceAddress DeviceAddress;
   std::string Name;
   BufferCreateDesc Desc;
   size_t SizeInBytes;
 
-  VulkanBuffer(VkDevice Dev, VkBuffer Buffer, VkDeviceMemory Memory,
-               VkDeviceAddress DeviceAddress, llvm::StringRef Name,
-               BufferCreateDesc Desc, size_t SizeInBytes)
+  VulkanBuffer(VkDevice Dev, VkBuffer Buffer, VkBuffer CounterBuffer,
+               VkDeviceMemory Memory, VkDeviceAddress DeviceAddress,
+               llvm::StringRef Name, BufferCreateDesc Desc, size_t SizeInBytes)
       : offloadtest::Buffer(GPUAPI::Vulkan), Dev(Dev), Buffer(Buffer),
-        Memory(Memory), DeviceAddress(DeviceAddress), Name(Name), Desc(Desc),
+        CounterBuffer(CounterBuffer), Memory(Memory),
+        DeviceAddress(DeviceAddress), Name(Name), Desc(Desc),
         SizeInBytes(SizeInBytes) {}
 
   size_t getSizeInBytes() const override { return SizeInBytes; }
@@ -2262,15 +2264,30 @@ public:
     BufInfo.size = SizeInBytes;
     BufInfo.usage =
         VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT;
+    BufInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+
     switch (Desc.Usage) {
     case BufferUsage::Storage:
       BufInfo.usage |= VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
+      break;
+    case BufferUsage::ConstantBuffer:
+      BufInfo.usage |= VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT |
+                       VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
+      break;
+    case BufferUsage::IndexBuffer:
+      BufInfo.usage |=
+          VK_BUFFER_USAGE_INDEX_BUFFER_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
       break;
     case BufferUsage::VertexBuffer:
       BufInfo.usage |= VK_BUFFER_USAGE_VERTEX_BUFFER_BIT |
                        VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
       break;
+    case BufferUsage::IndirectArgs:
+      BufInfo.usage |= VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT |
+                       VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
+      break;
     }
+
     // When ray tracing is supported, every buffer is eligible to act as an
     // acceleration-structure build input and to expose a device address. The
     // shared AS build helper assumes Storage buffers carry these flags.
@@ -2280,14 +2297,14 @@ public:
           VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR;
     BufInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
 
-    VkBuffer DeviceBuffer;
+    VkBuffer BufferObject;
     if (auto Err = VK::toError(
-            vkCreateBuffer(Device, &BufInfo, nullptr, &DeviceBuffer),
+            vkCreateBuffer(Device, &BufInfo, nullptr, &BufferObject),
             "Failed to create device buffer."))
       return Err;
 
     VkMemoryRequirements MemReqs;
-    vkGetBufferMemoryRequirements(Device, DeviceBuffer, &MemReqs);
+    vkGetBufferMemoryRequirements(Device, BufferObject, &MemReqs);
 
     VkMemoryAllocateFlagsInfo AllocFlagsInfo = {};
     AllocFlagsInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_FLAGS_INFO;
@@ -2300,30 +2317,84 @@ public:
     AllocInfo.allocationSize = MemReqs.size;
     auto MemIdx = getMemoryIndex(PhysicalDevice, MemReqs.memoryTypeBits,
                                  getVulkanMemoryFlags(Desc.Location));
-    if (!MemIdx)
+    if (!MemIdx) {
+      vkDestroyBuffer(Device, BufferObject, nullptr);
       return MemIdx.takeError();
+    }
     AllocInfo.memoryTypeIndex = *MemIdx;
+
+    VkBuffer CounterBuffer = nullptr;
+    VkMemoryRequirements CounterMemReqs = {};
+    VkDeviceSize CounterOffsetInBytes = 0;
+    if (Desc.HasCounter) {
+      VkBuffer CounterBuffer;
+      VkBufferCreateInfo CounterBufferInfo = {};
+      CounterBufferInfo.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+      CounterBufferInfo.size = sizeof(uint32_t);
+      CounterBufferInfo.usage = BufInfo.usage;
+      CounterBufferInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+      if (auto Err = VK::toError(vkCreateBuffer(Device, &CounterBufferInfo,
+                                                nullptr, &CounterBuffer),
+                                 "Could not create counter buffer.")) {
+        vkDestroyBuffer(Device, BufferObject, nullptr);
+        return Err;
+      }
+
+      vkGetBufferMemoryRequirements(Device, CounterBuffer, &CounterMemReqs);
+
+      CounterOffsetInBytes =
+          llvm::alignTo(AllocInfo.allocationSize, CounterMemReqs.alignment);
+      AllocInfo.allocationSize = CounterOffsetInBytes + CounterMemReqs.size;
+
+      assert(MemReqs.memoryTypeBits == CounterMemReqs.memoryTypeBits &&
+             "We are expecting the main resource and counter resource to have "
+             "the same memory type.");
+    }
 
     VkDeviceMemory DeviceMemory;
     if (auto Err = VK::toError(
             vkAllocateMemory(Device, &AllocInfo, nullptr, &DeviceMemory),
-            "Failed to allocate device memory."))
+            "Failed to allocate device memory.")) {
+      if (CounterBuffer)
+        vkDestroyBuffer(Device, CounterBuffer, nullptr);
+      vkDestroyBuffer(Device, BufferObject, nullptr);
       return Err;
+    }
+
     if (auto Err = VK::toError(
-            vkBindBufferMemory(Device, DeviceBuffer, DeviceMemory, 0),
-            "Failed to bind device buffer memory."))
+            vkBindBufferMemory(Device, BufferObject, DeviceMemory, 0),
+            "Failed to bind device buffer memory.")) {
+      if (CounterBuffer)
+        vkDestroyBuffer(Device, CounterBuffer, nullptr);
+      vkDestroyBuffer(Device, BufferObject, nullptr);
+      vkFreeMemory(Device, DeviceMemory, nullptr);
       return Err;
+    }
+
+    if (CounterBuffer != nullptr) {
+      if (auto Err = VK::toError(vkBindBufferMemory(Device, CounterBuffer,
+                                                    DeviceMemory,
+                                                    CounterOffsetInBytes),
+                                 "Failed to bind counter buffer memory.")) {
+        if (CounterBuffer)
+          vkDestroyBuffer(Device, CounterBuffer, nullptr);
+        vkDestroyBuffer(Device, BufferObject, nullptr);
+        vkFreeMemory(Device, DeviceMemory, nullptr);
+        return Err;
+      }
+    }
 
     VkDeviceAddress DevAddr = 0;
     if (HasRayTracingSupport) {
       VkBufferDeviceAddressInfo AddrInfo = {};
       AddrInfo.sType = VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO;
-      AddrInfo.buffer = DeviceBuffer;
+      AddrInfo.buffer = BufferObject;
       DevAddr = vkGetBufferDeviceAddress(Device, &AddrInfo);
     }
 
-    return std::make_unique<VulkanBuffer>(Device, DeviceBuffer, DeviceMemory,
-                                          DevAddr, Name, Desc, SizeInBytes);
+    return std::make_unique<VulkanBuffer>(Device, BufferObject, CounterBuffer,
+                                          DeviceMemory, DevAddr, Name, Desc,
+                                          SizeInBytes);
   }
 
   llvm::Expected<std::unique_ptr<offloadtest::Texture>>
@@ -4304,8 +4375,7 @@ llvm::Error VKComputeEncoder::batchBuildAS(llvm::ArrayRef<ASBuildItem> Items) {
 
       // Upload the instance array. Storage + CpuToGpu now carries device
       // address and AS-build-input flags (because RT is supported).
-      const BufferCreateDesc Desc{MemoryLocation::CpuToGpu,
-                                  BufferUsage::Storage};
+      const BufferCreateDesc Desc = BufferCreateDesc::uploadBuffer();
       auto InstBufOrErr = offloadtest::createBufferWithData(
           *Dev, "TLAS-Instances", Desc, Native.data(), Bytes, nullptr, nullptr);
       if (!InstBufOrErr)
@@ -4334,12 +4404,7 @@ llvm::Error VKComputeEncoder::batchBuildAS(llvm::ArrayRef<ASBuildItem> Items) {
       CB.KeepAliveOwned.push_back(std::move(*InstBufOrErr));
     }
 
-    // Allocate scratch (one per item; non-overlapping ranges as required).
-    // createBuffer() applies SHADER_DEVICE_ADDRESS + storage usage when ray
-    // tracing is supported, so we can re-use the same Buffer wrapper as the
-    // TLAS instance allocation and drop the raw-handle keep-alive bookkeeping.
-    const BufferCreateDesc ScratchDesc{MemoryLocation::GpuOnly,
-                                       BufferUsage::Storage};
+    const BufferCreateDesc ScratchDesc = BufferCreateDesc::scratchBuffer();
     auto ScratchOrErr =
         Dev->createBuffer("AS-Scratch", ScratchDesc, ScratchSize);
     if (!ScratchOrErr)


### PR DESCRIPTION
Improve the buffer creation API:
* Add a `BufferShaderAccessType` enum to distinguish between buffers that do raw access, typed access, or are just as structured buffers.
* Add `BufferShaderAccessTypeParams` to provide a format or stride in the cases of typed access or a structured buffer
* Add `MemoryBacking` to handle reserved resources
* Add `BufferUsage` variants for constant buffers, index buffers and indirect arguments
* Add `HasCounter` bool for structured buffers with a counter value.

Use the extra API features to:
* Create SRV, UAV, and CBV descriptors in DX12. These are not used anywhere, but are now ready to replace the buffer creation using raw dx12 with the generic graphics interface
* Allocate a counter value if needed to the buffer (DX12 and Vulkan)

Drive by fix:
* Add a helper function for a scratch buffer `BufferCreateDesc`
* Use the existing `BufferCreateDesc` helper functions in the acceleration structure code.