### PR TITLE
Add a Mesh Shader test that uses line geometry.

### DIFF
--- a/include/API/Enums.h
+++ b/include/API/Enums.h
@@ -45,7 +45,7 @@ enum class StoreAction {
   DontCare, ///< Contents may be discarded after the pass.
 };
 
-enum class PrimitiveTopology { TriangleList, PointList, PatchList };
+enum class PrimitiveTopology { TriangleList, PointList, PatchList, LineList };
 
 } // namespace offloadtest
 

--- a/include/Support/Pipeline.h
+++ b/include/Support/Pipeline.h
@@ -1026,6 +1026,7 @@ template <> struct ScalarEnumerationTraits<offloadtest::PrimitiveTopology> {
     ENUM_CASE(TriangleList);
     ENUM_CASE(PointList);
     ENUM_CASE(PatchList);
+    ENUM_CASE(LineList);
 #undef ENUM_CASE
   }
 };

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -112,6 +112,8 @@ getDXPrimitiveTopologyType(PrimitiveTopology Topology) {
     return D3D12_PRIMITIVE_TOPOLOGY_TYPE_POINT;
   case PrimitiveTopology::PatchList:
     return D3D12_PRIMITIVE_TOPOLOGY_TYPE_PATCH;
+  case PrimitiveTopology::LineList:
+    return D3D12_PRIMITIVE_TOPOLOGY_TYPE_LINE;
   }
   llvm_unreachable("All PrimitiveTopology cases handled");
 }
@@ -131,6 +133,8 @@ getDXPrimitiveTopology(PrimitiveTopology Topology,
     return static_cast<D3D_PRIMITIVE_TOPOLOGY>(
         D3D_PRIMITIVE_TOPOLOGY_1_CONTROL_POINT_PATCHLIST +
         (*PatchControlPoints - 1));
+  case PrimitiveTopology::LineList:
+    return D3D_PRIMITIVE_TOPOLOGY_LINELIST;
   }
   llvm_unreachable("All PrimitiveTopology cases handled");
 }

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -248,6 +248,8 @@ static VkPrimitiveTopology getVkPrimitiveTopology(PrimitiveTopology Topology) {
     return VK_PRIMITIVE_TOPOLOGY_POINT_LIST;
   case PrimitiveTopology::PatchList:
     return VK_PRIMITIVE_TOPOLOGY_PATCH_LIST;
+  case PrimitiveTopology::LineList:
+    return VK_PRIMITIVE_TOPOLOGY_LINE_LIST;
   }
   llvm_unreachable("All PrimitiveTopology cases handled");
 }

--- a/test/Graphics/MeshShaders/SimpleLines.test
+++ b/test/Graphics/MeshShaders/SimpleLines.test
@@ -20,8 +20,9 @@ void main(uint groupThreadID: SV_GroupThreadID, out vertices PSInput verts[32], 
 
     const float radius = 0.5;
     const float angle = float(groupThreadID) / 32.0f;
-    const float x = cos(angle * 2 * 3.14159265358) * radius;
-    const float y = sin(angle * 2 * 3.14159265358) * radius;
+    const float tau = 2.0 * 3.14159265359
+    const float x = cos(angle * tau) * radius;
+    const float y = sin(angle * tau) * radius;
 
     const float3 color = hueToRgb(angle);
 

--- a/test/Graphics/MeshShaders/SimpleLines.test
+++ b/test/Graphics/MeshShaders/SimpleLines.test
@@ -20,7 +20,7 @@ void main(uint groupThreadID: SV_GroupThreadID, out vertices PSInput verts[32], 
 
     const float radius = 0.5;
     const float angle = float(groupThreadID) / 32.0f;
-    const float tau = 2.0 * 3.14159265359
+    const float tau = 2.0 * 3.14159265359;
     const float x = cos(angle * tau) * radius;
     const float y = sin(angle * tau) * radius;
 

--- a/test/Graphics/MeshShaders/SimpleLines.test
+++ b/test/Graphics/MeshShaders/SimpleLines.test
@@ -1,0 +1,82 @@
+#--- mesh.hlsl
+struct PSInput
+{
+    float4 position : SV_POSITION;
+    float4 color : COLOR;
+};
+
+float3 hueToRgb(in float hue) {
+    return saturate(float3(
+        abs(hue * 6.0 - 3.0) - 1.0,
+        2.0 - abs(hue * 6.0 - 2.0),
+        2.0 - abs(hue * 6.0 - 4.0)
+    ));
+}
+
+[outputtopology("line")]
+[numthreads(32, 1, 1)]
+void main(uint groupThreadID: SV_GroupThreadID, out vertices PSInput verts[32], out indices uint2 lines[32]) {
+    SetMeshOutputCounts(32, 32);
+
+    const float radius = 0.5;
+    const float angle = float(groupThreadID) / 32.0f;
+    const float x = cos(angle * 2 * 3.14159265358) * radius;
+    const float y = sin(angle * 2 * 3.14159265358) * radius;
+
+    const float3 color = hueToRgb(angle);
+
+    verts[groupThreadID].position = float4(x, y, 0.0, 1.0);
+    verts[groupThreadID].color = float4(color, 1.0);
+
+    lines[groupThreadID] = uint2(groupThreadID, (groupThreadID + 1) % 32);
+}
+
+#--- pixel.hlsl
+struct PSInput
+{
+    float4 position : SV_POSITION;
+    float4 color : COLOR;
+};
+
+float4 main(PSInput input) : SV_TARGET
+{
+    return saturate(input.color);
+}
+#--- pipeline.yaml
+---
+Shaders:
+  - Stage: Mesh
+    Entry: main
+  - Stage: Pixel
+    Entry: main
+Buffers:
+  - Name: Output
+    Format: Float32
+    Channels: 4
+    FillSize: 1048576 # 256x256 @ 16 bytes per pixel
+    OutputProps:
+      Height: 256
+      Width: 256
+      Depth: 1
+Bindings:
+  Topology: LineList # Only care about the line part
+  RenderTarget: Output
+DescriptorSets: []
+...
+#--- rules.yaml
+---
+- Type: PixelPercent
+  Val: 0.2 # No more than 0.2% of pixels may be visibly different.
+...
+#--- end
+
+REQUIRES: MeshShader
+
+# Unimplemented https://github.com/llvm/llvm-project/issues/136966
+# XFAIL: Clang
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T ms_6_5 -Fo %t-mesh.o %t/mesh.hlsl
+# RUN: %dxc_target -T ps_6_5 -Fo %t-pixel.o %t/pixel.hlsl
+# RUN: %offloader %t/pipeline.yaml %t-mesh.o %t-pixel.o -r Output -o %t/Output.png
+# RUN: imgdiff %t/Output.png %goldenimage_dir/hlsl/Graphics/MeshShaders/SimpleLines.png -rules %t/rules.yaml


### PR DESCRIPTION
Add a Mesh Shader test that uses line geometry instead of triangle geometry.
It draws a circle of lines going through all colour hues.

Required new golden image: https://github.com/llvm/offload-golden-images/pull/10