### PR TITLE
Remove XFAILs for QuadReadAcrossDiagonal tests

### DIFF
--- a/test/WaveOps/QuadReadAcrossDiagonal.32.test
+++ b/test/WaveOps/QuadReadAcrossDiagonal.32.test
@@ -336,10 +336,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Unsupported in Clang, I have a working branch for QuadReadAcrossDiagonal intrinsic support
-# waiting on https://github.com/llvm/llvm-project/pull/187440 to be merged, so I can open a PR for it
-# XFAIL: Clang
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o 

--- a/test/WaveOps/QuadReadAcrossDiagonal.convergence.test
+++ b/test/WaveOps/QuadReadAcrossDiagonal.convergence.test
@@ -62,10 +62,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Unsupported in Clang, I have a working branch for QuadReadAcrossDiagonal intrinsic support
-# waiting on https://github.com/llvm/llvm-project/pull/187440 to be merged, so I can open a PR for it
-# XFAIL: Clang
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/WaveOps/QuadReadAcrossDiagonal.fp16.test
+++ b/test/WaveOps/QuadReadAcrossDiagonal.fp16.test
@@ -124,10 +124,6 @@ DescriptorSets:
 
 # REQUIRES: Half
 
-# Unsupported in Clang, I have a working branch for QuadReadAcrossDiagonal intrinsic support
-# waiting on https://github.com/llvm/llvm-project/pull/187440 to be merged, so I can open a PR for it
-# XFAIL: Clang
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/WaveOps/QuadReadAcrossDiagonal.fp64.test
+++ b/test/WaveOps/QuadReadAcrossDiagonal.fp64.test
@@ -124,10 +124,6 @@ DescriptorSets:
 
 # REQUIRES: Double
 
-# Unsupported in Clang, I have a working branch for QuadReadAcrossDiagonal intrinsic support
-# waiting on https://github.com/llvm/llvm-project/pull/187440 to be merged, so I can open a PR for it
-# XFAIL: Clang
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/WaveOps/QuadReadAcrossDiagonal.int16.test
+++ b/test/WaveOps/QuadReadAcrossDiagonal.int16.test
@@ -232,10 +232,6 @@ DescriptorSets:
 
 # REQUIRES: Int16
 
-# Unsupported in Clang, I have a working branch for QuadReadAcrossDiagonal intrinsic support
-# waiting on https://github.com/llvm/llvm-project/pull/187440 to be merged, so I can open a PR for it
-# XFAIL: Clang
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/WaveOps/QuadReadAcrossDiagonal.int64.test
+++ b/test/WaveOps/QuadReadAcrossDiagonal.int64.test
@@ -232,10 +232,6 @@ DescriptorSets:
 
 # REQUIRES: Int64
 
-# Unsupported in Clang, I have a working branch for QuadReadAcrossDiagonal intrinsic support
-# waiting on https://github.com/llvm/llvm-project/pull/187440 to be merged, so I can open a PR for it
-# XFAIL: Clang
-
 # Bug: https://github.com/llvm/offload-test-suite/issues/988
 # XFAIL: Metal
 


### PR DESCRIPTION
These are resolved as of llvm/llvm-project#188567