### PR TITLE
Enable split build feature

### DIFF
--- a/.github/workflows/pr-matrix.yaml
+++ b/.github/workflows/pr-matrix.yaml
@@ -32,6 +32,7 @@ jobs:
       SKU: ${{ matrix.SKU }}
       TestTarget: ${{ matrix.TestTarget }}
       OffloadTest-branch: ${{ github.event.pull_request.head.sha }}
+      SplitBuild: true
       LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=On
 
   Exec-Tests-Windows-Warp:
@@ -50,6 +51,7 @@ jobs:
       SKU: ${{ matrix.SKU }}
       TestTarget: ${{ matrix.TestTarget }}
       OffloadTest-branch: ${{ github.event.pull_request.head.sha }}
+      SplitBuild: true
       LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=On
 
   Exec-Tests-Extra:
@@ -72,6 +74,7 @@ jobs:
       SKU: ${{ matrix.SKU }}
       TestTarget: ${{ matrix.TestTarget }}
       OffloadTest-branch: ${{ github.event.pull_request.head.sha }}
+      SplitBuild: true
       LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=On
 
   Exec-Tests-MacOS:


### PR DESCRIPTION
This PR enables the split build feature across all workflow entry points defined in pr-matrix.yml.
This should remove the "skip" results in all the PRs.