### PR TITLE
Add `createTextureWithData` function.

### DIFF
--- a/include/API/Device.h
+++ b/include/API/Device.h
@@ -257,6 +257,11 @@ public:
   virtual llvm::Expected<std::unique_ptr<Texture>>
   createTexture(std::string Name, const TextureCreateDesc &Desc) = 0;
 
+  // The row stride required when uploading data to (or reading back from) a
+  // texture created with the given description, via an upload buffer.
+  virtual uint32_t
+  getTextureUploadRowStrideInBytes(const TextureCreateDesc &Desc) const = 0;
+
   virtual llvm::Expected<std::unique_ptr<RenderPass>>
   createRenderPass(const RenderPassDesc &Desc) = 0;
 
@@ -323,6 +328,12 @@ createBufferWithData(Device &Dev, std::string Name,
                      const BufferCreateDesc &Desc, const void *Data,
                      size_t SizeInBytes, ComputeEncoder *Encoder,
                      std::unique_ptr<offloadtest::Buffer> *OutUploadBuffer);
+
+llvm::Expected<std::unique_ptr<offloadtest::Texture>>
+createTextureWithData(Device &Dev, std::string Name,
+                      const TextureCreateDesc &Desc, const void *Data,
+                      size_t SizeInBytes, ComputeEncoder *Encoder,
+                      std::unique_ptr<offloadtest::Buffer> *OutUploadBuffer);
 
 // TLAS handles come in pre-allocated because the caller's binding loop
 // stamps the AS pointer into descriptor bundles before this helper runs;

--- a/include/API/Encoder.h
+++ b/include/API/Encoder.h
@@ -98,6 +98,9 @@ public:
                                          Buffer &Dst, size_t DstOffset,
                                          size_t Size) = 0;
 
+  /// Copy a buffer into a texture. The caller is expected to set up correct
+  /// striding using the stride acquired from
+  /// `Device::getTextureUploadRowStrideInBytes`.
   virtual llvm::Error copyBufferToTexture(Buffer &Src, Texture &Dst) = 0;
 
   /// Build a batch of acceleration structures in a single barrier slot. All

--- a/include/API/Encoder.h
+++ b/include/API/Encoder.h
@@ -22,6 +22,7 @@
 namespace offloadtest {
 
 class Buffer;
+class Texture;
 class PipelineState;
 class AccelerationStructure;
 struct BLASBuildRequest;
@@ -96,6 +97,8 @@ public:
   virtual llvm::Error copyBufferToBuffer(Buffer &Src, size_t SrcOffset,
                                          Buffer &Dst, size_t DstOffset,
                                          size_t Size) = 0;
+
+  virtual llvm::Error copyBufferToTexture(Buffer &Src, Texture &Dst) = 0;
 
   /// Build a batch of acceleration structures in a single barrier slot. All
   /// items in `Items` must be independent — no item may depend on another's

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -791,6 +791,42 @@ public:
     return llvm::Error::success();
   }
 
+  llvm::Error copyBufferToTexture(Buffer &Src, Texture &Dst) override {
+    auto &DXSrc = llvm::cast<DXBuffer>(Src);
+    auto &DXDst = llvm::cast<DXTexture>(Dst);
+
+    if (DXSrc.PreferredState != D3D12_RESOURCE_STATE_COPY_SOURCE)
+      CB.addResourceTransition(DXSrc.Buffer.Get(), DXSrc.PreferredState,
+                               D3D12_RESOURCE_STATE_COPY_SOURCE);
+
+    if (DXDst.PreferredState != D3D12_RESOURCE_STATE_COPY_DEST)
+      CB.addResourceTransition(DXDst.Resource.Get(), DXDst.PreferredState,
+                               D3D12_RESOURCE_STATE_COPY_DEST);
+    CB.flushBarrier();
+
+    const uint32_t ElementSize = getFormatSizeInBytes(DXDst.Desc.Fmt);
+    const D3D12_PLACED_SUBRESOURCE_FOOTPRINT Footprint{
+        0,
+        CD3DX12_SUBRESOURCE_FOOTPRINT(
+            getDXGIFormat(DXDst.Desc.Fmt), DXDst.Desc.Width, DXDst.Desc.Height,
+            1, getAlignedTexturePitch(DXDst.Desc.Width, ElementSize))};
+    const CD3DX12_TEXTURE_COPY_LOCATION DstLoc(DXDst.Resource.Get(), 0);
+    const CD3DX12_TEXTURE_COPY_LOCATION SrcLoc(DXSrc.Buffer.Get(), Footprint);
+    CB.CmdList->CopyTextureRegion(&DstLoc, 0, 0, 0, &SrcLoc, nullptr);
+
+    if (DXSrc.PreferredState != D3D12_RESOURCE_STATE_COPY_SOURCE)
+      CB.addResourceTransition(DXSrc.Buffer.Get(),
+                               D3D12_RESOURCE_STATE_COPY_SOURCE,
+                               DXSrc.PreferredState);
+
+    if (DXDst.PreferredState != D3D12_RESOURCE_STATE_COPY_DEST)
+      CB.addResourceTransition(DXDst.Resource.Get(),
+                               D3D12_RESOURCE_STATE_COPY_DEST,
+                               DXDst.PreferredState);
+
+    return llvm::Error::success();
+  }
+
   // Defined out-of-line below — needs DXDevice's full type for access to the
   // ID3D12Device5 entry point and helper allocators.
   llvm::Error batchBuildAS(llvm::ArrayRef<ASBuildItem> Items) override;
