### PR TITLE
[DX][AMD] Mark world-ray-echo.test as XFAIL on AMD DX12.

### DIFF
--- a/test/Feature/InlineRT/world-ray-echo.test
+++ b/test/Feature/InlineRT/world-ray-echo.test
@@ -90,6 +90,9 @@ Results:
 # REQUIRES: acceleration-structure
 # XFAIL: Clang
 
+# Bug: https://github.com/llvm/offload-test-suite/issues/1321
+# XFAIL: AMD && DirectX
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -fvk-use-dx-layout -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
This test is failing to (likely) a driver bug, mark it as XFAIL on AMD && DirectX

https://github.com/llvm/offload-test-suite/issues/1321