### PR TITLE
[Metal] MTLDevice BufferCreateDesc needs to be fully initalized

### DIFF
--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -1414,7 +1414,11 @@ class MTLDevice : public offloadtest::Device {
             Contributions.push_back(Inst.InstanceContributionToHitGroupIndex &
                                     0xFFFFFFu);
           const BufferCreateDesc Desc{MemoryLocation::GpuToCpu,
-                                      BufferUsage::Storage};
+                                      MemoryBacking::Automatic,
+                                      BufferUsage::Storage,
+                                      BufferShaderAccessType::Raw,
+                                      {},
+                                      false};
           auto ContribBufOrErr = createBufferWithData(
               *IS.CB->Dev, "AS-Contributions", Desc, Contributions.data(),
               InstCount * sizeof(uint32_t), nullptr, nullptr);


### PR DESCRIPTION
The Metal\Mac runner builds are failing because we can't create a buffer description. This change full initalize it so we fix the warnings and build errors.