@@ -1597,6 +1633,11 @@ public:
     }
 
     return Tex;
+  }
+
+  uint32_t getTextureUploadRowStrideInBytes(
+      const TextureCreateDesc &Desc) const override {
+    return getAlignedTexturePitch(Desc.Width, getFormatSizeInBytes(Desc.Fmt));
   }
 
   static llvm::Expected<std::unique_ptr<offloadtest::Device>>

--- a/lib/API/Device.cpp
+++ b/lib/API/Device.cpp
@@ -329,7 +329,7 @@ offloadtest::createTextureWithData(
 
   // Create Upload buffer
   const BufferCreateDesc UploadDesc = BufferCreateDesc::uploadBuffer();
-  std::string UploadBufferName = Name + " (Upload Buffer)";
+  const std::string UploadBufferName = Name + " (Upload Buffer)";
   auto UploadBufferOrErr =
       Dev.createBuffer(UploadBufferName, UploadDesc, UploadBufferSizeInBytes);
   if (!UploadBufferOrErr)

--- a/lib/API/Device.cpp
+++ b/lib/API/Device.cpp
@@ -300,3 +300,59 @@ offloadtest::createBufferWithData(
 
   return Buffer;
 }
+
+llvm::Expected<std::unique_ptr<offloadtest::Texture>>
+offloadtest::createTextureWithData(
+    Device &Dev, std::string Name, const TextureCreateDesc &Desc,
+    const void *Data, size_t SizeInBytes, ComputeEncoder *Encoder,
+    std::unique_ptr<offloadtest::Buffer> *OutUploadBuffer) {
+
+  const uint64_t PackedRowStrideInBytes =
+      Desc.Width * getFormatSizeInBytes(Desc.Fmt);
+  if (SizeInBytes < PackedRowStrideInBytes * Desc.Height)
+    return llvm::createStringError(
+        "Data upload is not enough for texture size.");
+
+  auto TextureOrErr = Dev.createTexture(Name, Desc);
+  if (!TextureOrErr)
+    return TextureOrErr.takeError();
+  auto Texture = std::move(*TextureOrErr);
+
+  if (OutUploadBuffer == nullptr)
+    return llvm::createStringError("An upload buffer is required to create a "
+                                   "GpuOnly texture with data.");
+
+  const uint64_t TexRowStrideInBytes =
+      Dev.getTextureUploadRowStrideInBytes(Desc);
+  const uint64_t UploadBufferSizeInBytes =
+      (Desc.Height - 1) * TexRowStrideInBytes + PackedRowStrideInBytes;
+
+  // Create Upload buffer
+  const BufferCreateDesc UploadDesc = BufferCreateDesc::uploadBuffer();
+  std::string UploadBufferName = Name + " (Upload Buffer)";
+  auto UploadBufferOrErr =
+      Dev.createBuffer(UploadBufferName, UploadDesc, UploadBufferSizeInBytes);
+  if (!UploadBufferOrErr)
+    return UploadBufferOrErr.takeError();
+  *OutUploadBuffer = std::move(*UploadBufferOrErr);
+
+  auto MappedPtrOrErr = (*OutUploadBuffer)->map();
+  if (!MappedPtrOrErr)
+    return MappedPtrOrErr.takeError();
+
+  uint8_t *DstPtr = (uint8_t *)*MappedPtrOrErr;
+  const uint8_t *SrcPtr = (const uint8_t *)Data;
+
+  for (uint32_t Y = 0; Y < Desc.Height; ++Y) {
+    memcpy(DstPtr, SrcPtr, PackedRowStrideInBytes);
+    DstPtr += TexRowStrideInBytes;
+    SrcPtr += PackedRowStrideInBytes;
+  }
+  (*OutUploadBuffer)->unmap();
+
+  // Copy Buffer to Texture
+  if (auto Err = Encoder->copyBufferToTexture(**OutUploadBuffer, *Texture))
+    return Err;
+
+  return Texture;
+}

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -587,6 +587,33 @@ public:
     return llvm::Error::success();
   }
 
