### PR TITLE
[DX][Metal] Enable array-of-constant-buffers.test

### DIFF
--- a/test/Feature/ResourceArrays/array-of-constant-buffers.test
+++ b/test/Feature/ResourceArrays/array-of-constant-buffers.test
@@ -67,11 +67,6 @@ DescriptorSets:
 ...
 #--- end
 
-# CBuffer<T> not yet implemented for DirectX
-# Unimplemented https://github.com/llvm/llvm-project/issues/122791
-# XFAIL: Clang && DirectX
-# XFAIL: Clang && Metal
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
with https://github.com/llvm/llvm-project/pull/204732 merged this test is now passing. Remove the DX and Metal xfails.