### PR TITLE
[Matrix][DirectX] Enable transpose tests when using layout keywords

### DIFF
--- a/test/Feature/CBuffer/Matrix/LayoutKeyword/transpose.test
+++ b/test/Feature/CBuffer/Matrix/LayoutKeyword/transpose.test
@@ -183,7 +183,7 @@ DescriptorSets:
 # Bug https://github.com/microsoft/DirectXShaderCompiler/issues/8473
 # XFAIL: Vulkan && DXC
 
-# Task: https://github.com/llvm/llvm-project/issues/201712
+# Unimplemented: https://github.com/llvm/llvm-project/issues/201712
 # XFAIL: Vulkan && Clang
 
 # RUN: split-file %s %t

--- a/test/Feature/CBuffer/Matrix/LayoutKeyword/transpose.test
+++ b/test/Feature/CBuffer/Matrix/LayoutKeyword/transpose.test
@@ -183,8 +183,8 @@ DescriptorSets:
 # Bug https://github.com/microsoft/DirectXShaderCompiler/issues/8473
 # XFAIL: Vulkan && DXC
 
-# Task: https://github.com/llvm/wg-hlsl/issues/305
-# XFAIL: Clang
+# Task: https://github.com/llvm/llvm-project/issues/201712
+# XFAIL: Vulkan && Clang
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -fvk-use-dx-layout -T cs_6_0 -Fo %t.o %t/source.hlsl


### PR DESCRIPTION
With https://github.com/llvm/llvm-project/pull/202486 now merged we can enable this test.