### PR TITLE
[DirectX] Enable WaveReadLaneAt test

### DIFF
--- a/test/WaveOps/WaveReadLaneAt.index.test
+++ b/test/WaveOps/WaveReadLaneAt.index.test
@@ -116,9 +116,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug: https://github.com/llvm/llvm-project/issues/202481
-# XFAIL: Clang && (DirectX || Metal)
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
Now that we fixed the switch table narrowing issue we should re-enable this test.