### PR TITLE
[CI] Add a VK and DX only test all tag

### DIFF
--- a/.github/workflows/pr-matrix.yaml
+++ b/.github/workflows/pr-matrix.yaml
@@ -58,6 +58,20 @@ jobs:
     permissions:
       contents: read
       checks: write
+    if: contains( github.event.pull_request.labels.*.name, 'test-dx-all')
+    strategy:
+      fail-fast: false
+      matrix:
+        SKU: [windows-amd, windows-qc]
+        TestTarget: [check-hlsl-d3d12, check-hlsl-clang-d3d12]
+    
+    if: contains( github.event.pull_request.labels.*.name, 'test-vk-all')
+    strategy:
+      fail-fast: false
+      matrix:
+        SKU: [windows-amd, windows-nvidia, windows-qc]
+        TestTarget: [check-hlsl-vk, check-hlsl-clang-vk]
+
     if: contains( github.event.pull_request.labels.*.name, 'test-all')
     strategy:
       fail-fast: false

--- a/.github/workflows/pr-matrix.yaml
+++ b/.github/workflows/pr-matrix.yaml
@@ -58,20 +58,6 @@ jobs:
     permissions:
       contents: read
       checks: write
-    if: contains( github.event.pull_request.labels.*.name, 'test-dx-all')
-    strategy:
-      fail-fast: false
-      matrix:
-        SKU: [windows-amd, windows-qc]
-        TestTarget: [check-hlsl-d3d12, check-hlsl-clang-d3d12]
-    
-    if: contains( github.event.pull_request.labels.*.name, 'test-vk-all')
-    strategy:
-      fail-fast: false
-      matrix:
-        SKU: [windows-amd, windows-nvidia, windows-qc]
-        TestTarget: [check-hlsl-vk, check-hlsl-clang-vk]
-
     if: contains( github.event.pull_request.labels.*.name, 'test-all')
     strategy:
       fail-fast: false
@@ -81,6 +67,46 @@ jobs:
         exclude:
           - { SKU: windows-nvidia, TestTarget: check-hlsl-d3d12 }
           - { SKU: windows-nvidia, TestTarget: check-hlsl-clang-d3d12 }
+
+    uses: ./.github/workflows/build-and-test-callable.yaml
+    with:
+      OS: windows
+      SKU: ${{ matrix.SKU }}
+      TestTarget: ${{ matrix.TestTarget }}
+      OffloadTest-branch: ${{ github.event.pull_request.head.sha }}
+      SplitBuild: true
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=On
+
+  Exec-Tests-Extra-DX-All:
+    permissions:
+      contents: read
+      checks: write
+    if: contains( github.event.pull_request.labels.*.name, 'test-dx-all')
+    strategy:
+      fail-fast: false
+      matrix:
+        SKU: [windows-amd, windows-qc]
+        TestTarget: [check-hlsl-d3d12, check-hlsl-clang-d3d12]
+
+    uses: ./.github/workflows/build-and-test-callable.yaml
+    with:
+      OS: windows
+      SKU: ${{ matrix.SKU }}
+      TestTarget: ${{ matrix.TestTarget }}
+      OffloadTest-branch: ${{ github.event.pull_request.head.sha }}
+      SplitBuild: true
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=On
+
+  Exec-Tests-Extra-VK-All:
+    permissions:
+      contents: read
+      checks: write
+    if: contains( github.event.pull_request.labels.*.name, 'test-vk-all')
+    strategy:
+      fail-fast: false
+      matrix:
+        SKU: [windows-amd, windows-nvidia, windows-qc]
+        TestTarget: [check-hlsl-vk, check-hlsl-clang-vk]
 
     uses: ./.github/workflows/build-and-test-callable.yaml
     with:


### PR DESCRIPTION
The test-all tag is a bit to expensive when we are only testing DIXL or SPIRV related changes. This PR allows us to pick only the runtime we need to test.