### PR TITLE
Use the internal lit shell

### DIFF
--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -19,7 +19,7 @@ from lit.llvm.subst import ToolSubst
 config.name = "OffloadTest-" + config.offloadtest_suite
 
 # testFormat: The test format to use to interpret tests.
-config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
+config.test_format = lit.formats.ShTest()
 
 # suffixes: A list of file extensions to treat as test files. This is overriden
 # by individual lit.local.cfg files in the test subdirectories.


### PR DESCRIPTION
The external lit shell is deprecated as of llvm/llvm-project#203689