+  llvm::Error copyBufferToTexture(offloadtest::Buffer &Src,
+                                  offloadtest::Texture &Dst) override {
+    if (auto Err = ensureBlitEncoder())
+      return Err;
+    auto &MTLSrc = static_cast<MTLBuffer &>(Src);
+    auto &MTLDst = static_cast<MTLTexture &>(Dst);
+
+    // The upload buffer is laid out with a tightly packed row stride matching
+    // getTextureUploadRowStrideInBytes(), so the source bytes-per-row is the
+    // texture width times the element size.
+    const size_t ElemSize = getFormatSizeInBytes(MTLDst.Desc.Fmt);
+    const size_t RowBytes = MTLDst.Desc.Width * ElemSize;
+    const size_t ImageBytes = RowBytes * MTLDst.Desc.Height;
+    const MTL::Size CopySize(MTLDst.Desc.Width, MTLDst.Desc.Height, 1);
+
+    insertDebugSignpost(llvm::formatv("copyBufferToTexture {0} -> {1}",
+                                      MTLSrc.Name, MTLDst.Name)
+                            .str());
+    BlitEnc->copyFromBuffer(MTLSrc.Buf, /*sourceOffset=*/0, RowBytes,
+                            ImageBytes, CopySize, MTLDst.Tex,
+                            /*destinationSlice=*/0, /*destinationLevel=*/0,
+                            MTL::Origin(0, 0, 0));
+    addBarrierScope(MTL::BarrierScopeTextures);
+
+    return llvm::Error::success();
+  }
+
   // Defined out-of-line below — needs MTLDevice's full type for access to the
   // MTL::Device handle (used to allocate scratch and instance buffers).
   llvm::Error batchBuildAS(llvm::ArrayRef<ASBuildItem> Items) override;
@@ -1704,6 +1731,11 @@ public:
       return llvm::createStringError(std::errc::not_enough_memory,
                                      "Failed to create Metal texture.");
     return std::make_unique<MTLTexture>(Tex, Name, Desc);
+  }
+
+  uint32_t getTextureUploadRowStrideInBytes(
+      const TextureCreateDesc &Desc) const override {
+    return Desc.Width * getFormatSizeInBytes(Desc.Fmt);
   }
 
   llvm::Expected<std::unique_ptr<offloadtest::CommandBuffer>>

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -901,6 +901,38 @@ public:
     return llvm::Error::success();
   }
 
+  llvm::Error copyBufferToTexture(offloadtest::Buffer &Src,
+                                  offloadtest::Texture &Dst) override {
+    auto &VKSrc = llvm::cast<VulkanBuffer>(Src);
+    auto &VKDst = llvm::cast<VulkanTexture>(Dst);
+
+    CB.addImageTransition(CB.PendingSrcAccess,                /*SrcAccessMask*/
+                          VK_ACCESS_TRANSFER_WRITE_BIT,       /*DstAccessMask*/
+                          VKDst.preferredLayoutOrUndefined(), /*OldLayout*/
+                          VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, /*NewLayout*/
+                          VKDst);
+    VKDst.IsInUndefinedLayout = false;
+
+    CB.addPendingBarrier(VK_PIPELINE_STAGE_TRANSFER_BIT,
+                         VK_ACCESS_TRANSFER_READ_BIT |
+                             VK_ACCESS_TRANSFER_WRITE_BIT);
+    CB.flushBarrier();
+
+    insertDebugSignpost(
+        llvm::formatv("copyTextureToBuffer {0} -> {1}", VKSrc.Name, VKDst.Name)
+            .str());
+    vkCmdCopyBufferToImage(CB.CmdBuffer, VKSrc.Buffer, VKDst.Image,
+                           VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 0, nullptr);
+
+    CB.addImageTransition(VK_ACCESS_TRANSFER_WRITE_BIT, /*SrcAccessMask*/
+                          VK_ACCESS_NONE,               /*DstAccessMask*/
+                          VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, /*OldLayout*/
+                          VKDst.preferredLayoutOrUndefined(),   /*NewLayout*/
+                          VKDst);
+
+    return llvm::Error::success();
+  }
+
   // Defined out-of-line below — needs VulkanDevice's full type for access to
   // the device-loaded ray-tracing entry points and helpers.
   llvm::Error batchBuildAS(llvm::ArrayRef<ASBuildItem> Items) override;
@@ -2545,6 +2577,14 @@ public:
     }
 
     return Tex;
+  }
+
+  uint32_t getTextureUploadRowStrideInBytes(
+      const TextureCreateDesc &Desc) const override {
+    const uint64_t TightRow =
+        uint64_t(Desc.Width) * getFormatSizeInBytes(Desc.Fmt);
+    return static_cast<uint32_t>(llvm::alignTo(
+        TightRow, Props.limits.optimalBufferCopyRowPitchAlignment));
   }
 
   const Capabilities &getCapabilities() override {


### PR DESCRIPTION
Another small PR as a step towards a fully generic API for creating resources and uploading data.
The function is not actually being called in this PR, since doing that would make the PR very large, create a lot of extra work, and make it difficult to review as well.

This all builds on top of building blocks that have been layed out while doing the same logic for buffers, so none of the logic here is really new other than just variants of already existing code.