### PR TITLE
[DX12] Add support for Samplers in DX12.

### DIFF
--- a/include/API/Device.h
+++ b/include/API/Device.h
@@ -20,6 +20,7 @@
 #include "API/Capabilities.h"
 #include "API/CommandBuffer.h"
 #include "API/RenderPass.h"
+#include "API/Sampler.h"
 #include "API/ShaderBindingTable.h"
 #include "API/Texture.h"
 
@@ -345,6 +346,9 @@ public:
 
   virtual llvm::Expected<std::unique_ptr<Texture>>
   createTexture(std::string Name, const TextureCreateDesc &Desc) = 0;
+
+  virtual llvm::Expected<std::unique_ptr<Sampler>>
+  createSampler(std::string Name, const SamplerCreateDesc &Desc) = 0;
 
   virtual llvm::Expected<std::unique_ptr<MemoryHeap>>
   createMemoryHeap(std::string Name, size_t SizeInBytes) = 0;

--- a/include/API/Sampler.h
+++ b/include/API/Sampler.h
@@ -1,0 +1,67 @@
+//===- Sampler.h - Offload API Texture ------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef OFFLOADTEST_API_SAMPLER_H
+#define OFFLOADTEST_API_SAMPLER_H
+
+#include "API/API.h"
+#include "API/Resources.h"
+
+namespace offloadtest {
+
+enum class FilterMode { Nearest, Linear };
+
+enum class AddressMode { Clamp, Repeat, Mirror, Border, MirrorOnce };
+
+enum class CompareFunction {
+  Never,
+  Less,
+  Equal,
+  LessEqual,
+  Greater,
+  NotEqual,
+  GreaterEqual,
+  Always
+};
+
+enum class SamplerKind { Sampler, SamplerComparison };
+
+struct SamplerCreateDesc {
+  FilterMode MinFilter = FilterMode::Linear;
+  FilterMode MagFilter = FilterMode::Linear;
+  AddressMode Address = AddressMode::Clamp;
+  float MinLOD = 0.0f;
+  float MaxLOD = std::numeric_limits<float>::max();
+  float MipLODBias = 0.0f;
+  CompareFunction ComparisonOp = CompareFunction::Never;
+  SamplerKind Kind = SamplerKind::Sampler;
+};
+
+class Sampler {
+  GPUAPI API;
+
+public:
+  virtual ~Sampler();
+  Sampler(const Sampler &) = delete;
+  // Sampler(Sampler &&) = delete;
+  Sampler &operator=(const Sampler &) = delete;
+  // Sampler &operator=(Sampler &&) = delete;
+
+  GPUAPI getAPI() const { return API; }
+  virtual const SamplerCreateDesc &getDesc() const = 0;
+
+protected:
+  explicit Sampler(GPUAPI API) : API(API) {}
+};
+
+} // namespace offloadtest
+
+#endif // OFFLOADTEST_API_SAMPLER_H

--- a/include/API/Sampler.h
+++ b/include/API/Sampler.h
@@ -1,11 +1,8 @@
-//===- Sampler.h - Offload API Texture ------------------------------------===//
+//===- Sampler.h - Offload API Sampler ------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//===----------------------------------------------------------------------===//
-//
 //
 //===----------------------------------------------------------------------===//
 
@@ -51,9 +48,7 @@ class Sampler {
 public:
   virtual ~Sampler();
   Sampler(const Sampler &) = delete;
-  // Sampler(Sampler &&) = delete;
   Sampler &operator=(const Sampler &) = delete;
-  // Sampler &operator=(Sampler &&) = delete;
 
   GPUAPI getAPI() const { return API; }
   virtual const SamplerCreateDesc &getDesc() const = 0;

--- a/include/API/Texture.h
+++ b/include/API/Texture.h
@@ -105,12 +105,6 @@ inline llvm::Error validateTextureCreateDesc(const TextureCreateDesc &Desc) {
         std::errc::not_supported,
         "DepthStencil combined with Storage is not yet supported.");
 
-  // Depth formats require DepthStencil usage; non-depth formats forbid it.
-  if (IsDepth && !IsDS)
-    return llvm::createStringError(
-        std::errc::invalid_argument,
-        "Depth format '%s' requires DepthStencil usage.",
-        getFormatName(Desc.Fmt).data());
   if (!IsDepth && IsDS)
     return llvm::createStringError(
         std::errc::invalid_argument,

--- a/include/Support/Pipeline.h
+++ b/include/Support/Pipeline.h
@@ -16,6 +16,7 @@
 #include "API/AccelerationStructure.h"
 #include "API/Enums.h"
 #include "API/Resources.h"
+#include "API/Sampler.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Error.h"
@@ -140,24 +141,7 @@ static inline DescriptorKind getDescriptorKind(ResourceKind RK) {
   llvm_unreachable("All cases handled");
 }
 
-enum class FilterMode { Nearest, Linear };
-
-enum class AddressMode { Clamp, Repeat, Mirror, Border, MirrorOnce };
-
-enum class CompareFunction {
-  Never,
-  Less,
-  Equal,
-  LessEqual,
-  Greater,
-  NotEqual,
-  GreaterEqual,
-  Always
-};
-
-enum class SamplerKind { Sampler, SamplerComparison };
-
-struct Sampler {
+struct YAMLSampler {
   std::string Name;
   FilterMode MinFilter = FilterMode::Linear;
   FilterMode MagFilter = FilterMode::Linear;
@@ -270,7 +254,7 @@ struct Resource {
   DirectXBinding DXBinding;
   std::optional<VulkanBinding> VKBinding;
   CPUBuffer *BufferPtr = nullptr;
-  Sampler *SamplerPtr = nullptr;
+  YAMLSampler *SamplerPtr = nullptr;
   bool HasCounter = false;
   std::optional<uint32_t> TilesMapped;
   bool IsReserved = false;
@@ -630,7 +614,7 @@ struct Pipeline {
   IOBindings Bindings;
   llvm::SmallVector<PushConstantBlock> PushConstants;
   llvm::SmallVector<CPUBuffer> Buffers;
-  llvm::SmallVector<Sampler> Samplers;
+  llvm::SmallVector<YAMLSampler> Samplers;
   llvm::SmallVector<Result> Results;
   llvm::SmallVector<DescriptorSet> Sets;
   DispatchParametersSet DispatchParameters;
@@ -671,7 +655,7 @@ struct Pipeline {
     return nullptr;
   }
 
-  Sampler *getSampler(llvm::StringRef Name) {
+  YAMLSampler *getSampler(llvm::StringRef Name) {
     for (auto &S : Samplers)
       if (Name == S.Name)
         return &S;
@@ -712,7 +696,7 @@ struct Pipeline {
 LLVM_YAML_IS_SEQUENCE_VECTOR(offloadtest::DescriptorSet)
 LLVM_YAML_IS_SEQUENCE_VECTOR(offloadtest::Resource)
 LLVM_YAML_IS_SEQUENCE_VECTOR(offloadtest::CPUBuffer)
-LLVM_YAML_IS_SEQUENCE_VECTOR(offloadtest::Sampler)
+LLVM_YAML_IS_SEQUENCE_VECTOR(offloadtest::YAMLSampler)
 LLVM_YAML_IS_SEQUENCE_VECTOR(offloadtest::Shader)
 LLVM_YAML_IS_SEQUENCE_VECTOR(offloadtest::dx::RootParameter)
 LLVM_YAML_IS_SEQUENCE_VECTOR(offloadtest::Result)
@@ -744,8 +728,8 @@ template <> struct MappingTraits<offloadtest::CPUBuffer> {
   static void mapping(IO &I, offloadtest::CPUBuffer &R);
 };
 
-template <> struct MappingTraits<offloadtest::Sampler> {
-  static void mapping(IO &I, offloadtest::Sampler &S);
+template <> struct MappingTraits<offloadtest::YAMLSampler> {
+  static void mapping(IO &I, offloadtest::YAMLSampler &S);
 };
 
 template <> struct MappingTraits<offloadtest::Result> {

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -141,6 +141,67 @@ getDXPrimitiveTopology(PrimitiveTopology Topology,
   llvm_unreachable("All PrimitiveTopology cases handled");
 }
 
+static D3D12_FILTER getDXFilterMode(FilterMode MinFilter, FilterMode MagFilter,
+                                    bool IsComparison) {
+  if (IsComparison) {
+    if (MinFilter == FilterMode::Nearest)
+      return MagFilter == FilterMode::Nearest
+                 ? D3D12_FILTER_COMPARISON_MIN_MAG_MIP_POINT
+                 : D3D12_FILTER_COMPARISON_MIN_POINT_MAG_LINEAR_MIP_POINT;
+    else
+      return MagFilter == FilterMode::Nearest
+                 ? D3D12_FILTER_COMPARISON_MIN_LINEAR_MAG_MIP_POINT
+                 : D3D12_FILTER_COMPARISON_MIN_MAG_LINEAR_MIP_POINT;
+  } else {
+    if (MinFilter == FilterMode::Nearest)
+      return MagFilter == FilterMode::Nearest
+                 ? D3D12_FILTER_MIN_MAG_MIP_POINT
+                 : D3D12_FILTER_MIN_POINT_MAG_LINEAR_MIP_POINT;
+    else
+      return MagFilter == FilterMode::Nearest
+                 ? D3D12_FILTER_MIN_LINEAR_MAG_MIP_POINT
+                 : D3D12_FILTER_MIN_MAG_LINEAR_MIP_POINT;
+  }
+}
+
+static D3D12_TEXTURE_ADDRESS_MODE getDXTextureAddressMode(AddressMode Mode) {
+  switch (Mode) {
+  case AddressMode::Clamp:
+    return D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
+  case AddressMode::Repeat:
+    return D3D12_TEXTURE_ADDRESS_MODE_WRAP;
+  case AddressMode::Mirror:
+    return D3D12_TEXTURE_ADDRESS_MODE_MIRROR;
+  case AddressMode::Border:
+    return D3D12_TEXTURE_ADDRESS_MODE_BORDER;
+  case AddressMode::MirrorOnce:
+    return D3D12_TEXTURE_ADDRESS_MODE_MIRROR_ONCE;
+  }
+  llvm_unreachable("All cases handled.");
+}
+
+static D3D12_COMPARISON_FUNC getDXComparisonFunc(CompareFunction ComparisonOp) {
+  switch (ComparisonOp) {
+  case CompareFunction::Never:
+    return D3D12_COMPARISON_FUNC_NEVER;
+  case CompareFunction::Less:
+    return D3D12_COMPARISON_FUNC_LESS;
+  case CompareFunction::Equal:
+    return D3D12_COMPARISON_FUNC_EQUAL;
+  case CompareFunction::LessEqual:
+    return D3D12_COMPARISON_FUNC_LESS_EQUAL;
+  case CompareFunction::Greater:
+    return D3D12_COMPARISON_FUNC_GREATER;
+  case CompareFunction::NotEqual:
+    return D3D12_COMPARISON_FUNC_NOT_EQUAL;
+  case CompareFunction::GreaterEqual:
+    return D3D12_COMPARISON_FUNC_GREATER_EQUAL;
+  case CompareFunction::Always:
+    return D3D12_COMPARISON_FUNC_ALWAYS;
+  }
+  llvm_unreachable("All cases handled.");
+}
+
 namespace {
 class DXDevice;
 
@@ -243,10 +304,47 @@ public:
   }
 };
 
+class DXSampler : public offloadtest::Sampler {
+public:
+  D3D12_CPU_DESCRIPTOR_HANDLE Handle = {};
+  std::string Name;
+  SamplerCreateDesc Desc;
+
+  DXSampler(llvm::StringRef Name, SamplerCreateDesc Desc,
+            D3D12_CPU_DESCRIPTOR_HANDLE Handle)
+      : offloadtest::Sampler(GPUAPI::DirectX), Handle(Handle), Name(Name),
+        Desc(Desc) {}
+
+  const SamplerCreateDesc &getDesc() const override { return Desc; }
+
+  static bool classof(const offloadtest::Sampler *S) {
+    return S->getAPI() == GPUAPI::DirectX;
+  }
+};
+
+enum class RootParameterType : uint32_t {
+  DescriptorTable = 0,
+  SamplerTable,
+  Constant,
+  CBV,
+  SRV,
+  UAV,
+};
+
+struct RoogtSignatureLayout {
+  RootParameterType ParameterType : 3;
+  uint32_t Count : 29;
+
+  RoogtSignatureLayout(RootParameterType ParameterType, uint32_t Count)
+      : ParameterType(ParameterType), Count(Count) {}
+  RoogtSignatureLayout() = delete;
+};
+
 class DXPipelineState : public offloadtest::PipelineState {
 public:
   std::string Name;
   ComPtr<ID3D12RootSignature> RootSig;
+  llvm::SmallVector<RoogtSignatureLayout> Layout;
   ComPtr<ID3D12PipelineState> PSO;
   // Only set for graphics pipelines.
   std::optional<D3D_PRIMITIVE_TOPOLOGY> Topology;
@@ -256,11 +354,13 @@ public:
   bool IsRayTracing = false;
 
   DXPipelineState(llvm::StringRef Name, ComPtr<ID3D12RootSignature> RootSig,
+                  llvm::SmallVector<RoogtSignatureLayout> Layout,
                   ComPtr<ID3D12PipelineState> PSO,
                   std::optional<D3D_PRIMITIVE_TOPOLOGY> Topology,
                   bool IsRT = false)
       : offloadtest::PipelineState(GPUAPI::DirectX), Name(Name),
-        RootSig(RootSig), PSO(PSO), Topology(Topology), IsRayTracing(IsRT) {}
+        RootSig(RootSig), Layout(std::move(Layout)), PSO(PSO),
+        Topology(Topology), IsRayTracing(IsRT) {}
 
   static bool classof(const offloadtest::PipelineState *B) {
     return B->getAPI() == GPUAPI::DirectX;
@@ -279,9 +379,11 @@ public:
 
   DXRayTracingPipelineState(llvm::StringRef Name,
                             ComPtr<ID3D12RootSignature> RootSig,
+                            llvm::SmallVector<RoogtSignatureLayout> Layout,
                             ComPtr<ID3D12StateObject> SO,
                             ComPtr<ID3D12StateObjectProperties> Props)
-      : DXPipelineState(Name, RootSig, /*PSO=*/nullptr, std::nullopt,
+      : DXPipelineState(Name, RootSig, std::move(Layout), /*PSO=*/nullptr,
+                        std::nullopt,
                         /*IsRT=*/true),
         StateObject(SO), Properties(Props) {}
 
@@ -1166,15 +1268,18 @@ public:
   DescriptorAllocator RTVAllocator;
   DescriptorAllocator DSVAllocator;
   DescriptorAllocator CSUAllocator;
+  DescriptorAllocator SamplerAllocator;
 
   DXDevice(ComPtr<IDXCoreAdapter> A, ComPtr<ID3D12DeviceX> D, DXQueue Q,
            DescriptorAllocator RTVAllocator, DescriptorAllocator DSVAllocator,
-           DescriptorAllocator CSUAllocator, std::string Desc,
+           DescriptorAllocator CSUAllocator,
+           DescriptorAllocator SamplerAllocator, std::string Desc,
            std::string DriverVer)
       : Adapter(A), Device(D), GraphicsQueue(std::move(Q)),
         RTVAllocator(std::move(RTVAllocator)),
         DSVAllocator(std::move(DSVAllocator)),
-        CSUAllocator(std::move(CSUAllocator)) {
+        CSUAllocator(std::move(CSUAllocator)),
+        SamplerAllocator(std::move(SamplerAllocator)) {
     Description = std::move(Desc);
     DriverVersion = std::move(DriverVer);
     DriverName = "DirectX";
@@ -1216,9 +1321,10 @@ public:
 
   Queue &getGraphicsQueue() override { return GraphicsQueue; }
 
-  llvm::Error
-  createRootSignatureFromShader(llvm::StringRef, const ShaderContainer &Shader,
-                                ComPtr<ID3D12RootSignature> &OutRootSignature) {
+  llvm::Error createRootSignatureFromShader(
+      llvm::StringRef Name, const ShaderContainer &Shader,
+      ComPtr<ID3D12RootSignature> &OutRootSignature,
+      llvm::SmallVectorImpl<RoogtSignatureLayout> &Layout) {
     // Try pulling a root signature from the DXIL first
     auto ExContainer =
         llvm::object::DXContainer::create(Shader.Shader->getMemBufferRef());
@@ -1238,14 +1344,71 @@ public:
                                           IID_PPV_ARGS(&OutRootSignature)),
               "Failed to create root signature."))
         return Err;
+
+      const std::wstring WStr(Name.begin(), Name.end());
+      OutRootSignature->SetName(WStr.c_str());
+
+      // Deserialize the root signature to determine how we need to bind
+      // descriptor tables
+      ComPtr<ID3D12VersionedRootSignatureDeserializer> Deserializer;
+      if (auto Err = HR::toError(
+              D3D12CreateVersionedRootSignatureDeserializer(
+                  Binary.data(), Binary.size(), IID_PPV_ARGS(&Deserializer)),
+              "Failed to create Root Signature Deserializer"))
+        return Err;
+
+      const D3D12_VERSIONED_ROOT_SIGNATURE_DESC *RootSigDesc = nullptr;
+      if (auto Err =
+              HR::toError(Deserializer->GetRootSignatureDescAtVersion(
+                              D3D_ROOT_SIGNATURE_VERSION_1, &RootSigDesc),
+                          "Failed to deseralize root signature"))
+        return Err;
+
+      for (uint32_t I = 0; I < RootSigDesc->Desc_1_0.NumParameters; ++I) {
+        const D3D12_ROOT_PARAMETER &Parameter =
+            RootSigDesc->Desc_1_0.pParameters[I];
+        switch (Parameter.ParameterType) {
+        case D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE: {
+          uint32_t DescriptorCount = 0;
+          for (uint32_t I = 0;
+               I < Parameter.DescriptorTable.NumDescriptorRanges; ++I)
+            DescriptorCount +=
+                Parameter.DescriptorTable.pDescriptorRanges[I].NumDescriptors;
+
+          if (Parameter.DescriptorTable.NumDescriptorRanges > 0 &&
+              Parameter.DescriptorTable.pDescriptorRanges[0].RangeType ==
+                  D3D12_DESCRIPTOR_RANGE_TYPE_SAMPLER)
+            Layout.push_back(RoogtSignatureLayout(
+                RootParameterType::SamplerTable, DescriptorCount));
+          else
+            Layout.push_back(RoogtSignatureLayout(
+                RootParameterType::DescriptorTable, DescriptorCount));
+          break;
+        }
+        case D3D12_ROOT_PARAMETER_TYPE_32BIT_CONSTANTS:
+          Layout.push_back(RoogtSignatureLayout(
+              RootParameterType::Constant, Parameter.Constants.Num32BitValues));
+          break;
+        case D3D12_ROOT_PARAMETER_TYPE_CBV:
+          Layout.push_back(RoogtSignatureLayout(RootParameterType::CBV, 1));
+          break;
+        case D3D12_ROOT_PARAMETER_TYPE_SRV:
+          Layout.push_back(RoogtSignatureLayout(RootParameterType::SRV, 1));
+          break;
+        case D3D12_ROOT_PARAMETER_TYPE_UAV:
+          Layout.push_back(RoogtSignatureLayout(RootParameterType::UAV, 1));
+          break;
+        }
+      }
     }
 
     return llvm::Error::success();
   }
 
   llvm::Error createRootSignatureFromBindingsDesc(
-      llvm::StringRef, const BindingsDesc &BndDesc, bool IsGraphics,
-      ComPtr<ID3D12RootSignature> &OutRootSignature) {
+      llvm::StringRef Name, const BindingsDesc &BndDesc, bool IsGraphics,
+      ComPtr<ID3D12RootSignature> &OutRootSignature,
+      llvm::SmallVectorImpl<RoogtSignatureLayout> &Layout) {
     uint32_t DescriptorCount = 0;
     for (auto &D : BndDesc.DescriptorSetDescs)
       DescriptorCount += D.ResourceBindings.size();
@@ -1258,7 +1421,11 @@ public:
       uint32_t DescriptorIdx = 0;
       const uint32_t StartRangeIdx = RangeIdx;
       for (const auto &Binding : Set.ResourceBindings) {
-        switch (getDescriptorKind(Binding.Kind)) {
+        const DescriptorKind Kind = getDescriptorKind(Binding.Kind);
+        if (Kind == DescriptorKind::SAMPLER)
+          continue;
+
+        switch (Kind) {
         case DescriptorKind::SRV:
           Ranges.get()[RangeIdx].RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SRV;
           break;
@@ -1269,7 +1436,8 @@ public:
           Ranges.get()[RangeIdx].RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_CBV;
           break;
         case DescriptorKind::SAMPLER:
-          llvm_unreachable("Not implemented yet."); // Requires a separate heap
+          llvm_unreachable("Sampler should have been filtered out.");
+          break;
         }
         Ranges.get()[RangeIdx].NumDescriptors = Binding.DescriptorCount;
         Ranges.get()[RangeIdx].BaseShaderRegister = Binding.DXBinding.Register;
@@ -1279,12 +1447,49 @@ public:
         RangeIdx++;
         DescriptorIdx += Binding.DescriptorCount;
       }
-      RootParams.push_back(D3D12_ROOT_PARAMETER{
-          D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE,
-          {D3D12_ROOT_DESCRIPTOR_TABLE{
-              static_cast<uint32_t>(Set.ResourceBindings.size()),
-              &Ranges.get()[StartRangeIdx]}},
-          D3D12_SHADER_VISIBILITY_ALL});
+      const uint32_t RangeCount =
+          static_cast<uint32_t>(RangeIdx - StartRangeIdx);
+      if (RangeCount > 0) {
+        RootParams.push_back(
+            D3D12_ROOT_PARAMETER{D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE,
+                                 {D3D12_ROOT_DESCRIPTOR_TABLE{
+                                     RangeCount, &Ranges.get()[StartRangeIdx]}},
+                                 D3D12_SHADER_VISIBILITY_ALL});
+        Layout.push_back(RoogtSignatureLayout(
+            RootParameterType::DescriptorTable, DescriptorIdx));
+      }
+
+      uint32_t SamplerDescriptorIdx = 0;
+      const uint32_t SamplerStartRangeIdx = RangeIdx;
+      for (const auto &Binding : Set.ResourceBindings) {
+        const DescriptorKind Kind = getDescriptorKind(Binding.Kind);
+        if (Kind != DescriptorKind::SAMPLER)
+          continue;
+
+        Ranges.get()[RangeIdx].RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SAMPLER;
+        Ranges.get()[RangeIdx].NumDescriptors = Binding.DescriptorCount;
+        Ranges.get()[RangeIdx].BaseShaderRegister = Binding.DXBinding.Register;
+        Ranges.get()[RangeIdx].RegisterSpace = Binding.DXBinding.Space;
+        Ranges.get()[RangeIdx].OffsetInDescriptorsFromTableStart =
+            SamplerDescriptorIdx;
+
+        assert(Binding.DescriptorCount == 1 && "Manon expected this to be 1.");
+        RangeIdx++;
+        SamplerDescriptorIdx += Binding.DescriptorCount;
+      }
+
+      const uint32_t SamplerRangeCount =
+          static_cast<uint32_t>(RangeIdx - SamplerStartRangeIdx);
+      if (SamplerRangeCount > 0) {
+        RootParams.push_back(D3D12_ROOT_PARAMETER{
+            D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE,
+            {D3D12_ROOT_DESCRIPTOR_TABLE{
+                static_cast<uint32_t>(RangeIdx - SamplerStartRangeIdx),
+                &Ranges.get()[SamplerStartRangeIdx]}},
+            D3D12_SHADER_VISIBILITY_ALL});
+        Layout.push_back(RoogtSignatureLayout(RootParameterType::SamplerTable,
+                                              SamplerDescriptorIdx));
+      }
     }
 
     CD3DX12_ROOT_SIGNATURE_DESC Desc;
@@ -1315,32 +1520,37 @@ public:
             "Failed to create root signature."))
       return Err;
 
+    const std::wstring WStr(Name.begin(), Name.end());
+    OutRootSignature->SetName(WStr.c_str());
+
     return llvm::Error::success();
   }
 
   llvm::Error
   createRootSignature(llvm::StringRef Name, const BindingsDesc &BndDesc,
                       const ShaderContainer &Shader, bool IsGraphics,
-                      ComPtr<ID3D12RootSignature> &OutRootSignature) {
+                      ComPtr<ID3D12RootSignature> &OutRootSignature,
+                      llvm::SmallVectorImpl<RoogtSignatureLayout> &Layout) {
     assert(OutRootSignature.Get() == nullptr);
 
-    if (auto Err =
-            createRootSignatureFromShader(Name, Shader, OutRootSignature))
+    if (auto Err = createRootSignatureFromShader(Name, Shader, OutRootSignature,
+                                                 Layout))
       return Err;
 
     if (OutRootSignature.Get() != nullptr)
       return llvm::Error::success();
 
     return createRootSignatureFromBindingsDesc(Name, BndDesc, IsGraphics,
-                                               OutRootSignature);
+                                               OutRootSignature, Layout);
   }
 
   llvm::Expected<std::unique_ptr<PipelineState>>
   createPipelineCs(llvm::StringRef Name, const BindingsDesc &BndDesc,
                    ShaderContainer CS) override {
     ComPtr<ID3D12RootSignature> RootSig;
+    llvm::SmallVector<RoogtSignatureLayout> Layout;
     if (auto Err = createRootSignature(Name, BndDesc, CS,
-                                       /*IsGraphics=*/false, RootSig))
+                                       /*IsGraphics=*/false, RootSig, Layout))
       return Err;
 
     auto DXIL = CS.Shader->getBuffer();
@@ -1360,7 +1570,8 @@ public:
             "Failed to create PSO."))
       return Err;
 
-    return std::make_unique<DXPipelineState>(Name, RootSig, PSO, std::nullopt);
+    return std::make_unique<DXPipelineState>(Name, RootSig, std::move(Layout),
+                                             PSO, std::nullopt);
   }
 
   llvm::Expected<std::unique_ptr<PipelineState>>
@@ -1370,8 +1581,9 @@ public:
     assert(Desc.RTFormats.size() <= 8);
 
     ComPtr<ID3D12RootSignature> RootSig;
+    llvm::SmallVector<RoogtSignatureLayout> Layout;
     if (auto Err = createRootSignature(Name, BndDesc, Desc.VS,
-                                       /*IsGraphics=*/true, RootSig))
+                                       /*IsGraphics=*/true, RootSig, Layout))
       return Err;
 
     std::vector<D3D12_INPUT_ELEMENT_DESC> DXInputLayout;
@@ -1435,7 +1647,7 @@ public:
       return Err;
 
     return std::make_unique<DXPipelineState>(
-        Name, RootSig, PSO,
+        Name, RootSig, std::move(Layout), PSO,
         getDXPrimitiveTopology(Desc.Topology, Desc.PatchControlPoints));
   }
 
@@ -1445,8 +1657,9 @@ public:
     assert(Desc.RTFormats.size() <= 8);
 
     ComPtr<ID3D12RootSignature> RootSig;
+    llvm::SmallVector<RoogtSignatureLayout> Layout;
     if (auto Err = createRootSignature(Name, BindingsDesc, Desc.MS,
-                                       /*IsGraphics=*/true, RootSig))
+                                       /*IsGraphics=*/true, RootSig, Layout))
       return Err;
 
     const D3D12_SHADER_BYTECODE MSBytecode = {
@@ -1512,7 +1725,8 @@ public:
             "Failed to create mesh shader PSO."))
       return Err;
 
-    return std::make_unique<DXPipelineState>(Name, RootSig, PSO, std::nullopt);
+    return std::make_unique<DXPipelineState>(Name, RootSig, std::move(Layout),
+                                             PSO, std::nullopt);
   }
 
   static std::wstring widen(llvm::StringRef S) {
@@ -1544,8 +1758,9 @@ public:
     ShaderContainer LibContainer = {};
     LibContainer.Shader = Desc.Library;
     ComPtr<ID3D12RootSignature> RootSig;
+    llvm::SmallVector<RoogtSignatureLayout> Layout;
     if (auto Err = createRootSignature(Name, BndDesc, LibContainer,
-                                       /*IsGraphics=*/false, RootSig))
+                                       /*IsGraphics=*/false, RootSig, Layout))
       return Err;
 
     CD3DX12_STATE_OBJECT_DESC SODesc(
@@ -1612,7 +1827,7 @@ public:
       return Err;
 
     auto State = std::make_unique<DXRayTracingPipelineState>(
-        Name, RootSig, StateObject, Properties);
+        Name, RootSig, Layout, StateObject, Properties);
     // Cache identifiers up-front. The driver-owned blobs are alive for
     // Properties' lifetime, which lives on the PSO.
     //
@@ -2044,6 +2259,42 @@ public:
     return Tex;
   }
 
+  llvm::Expected<std::unique_ptr<Sampler>>
+  createSampler(std::string Name, const SamplerCreateDesc &Desc) override {
+
+    auto HandleOrErr = SamplerAllocator.allocate();
+    if (!HandleOrErr)
+      return HandleOrErr.takeError();
+    const D3D12_CPU_DESCRIPTOR_HANDLE Handle = *HandleOrErr;
+
+    const D3D12_TEXTURE_ADDRESS_MODE AddressMode =
+        getDXTextureAddressMode(Desc.Address);
+
+    bool IsComparison = false;
+    D3D12_COMPARISON_FUNC ComparisonFunc = D3D12_COMPARISON_FUNC_NONE;
+    if (Desc.Kind == SamplerKind::SamplerComparison) {
+      IsComparison = true;
+      ComparisonFunc = getDXComparisonFunc(Desc.ComparisonOp);
+    }
+
+    const D3D12_SAMPLER_DESC SamplerDesc = {
+        getDXFilterMode(Desc.MinFilter, Desc.MagFilter, IsComparison),
+        AddressMode, // U
+        AddressMode, // V
+        AddressMode, // W
+        Desc.MipLODBias,
+        0, // MaxAnisotropy
+        ComparisonFunc,
+        {0.0f, 0.0f, 0.0f, 0.0f}, // BorderColor
+        Desc.MinLOD,
+        Desc.MaxLOD,
+    };
+
+    Device->CreateSampler(&SamplerDesc, Handle);
+
+    return std::make_unique<DXSampler>(Name, Desc, Handle);
+  }
+
   uint32_t getTextureUploadRowStrideInBytes(
       const TextureCreateDesc &Desc) const override {
     return getAlignedTexturePitch(Desc.Width, getFormatSizeInBytes(Desc.Fmt));
@@ -2114,11 +2365,16 @@ public:
     if (!CSUHeapOrErr)
       return CSUHeapOrErr.takeError();
 
+    auto SamplerHeapOrErr = DescriptorAllocator::create(
+        Device.Get(), D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER, 256);
+    if (!SamplerHeapOrErr)
+      return SamplerHeapOrErr.takeError();
+
     return std::make_unique<DXDevice>(
         Adapter, Device, std::move(*GraphicsQueueOrErr),
         std::move(*RTVHeapOrErr), std::move(*DSVHeapOrErr),
-        std::move(*CSUHeapOrErr), std::string(DescVec.data()),
-        std::move(DriverVer));
+        std::move(*CSUHeapOrErr), std::move(*SamplerHeapOrErr),
+        std::string(DescVec.data()), std::move(DriverVer));
   }
 
   const Capabilities &getCapabilities() override {
@@ -2160,18 +2416,44 @@ public:
     return llvm::Error::success();
   }
 
-  llvm::Error createDescriptorHeap(Pipeline &P,
-                                   ComPtr<ID3D12DescriptorHeap> &DescHeap) {
+  llvm::Error createDescriptorHeaps(Pipeline &P,
+                                    ComPtr<ID3D12DescriptorHeap> &DescHeap,
+                                    ComPtr<ID3D12DescriptorHeap> &SamplerHeap) {
     if (P.getDescriptorCount() == 0)
       return llvm::Error::success();
+
+    uint32_t DescriptorCount = 0;
+    uint32_t SamplerCount = 0;
+    for (auto &D : P.Sets)
+      for (auto &R : D.Resources)
+        if (R.isSampler())
+          SamplerCount += 1;
+        else
+          DescriptorCount += R.getArraySize();
+
+    // prevent empty heaps
+    if (DescriptorCount == 0)
+      DescriptorCount = 1;
+    if (SamplerCount == 0)
+      SamplerCount = 1;
+
     const D3D12_DESCRIPTOR_HEAP_DESC HeapDesc = {
-        D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV,
-        P.getDescriptorCountWithFlattenedArrays(),
+        D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, DescriptorCount,
         D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE, 0};
     if (auto Err = HR::toError(
             Device->CreateDescriptorHeap(&HeapDesc, IID_PPV_ARGS(&DescHeap)),
             "Failed to create descriptor heap."))
       return Err;
+
+    const D3D12_DESCRIPTOR_HEAP_DESC SamplerHeapDesc = {
+        D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER, SamplerCount,
+        D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE, 0};
+    if (auto Err =
+            HR::toError(Device->CreateDescriptorHeap(
+                            &SamplerHeapDesc, IID_PPV_ARGS(&SamplerHeap)),
+                        "Failed to create sampler descriptor heap."))
+      return Err;
+
     return llvm::Error::success();
   }
 
@@ -2331,15 +2613,26 @@ public:
   }
 
   void buildDescriptorTables(llvm::ArrayRef<DescriptorTable> DescTables,
-                             const ComPtr<ID3D12DescriptorHeap> &DescHeap) {
+                             const ComPtr<ID3D12DescriptorHeap> &DescHeap,
+                             const ComPtr<ID3D12DescriptorHeap> &SamplerHeap) {
     // Bind descriptors in descriptor tables.
-    if (!DescHeap)
+    if (!DescHeap && !SamplerHeap)
       return;
+
     uint32_t HeapIndex = 0;
+    uint32_t SamplerHeapIndex = 0;
+
     const D3D12_CPU_DESCRIPTOR_HANDLE HeapStart =
         DescHeap->GetCPUDescriptorHandleForHeapStart();
+    const D3D12_CPU_DESCRIPTOR_HANDLE SamplerHeapStart =
+        SamplerHeap->GetCPUDescriptorHandleForHeapStart();
+
     const uint32_t DescHandleIncSize = Device->GetDescriptorHandleIncrementSize(
         D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+    const uint32_t SamplerHandleIncSize =
+        Device->GetDescriptorHandleIncrementSize(
+            D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER);
+
     for (auto &T : DescTables) {
       for (auto &R : T.Resources) {
         for (const auto &Set : R.second) {
@@ -2388,6 +2681,9 @@ public:
             const DXAccelerationStructure &AccelerationStructureDX =
                 llvm::cast<DXAccelerationStructure>(*Set.AS);
             DescriptorHandle = AccelerationStructureDX.SRVHandle;
+          } else if (Set.Sampler != nullptr) {
+            const DXSampler &SamplerDX = llvm::cast<DXSampler>(*Set.Sampler);
+            DescriptorHandle = SamplerDX.Handle;
           } else {
             llvm_unreachable("Resource was a texture nor buffer. Samplers "
                              "are unsupported");
@@ -2395,10 +2691,20 @@ public:
 
           assert(DescriptorHandle.ptr != 0 &&
                  "Somehow got a null descriptor :(");
-          Device->CopyDescriptorsSimple(
-              1, {HeapStart.ptr + HeapIndex * DescHandleIncSize},
-              DescriptorHandle, D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
-          HeapIndex += 1;
+
+          if (Set.Sampler != nullptr) {
+            Device->CopyDescriptorsSimple(
+                1,
+                {SamplerHeapStart.ptr +
+                 SamplerHeapIndex * SamplerHandleIncSize},
+                DescriptorHandle, D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER);
+            SamplerHeapIndex += 1;
+          } else {
+            Device->CopyDescriptorsSimple(
+                1, {HeapStart.ptr + HeapIndex * DescHandleIncSize},
+                DescriptorHandle, D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+            HeapIndex += 1;
+          }
         }
       }
     }
@@ -2406,14 +2712,16 @@ public:
 
   llvm::Error
   createComputeCommands(Pipeline &P, SharedInvocationState &IS,
-                        const ComPtr<ID3D12DescriptorHeap> &DescHeap) {
+                        const ComPtr<ID3D12DescriptorHeap> &DescHeap,
+                        const ComPtr<ID3D12DescriptorHeap> &SamplerHeap) {
     const DXCommandBuffer &DXCB = llvm::cast<DXCommandBuffer>(*IS.CB);
 
-    CD3DX12_GPU_DESCRIPTOR_HANDLE Handle;
+    CD3DX12_GPU_DESCRIPTOR_HANDLE Handle, SamplerHandle;
     if (DescHeap) {
-      ID3D12DescriptorHeap *const Heaps[] = {DescHeap.Get()};
-      DXCB.CmdList->SetDescriptorHeaps(1, Heaps);
+      ID3D12DescriptorHeap *const Heaps[] = {DescHeap.Get(), SamplerHeap.Get()};
+      DXCB.CmdList->SetDescriptorHeaps(2, Heaps);
       Handle = DescHeap->GetGPUDescriptorHandleForHeapStart();
+      SamplerHandle = SamplerHeap->GetGPUDescriptorHandleForHeapStart();
     }
     const DXPipelineState &DXPipeline =
         llvm::cast<DXPipelineState>(*IS.Pipeline.get());
@@ -2421,6 +2729,8 @@ public:
 
     const uint32_t Inc = Device->GetDescriptorHandleIncrementSize(
         D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+    const uint32_t SamplerInc = Device->GetDescriptorHandleIncrementSize(
+        D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER);
 
     if (P.Settings.DX.RootParams.size() > 0) {
       uint32_t ConstantOffset = 0u;
@@ -2444,6 +2754,7 @@ public:
           break;
         }
         case dx::RootParamKind::DescriptorTable:
+          // TODO(manon): Add support for descriptor tables containing samplers
           DXCB.CmdList->SetComputeRootDescriptorTable(RootParamIndex++, Handle);
           Handle.Offset(P.Sets[DescriptorTableIndex++].Resources.size(), Inc);
           break;
@@ -2478,7 +2789,8 @@ public:
                                                            VirtualAddress);
             break;
           case DescriptorKind::SAMPLER:
-            llvm_unreachable("Not implemented yet.");
+            llvm_unreachable(
+                "Samplers cannot be written directly into the Root Signature.");
           }
           ++RootDescIt;
           break;
@@ -2488,9 +2800,22 @@ public:
       // If no explicit root parameters are provided, fall back to using the
       // descriptor set layout. This is to make it easier to write tests that
       // don't need complicated root signatures.
-      for (uint32_t Idx = 0u; Idx < P.Sets.size(); ++Idx) {
-        DXCB.CmdList->SetComputeRootDescriptorTable(Idx, Handle);
-        Handle.Offset(P.Sets[Idx].Resources.size(), Inc);
+      for (uint32_t I = 0, N = DXPipeline.Layout.size(); I < N; ++I) {
+        const auto &Layout = DXPipeline.Layout[I];
+        switch (Layout.ParameterType) {
+        case RootParameterType::DescriptorTable:
+          DXCB.CmdList->SetComputeRootDescriptorTable(I, Handle);
+          Handle.Offset(Layout.Count, Inc);
+          break;
+        case RootParameterType::SamplerTable:
+          DXCB.CmdList->SetComputeRootDescriptorTable(I, SamplerHandle);
+          SamplerHandle.Offset(Layout.Count, SamplerInc);
+          break;
+        default:
+          return llvm::createStringError(
+              "Root Signatures that contain constants and inline descriptors "
+              "require custom RootParamters to be defined.");
+        }
       }
     }
 
@@ -2537,17 +2862,44 @@ public:
 
   llvm::Error
   createGraphicsCommands(Pipeline &P, SharedInvocationState &IS,
-                         const ComPtr<ID3D12DescriptorHeap> &DescHeap) {
+                         const ComPtr<ID3D12DescriptorHeap> &DescHeap,
+                         const ComPtr<ID3D12DescriptorHeap> &SamplerHeap) {
     const DXPipelineState &DXPipeline =
         llvm::cast<DXPipelineState>(*IS.Pipeline.get());
     const DXCommandBuffer &DXCB = llvm::cast<DXCommandBuffer>(*IS.CB);
-
     DXCB.CmdList->SetGraphicsRootSignature(DXPipeline.RootSig.Get());
+
     if (DescHeap) {
-      ID3D12DescriptorHeap *const Heaps[] = {DescHeap.Get()};
-      DXCB.CmdList->SetDescriptorHeaps(1, Heaps);
-      DXCB.CmdList->SetGraphicsRootDescriptorTable(
-          0, DescHeap->GetGPUDescriptorHandleForHeapStart());
+      ID3D12DescriptorHeap *const Heaps[] = {DescHeap.Get(), SamplerHeap.Get()};
+      DXCB.CmdList->SetDescriptorHeaps(2, Heaps);
+      CD3DX12_GPU_DESCRIPTOR_HANDLE Handle(
+          DescHeap->GetGPUDescriptorHandleForHeapStart());
+      CD3DX12_GPU_DESCRIPTOR_HANDLE SamplerHandle(
+          SamplerHeap->GetGPUDescriptorHandleForHeapStart());
+
+      const uint32_t Inc = Device->GetDescriptorHandleIncrementSize(
+          D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+      const uint32_t SamplerInc = Device->GetDescriptorHandleIncrementSize(
+          D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER);
+
+      for (uint32_t I = 0, N = DXPipeline.Layout.size(); I < N; ++I) {
+        const auto &Layout = DXPipeline.Layout[I];
+        llvm::outs() << "Layout.Count: " << Layout.Count << "\n";
+        switch (Layout.ParameterType) {
+        case RootParameterType::DescriptorTable:
+          DXCB.CmdList->SetGraphicsRootDescriptorTable(I, Handle);
+          Handle.Offset(Layout.Count, Inc);
+          break;
+        case RootParameterType::SamplerTable:
+          DXCB.CmdList->SetGraphicsRootDescriptorTable(I, SamplerHandle);
+          SamplerHandle.Offset(Layout.Count, SamplerInc);
+          break;
+        default:
+          return llvm::createStringError(
+              "Root Signatures that contain constants and inline descriptors "
+              "require custom RootParamters to be defined.");
+        }
+      }
     }
 
     RenderPassBeginDesc BeginDesc = {};
@@ -2617,8 +2969,8 @@ public:
   llvm::Error executeProgram(Pipeline &P) override {
     llvm::outs() << "Configuring execution on device: " << Description << "\n";
 
-    ComPtr<ID3D12DescriptorHeap> DescHeap;
-    if (auto Err = createDescriptorHeap(P, DescHeap))
+    ComPtr<ID3D12DescriptorHeap> DescHeap, SamplerHeap;
+    if (auto Err = createDescriptorHeaps(P, DescHeap, SamplerHeap))
       return Err;
     llvm::outs() << "Descriptor heap created.\n";
 
@@ -2633,7 +2985,7 @@ public:
       return Err;
     llvm::outs() << "Buffers created.\n";
 
-    buildDescriptorTables(State.DescTables, DescHeap);
+    buildDescriptorTables(State.DescTables, DescHeap, SamplerHeap);
 
     if (!P.AccelStructs.BLAS.empty() || !P.AccelStructs.TLAS.empty()) {
       auto EncOrErr = State.CB->createComputeEncoder();
@@ -2680,7 +3032,7 @@ public:
         return PipelineStateOrErr.takeError();
       State.Pipeline = std::move(*PipelineStateOrErr);
       llvm::outs() << "Compute Pipeline created.\n";
-      if (auto Err = createComputeCommands(P, State, DescHeap))
+      if (auto Err = createComputeCommands(P, State, DescHeap, SamplerHeap))
         return Err;
       llvm::outs() << "Compute command list created.\n";
 
@@ -2786,7 +3138,7 @@ public:
         llvm::outs() << "Mesh Shader Pipeline created.\n";
       }
 
-      if (auto Err = createGraphicsCommands(P, State, DescHeap))
+      if (auto Err = createGraphicsCommands(P, State, DescHeap, SamplerHeap))
         return Err;
       llvm::outs() << "Graphics command list created complete.\n";
     } else if (P.isRayTracing()) {
@@ -2817,7 +3169,7 @@ public:
       State.SBT = std::move(*SBTOrErr);
       llvm::outs() << "Shader Binding Table created.\n";
 
-      if (auto Err = createComputeCommands(P, State, DescHeap))
+      if (auto Err = createComputeCommands(P, State, DescHeap, SamplerHeap))
         return Err;
       llvm::outs() << "RayTracing command list created.\n";
     } else {

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -2731,6 +2731,17 @@ public:
         D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER);
 
     if (P.Settings.DX.RootParams.size() > 0) {
+
+      // Samplers are not supported in RootParams, error if we do find any.
+      for (const auto &Set : P.Sets) {
+        for (const auto &R : Set.Resources) {
+          if (R.isSampler())
+            return llvm::createStringError(
+                "Descriptor tables containing samplers are not yet supported "
+                "with explicit RootParameters.");
+        }
+      }
+
       uint32_t ConstantOffset = 0u;
       uint32_t RootParamIndex = 0u;
       uint32_t DescriptorTableIndex = 0u;
@@ -2752,7 +2763,6 @@ public:
           break;
         }
         case dx::RootParamKind::DescriptorTable:
-          // TODO(manon): Add support for descriptor tables containing samplers
           DXCB.CmdList->SetComputeRootDescriptorTable(RootParamIndex++, Handle);
           Handle.Offset(P.Sets[DescriptorTableIndex++].Resources.size(), Inc);
           break;

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -2822,7 +2822,7 @@ public:
         default:
           return llvm::createStringError(
               "Root Signatures that contain constants and inline descriptors "
-              "require custom RootParamters to be defined.");
+              "require custom RootParameters to be defined.");
         }
       }
     }
@@ -2904,7 +2904,7 @@ public:
         default:
           return llvm::createStringError(
               "Root Signatures that contain constants and inline descriptors "
-              "require custom RootParamters to be defined.");
+              "require custom RootParameters to be defined.");
         }
       }
     }

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -148,20 +148,19 @@ static D3D12_FILTER getDXFilterMode(FilterMode MinFilter, FilterMode MagFilter,
       return MagFilter == FilterMode::Nearest
                  ? D3D12_FILTER_COMPARISON_MIN_MAG_MIP_POINT
                  : D3D12_FILTER_COMPARISON_MIN_POINT_MAG_LINEAR_MIP_POINT;
-    else
-      return MagFilter == FilterMode::Nearest
-                 ? D3D12_FILTER_COMPARISON_MIN_LINEAR_MAG_MIP_POINT
-                 : D3D12_FILTER_COMPARISON_MIN_MAG_LINEAR_MIP_POINT;
-  } else {
-    if (MinFilter == FilterMode::Nearest)
-      return MagFilter == FilterMode::Nearest
-                 ? D3D12_FILTER_MIN_MAG_MIP_POINT
-                 : D3D12_FILTER_MIN_POINT_MAG_LINEAR_MIP_POINT;
-    else
-      return MagFilter == FilterMode::Nearest
-                 ? D3D12_FILTER_MIN_LINEAR_MAG_MIP_POINT
-                 : D3D12_FILTER_MIN_MAG_LINEAR_MIP_POINT;
+
+    return MagFilter == FilterMode::Nearest
+               ? D3D12_FILTER_COMPARISON_MIN_LINEAR_MAG_MIP_POINT
+               : D3D12_FILTER_COMPARISON_MIN_MAG_LINEAR_MIP_POINT;
   }
+  if (MinFilter == FilterMode::Nearest)
+    return MagFilter == FilterMode::Nearest
+               ? D3D12_FILTER_MIN_MAG_MIP_POINT
+               : D3D12_FILTER_MIN_POINT_MAG_LINEAR_MIP_POINT;
+
+  return MagFilter == FilterMode::Nearest
+             ? D3D12_FILTER_MIN_LINEAR_MAG_MIP_POINT
+             : D3D12_FILTER_MIN_MAG_LINEAR_MIP_POINT;
 }
 
 static D3D12_TEXTURE_ADDRESS_MODE getDXTextureAddressMode(AddressMode Mode) {

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -330,20 +330,20 @@ enum class RootParameterType : uint32_t {
   UAV,
 };
 
-struct RoogtSignatureLayout {
+struct RootSignatureLayout {
   RootParameterType ParameterType : 3;
   uint32_t Count : 29;
 
-  RoogtSignatureLayout(RootParameterType ParameterType, uint32_t Count)
+  RootSignatureLayout(RootParameterType ParameterType, uint32_t Count)
       : ParameterType(ParameterType), Count(Count) {}
-  RoogtSignatureLayout() = delete;
+  RootSignatureLayout() = delete;
 };
 
 class DXPipelineState : public offloadtest::PipelineState {
 public:
   std::string Name;
   ComPtr<ID3D12RootSignature> RootSig;
-  llvm::SmallVector<RoogtSignatureLayout> Layout;
+  llvm::SmallVector<RootSignatureLayout> Layout;
   ComPtr<ID3D12PipelineState> PSO;
   // Only set for graphics pipelines.
   std::optional<D3D_PRIMITIVE_TOPOLOGY> Topology;
@@ -353,7 +353,7 @@ public:
   bool IsRayTracing = false;
 
   DXPipelineState(llvm::StringRef Name, ComPtr<ID3D12RootSignature> RootSig,
-                  llvm::SmallVector<RoogtSignatureLayout> Layout,
+                  llvm::SmallVector<RootSignatureLayout> Layout,
                   ComPtr<ID3D12PipelineState> PSO,
                   std::optional<D3D_PRIMITIVE_TOPOLOGY> Topology,
                   bool IsRT = false)
@@ -378,7 +378,7 @@ public:
 
   DXRayTracingPipelineState(llvm::StringRef Name,
                             ComPtr<ID3D12RootSignature> RootSig,
-                            llvm::SmallVector<RoogtSignatureLayout> Layout,
+                            llvm::SmallVector<RootSignatureLayout> Layout,
                             ComPtr<ID3D12StateObject> SO,
                             ComPtr<ID3D12StateObjectProperties> Props)
       : DXPipelineState(Name, RootSig, std::move(Layout), /*PSO=*/nullptr,
@@ -1323,7 +1323,7 @@ public:
   llvm::Error createRootSignatureFromShader(
       llvm::StringRef Name, const ShaderContainer &Shader,
       ComPtr<ID3D12RootSignature> &OutRootSignature,
-      llvm::SmallVectorImpl<RoogtSignatureLayout> &Layout) {
+      llvm::SmallVectorImpl<RootSignatureLayout> &Layout) {
     // Try pulling a root signature from the DXIL first
     auto ExContainer =
         llvm::object::DXContainer::create(Shader.Shader->getMemBufferRef());
@@ -1377,25 +1377,25 @@ public:
           if (Parameter.DescriptorTable.NumDescriptorRanges > 0 &&
               Parameter.DescriptorTable.pDescriptorRanges[0].RangeType ==
                   D3D12_DESCRIPTOR_RANGE_TYPE_SAMPLER)
-            Layout.push_back(RoogtSignatureLayout(
+            Layout.push_back(RootSignatureLayout(
                 RootParameterType::SamplerTable, DescriptorCount));
           else
-            Layout.push_back(RoogtSignatureLayout(
+            Layout.push_back(RootSignatureLayout(
                 RootParameterType::DescriptorTable, DescriptorCount));
           break;
         }
         case D3D12_ROOT_PARAMETER_TYPE_32BIT_CONSTANTS:
-          Layout.push_back(RoogtSignatureLayout(
+          Layout.push_back(RootSignatureLayout(
               RootParameterType::Constant, Parameter.Constants.Num32BitValues));
           break;
         case D3D12_ROOT_PARAMETER_TYPE_CBV:
-          Layout.push_back(RoogtSignatureLayout(RootParameterType::CBV, 1));
+          Layout.push_back(RootSignatureLayout(RootParameterType::CBV, 1));
           break;
         case D3D12_ROOT_PARAMETER_TYPE_SRV:
-          Layout.push_back(RoogtSignatureLayout(RootParameterType::SRV, 1));
+          Layout.push_back(RootSignatureLayout(RootParameterType::SRV, 1));
           break;
         case D3D12_ROOT_PARAMETER_TYPE_UAV:
-          Layout.push_back(RoogtSignatureLayout(RootParameterType::UAV, 1));
+          Layout.push_back(RootSignatureLayout(RootParameterType::UAV, 1));
           break;
         }
       }
@@ -1407,7 +1407,7 @@ public:
   llvm::Error createRootSignatureFromBindingsDesc(
       llvm::StringRef Name, const BindingsDesc &BndDesc, bool IsGraphics,
       ComPtr<ID3D12RootSignature> &OutRootSignature,
-      llvm::SmallVectorImpl<RoogtSignatureLayout> &Layout) {
+      llvm::SmallVectorImpl<RootSignatureLayout> &Layout) {
     uint32_t DescriptorCount = 0;
     for (auto &D : BndDesc.DescriptorSetDescs)
       DescriptorCount += D.ResourceBindings.size();
@@ -1454,8 +1454,8 @@ public:
                                  {D3D12_ROOT_DESCRIPTOR_TABLE{
                                      RangeCount, &Ranges.get()[StartRangeIdx]}},
                                  D3D12_SHADER_VISIBILITY_ALL});
-        Layout.push_back(RoogtSignatureLayout(
-            RootParameterType::DescriptorTable, DescriptorIdx));
+        Layout.push_back(RootSignatureLayout(RootParameterType::DescriptorTable,
+                                             DescriptorIdx));
       }
 
       uint32_t SamplerDescriptorIdx = 0;
@@ -1485,8 +1485,8 @@ public:
                 static_cast<uint32_t>(RangeIdx - SamplerStartRangeIdx),
                 &Ranges.get()[SamplerStartRangeIdx]}},
             D3D12_SHADER_VISIBILITY_ALL});
-        Layout.push_back(RoogtSignatureLayout(RootParameterType::SamplerTable,
-                                              SamplerDescriptorIdx));
+        Layout.push_back(RootSignatureLayout(RootParameterType::SamplerTable,
+                                             SamplerDescriptorIdx));
       }
     }
 
@@ -1528,7 +1528,7 @@ public:
   createRootSignature(llvm::StringRef Name, const BindingsDesc &BndDesc,
                       const ShaderContainer &Shader, bool IsGraphics,
                       ComPtr<ID3D12RootSignature> &OutRootSignature,
-                      llvm::SmallVectorImpl<RoogtSignatureLayout> &Layout) {
+                      llvm::SmallVectorImpl<RootSignatureLayout> &Layout) {
     assert(OutRootSignature.Get() == nullptr);
 
     if (auto Err = createRootSignatureFromShader(Name, Shader, OutRootSignature,
@@ -1546,7 +1546,7 @@ public:
   createPipelineCs(llvm::StringRef Name, const BindingsDesc &BndDesc,
                    ShaderContainer CS) override {
     ComPtr<ID3D12RootSignature> RootSig;
-    llvm::SmallVector<RoogtSignatureLayout> Layout;
+    llvm::SmallVector<RootSignatureLayout> Layout;
     if (auto Err = createRootSignature(Name, BndDesc, CS,
                                        /*IsGraphics=*/false, RootSig, Layout))
       return Err;
@@ -1579,7 +1579,7 @@ public:
     assert(Desc.RTFormats.size() <= 8);
 
     ComPtr<ID3D12RootSignature> RootSig;
-    llvm::SmallVector<RoogtSignatureLayout> Layout;
+    llvm::SmallVector<RootSignatureLayout> Layout;
     if (auto Err = createRootSignature(Name, BndDesc, Desc.VS,
                                        /*IsGraphics=*/true, RootSig, Layout))
       return Err;
@@ -1655,7 +1655,7 @@ public:
     assert(Desc.RTFormats.size() <= 8);
 
     ComPtr<ID3D12RootSignature> RootSig;
-    llvm::SmallVector<RoogtSignatureLayout> Layout;
+    llvm::SmallVector<RootSignatureLayout> Layout;
     if (auto Err = createRootSignature(Name, BindingsDesc, Desc.MS,
                                        /*IsGraphics=*/true, RootSig, Layout))
       return Err;
@@ -1756,7 +1756,7 @@ public:
     ShaderContainer LibContainer = {};
     LibContainer.Shader = Desc.Library;
     ComPtr<ID3D12RootSignature> RootSig;
-    llvm::SmallVector<RoogtSignatureLayout> Layout;
+    llvm::SmallVector<RootSignatureLayout> Layout;
     if (auto Err = createRootSignature(Name, BndDesc, LibContainer,
                                        /*IsGraphics=*/false, RootSig, Layout))
       return Err;

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -2614,7 +2614,7 @@ public:
                              const ComPtr<ID3D12DescriptorHeap> &DescHeap,
                              const ComPtr<ID3D12DescriptorHeap> &SamplerHeap) {
     // Bind descriptors in descriptor tables.
-    if (!DescHeap && !SamplerHeap)
+    if (!DescHeap)
       return;
 
     uint32_t HeapIndex = 0;

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -2883,7 +2883,6 @@ public:
 
       for (uint32_t I = 0, N = DXPipeline.Layout.size(); I < N; ++I) {
         const auto &Layout = DXPipeline.Layout[I];
-        llvm::outs() << "Layout.Count: " << Layout.Count << "\n";
         switch (Layout.ParameterType) {
         case RootParameterType::DescriptorTable:
           DXCB.CmdList->SetGraphicsRootDescriptorTable(I, Handle);

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -1472,7 +1472,6 @@ public:
         Ranges.get()[RangeIdx].OffsetInDescriptorsFromTableStart =
             SamplerDescriptorIdx;
 
-        assert(Binding.DescriptorCount == 1 && "Manon expected this to be 1.");
         RangeIdx++;
         SamplerDescriptorIdx += Binding.DescriptorCount;
       }

--- a/lib/API/Device.cpp
+++ b/lib/API/Device.cpp
@@ -36,6 +36,8 @@ Queue::~Queue() {}
 
 Texture::~Texture() {}
 
+Sampler::~Sampler() {}
+
 MemoryHeap::~MemoryHeap() {}
 
 RenderPass::~RenderPass() {}

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -498,6 +498,17 @@ public:
   }
 };
 
+class MTLSampler : public offloadtest::Sampler {
+public:
+  SamplerCreateDesc Desc;
+
+  const SamplerCreateDesc &getDesc() const override { return Desc; }
+
+  static bool classof(const offloadtest::Sampler *S) {
+    return S->getAPI() == GPUAPI::Metal;
+  }
+};
+
 /// Metal has no standalone render-pass object: render pass info lives on
 /// MTLRenderPassDescriptor and is consumed when a render command encoder
 /// is created. We therefore just stash the descriptor for the encoder to
@@ -2395,6 +2406,11 @@ public:
       return llvm::createStringError(std::errc::not_enough_memory,
                                      "Failed to create Metal texture.");
     return std::make_unique<MTLTexture>(Tex, Name, Desc);
+  }
+
+  llvm::Expected<std::unique_ptr<Sampler>>
+  createSampler(std::string, const SamplerCreateDesc &) override {
+    return llvm::createStringError("createSampler is unimplemented on Metal.");
   }
 
   uint32_t getTextureUploadRowStrideInBytes(

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -570,6 +570,17 @@ public:
   }
 };
 
+class VulkanSampler : public offloadtest::Sampler {
+public:
+  SamplerCreateDesc Desc;
+
+  const SamplerCreateDesc &getDesc() const override { return Desc; }
+
+  static bool classof(const offloadtest::Sampler *S) {
+    return S->getAPI() == GPUAPI::Vulkan;
+  }
+};
+
 class VulkanAccelerationStructure : public offloadtest::AccelerationStructure {
 public:
   VkDevice Dev;
@@ -2920,6 +2931,11 @@ public:
     return Tex;
   }
 
+  llvm::Expected<std::unique_ptr<Sampler>>
+  createSampler(std::string, const SamplerCreateDesc &) override {
+    return llvm::createStringError("createSampler is unimplemented on Vulkan.");
+  }
+
   uint32_t getTextureUploadRowStrideInBytes(
       const TextureCreateDesc &Desc) const override {
     const uint64_t TightRow =
@@ -3446,7 +3462,7 @@ public:
   llvm::Expected<ResourceRef> createSampler(Resource &R, BufferRef &Host) {
     VkSamplerCreateInfo SamplerInfo = {};
     SamplerInfo.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
-    const Sampler &S = *R.SamplerPtr;
+    const YAMLSampler &S = *R.SamplerPtr;
     SamplerInfo.magFilter = getVKFilter(S.MagFilter);
     SamplerInfo.minFilter = getVKFilter(S.MinFilter);
     SamplerInfo.mipmapMode = VK_SAMPLER_MIPMAP_MODE_NEAREST;

--- a/lib/Support/OffloadMigration.cpp
+++ b/lib/Support/OffloadMigration.cpp
@@ -325,7 +325,7 @@ llvm::Error createResources(Device &Dev, Pipeline &P,
       assert(Inserted.second && "TLAS bound to multiple resources NYI");
       (void)Inserted;
     } else if (R.isSampler()) {
-      SamplerCreateDesc Desc = {
+      const SamplerCreateDesc Desc = {
           R.SamplerPtr->MinFilter,    R.SamplerPtr->MagFilter,
           R.SamplerPtr->Address,      R.SamplerPtr->MinLOD,
           R.SamplerPtr->MaxLOD,       R.SamplerPtr->MipLODBias,

--- a/lib/Support/OffloadMigration.cpp
+++ b/lib/Support/OffloadMigration.cpp
@@ -324,9 +324,23 @@ llvm::Error createResources(Device &Dev, Pipeline &P,
           IS.TLASes.try_emplace(R.TLASPtr->Name, std::move(*ASOrErr));
       assert(Inserted.second && "TLAS bound to multiple resources NYI");
       (void)Inserted;
+    } else if (R.isSampler()) {
+      SamplerCreateDesc Desc = {
+          R.SamplerPtr->MinFilter,    R.SamplerPtr->MagFilter,
+          R.SamplerPtr->Address,      R.SamplerPtr->MinLOD,
+          R.SamplerPtr->MaxLOD,       R.SamplerPtr->MipLODBias,
+          R.SamplerPtr->ComparisonOp, R.SamplerPtr->Kind,
+      };
+
+      auto SamplerOrErr = Dev.createSampler(R.SamplerPtr->Name, Desc);
+      if (!SamplerOrErr)
+        return SamplerOrErr.takeError();
+
+      ResourceSet RSet(std::move(*SamplerOrErr));
+      ResBundle.push_back(std::move(RSet));
     } else {
       return llvm::createStringError(std::errc::not_supported,
-                                     "Samplers are not yet implemented.");
+                                     "Unrecognized resource type.");
     }
 
     Resources.push_back(std::make_pair(&R, std::move(ResBundle)));

--- a/lib/Support/OffloadMigration.h
+++ b/lib/Support/OffloadMigration.h
@@ -36,6 +36,7 @@ struct ResourceSet {
   std::unique_ptr<MemoryHeap> BackingMemory;
   std::unique_ptr<Buffer> Buffer;
   std::unique_ptr<Texture> Texture;
+  std::unique_ptr<Sampler> Sampler;
   std::unique_ptr<offloadtest::Buffer> Readback;
   std::unique_ptr<offloadtest::Buffer> CounterReadback;
 
@@ -54,6 +55,8 @@ struct ResourceSet {
               std::unique_ptr<offloadtest::Buffer> Readback)
       : BackingMemory(std::move(BackingMemory)), Texture(std::move(Texture)),
         Readback(std::move(Readback)) {}
+  ResourceSet(std::unique_ptr<offloadtest::Sampler> Sampler)
+      : Sampler(std::move(Sampler)) {}
   explicit ResourceSet(AccelerationStructure *AS) : AS(AS) {}
 
   ResourceSet(const ResourceSet &) = delete;
@@ -61,12 +64,14 @@ struct ResourceSet {
 
   ResourceSet(ResourceSet &&A)
       : BackingMemory(std::move(A.BackingMemory)), Buffer(std::move(A.Buffer)),
-        Texture(std::move(A.Texture)), Readback(std::move(A.Readback)),
+        Texture(std::move(A.Texture)), Sampler(std::move(A.Sampler)),
+        Readback(std::move(A.Readback)),
         CounterReadback(std::move(A.CounterReadback)), AS(A.AS) {}
   ResourceSet &operator=(ResourceSet &&A) {
     BackingMemory = std::move(A.BackingMemory);
     Buffer = std::move(A.Buffer);
     Texture = std::move(A.Texture);
+    Sampler = std::move(A.Sampler);
     Readback = std::move(A.Readback);
     CounterReadback = std::move(A.CounterReadback);
     AS = A.AS;

--- a/lib/Support/Pipeline.cpp
+++ b/lib/Support/Pipeline.cpp
@@ -331,8 +331,8 @@ static void setCounters(IO &I, offloadtest::CPUBuffer &B) {
   }
 }
 
-void MappingTraits<offloadtest::Sampler>::mapping(IO &I,
-                                                  offloadtest::Sampler &S) {
+void MappingTraits<offloadtest::YAMLSampler>::mapping(
+    IO &I, offloadtest::YAMLSampler &S) {
   I.mapRequired("Name", S.Name);
   I.mapOptional("Kind", S.Kind);
   I.mapOptional("MinFilter", S.MinFilter);

--- a/test/Feature/Textures/Texture2D.Gather.test.yaml
+++ b/test/Feature/Textures/Texture2D.Gather.test.yaml
@@ -119,6 +119,7 @@ Results:
 
 # Unimplemented: Clang: https://github.com/llvm/llvm-project/issues/101558
 # XFAIL: Metal
+# XFAIL: Clang && DirectX
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl

--- a/test/Feature/Textures/Texture2D.Gather.test.yaml
+++ b/test/Feature/Textures/Texture2D.Gather.test.yaml
@@ -117,8 +117,8 @@ Results:
 ...
 #--- end
 
-# Unimplemented: Clang + DX: https://github.com/llvm/llvm-project/issues/101558
-# XFAIL: DirectX || Metal
+# Unimplemented: Clang: https://github.com/llvm/llvm-project/issues/101558
+# XFAIL: Metal
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl

--- a/test/Feature/Textures/Texture2D.GatherCmp.test.yaml
+++ b/test/Feature/Textures/Texture2D.GatherCmp.test.yaml
@@ -140,6 +140,7 @@ Results:
 
 # Unimplemented: Clang: https://github.com/llvm/llvm-project/issues/101558
 # XFAIL: Metal
+# XFAIL: Clang && DirectX
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl

--- a/test/Feature/Textures/Texture2D.GatherCmp.test.yaml
+++ b/test/Feature/Textures/Texture2D.GatherCmp.test.yaml
@@ -138,8 +138,8 @@ Results:
 ...
 #--- end
 
-# Unimplemented: Clang + DX: https://github.com/llvm/llvm-project/issues/101558
-# XFAIL: DirectX || Metal
+# Unimplemented: Clang: https://github.com/llvm/llvm-project/issues/101558
+# XFAIL: Metal
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl

--- a/test/Feature/Textures/Texture2D.SampleCmp.test.yaml
+++ b/test/Feature/Textures/Texture2D.SampleCmp.test.yaml
@@ -193,7 +193,7 @@ Results:
 #--- end
 
 # Unimplemented: https://github.com/llvm/offload-test-suite/issues/664
-# XFAIL: DirectX || Metal || Vulkan && Darwin
+# XFAIL: Metal || Vulkan && Darwin
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T vs_6_0 -E mainVS -Fo %t-vs.o %t/vertex.hlsl

--- a/test/Feature/Textures/Texture2D.SampleCmp.test.yaml
+++ b/test/Feature/Textures/Texture2D.SampleCmp.test.yaml
@@ -194,6 +194,7 @@ Results:
 
 # Unimplemented: https://github.com/llvm/offload-test-suite/issues/664
 # XFAIL: Metal || Vulkan && Darwin
+# XFAIL: Clang && DirectX
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T vs_6_0 -E mainVS -Fo %t-vs.o %t/vertex.hlsl

--- a/test/Feature/Textures/Texture2D.Sampler.address.test.yaml
+++ b/test/Feature/Textures/Texture2D.Sampler.address.test.yaml
@@ -161,6 +161,7 @@ Results:
 
 # Unimplemented: https://github.com/llvm/offload-test-suite/issues/664
 # XFAIL: Metal
+# XFAIL: Clang && DirectX
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T vs_6_0 -E mainVS -Fo %t-vs.o %t/vertex.hlsl

--- a/test/Feature/Textures/Texture2D.Sampler.address.test.yaml
+++ b/test/Feature/Textures/Texture2D.Sampler.address.test.yaml
@@ -160,7 +160,7 @@ Results:
 #--- end
 
 # Unimplemented: https://github.com/llvm/offload-test-suite/issues/664
-# XFAIL: DirectX || Metal
+# XFAIL: Metal
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T vs_6_0 -E mainVS -Fo %t-vs.o %t/vertex.hlsl

--- a/test/Feature/Textures/Texture2D.Sampler.filter.test.yaml
+++ b/test/Feature/Textures/Texture2D.Sampler.filter.test.yaml
@@ -132,6 +132,7 @@ Results:
 
 # Unimplemented: https://github.com/llvm/offload-test-suite/issues/664
 # XFAIL: Metal
+# XFAIL: Clang && DirectX
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T vs_6_0 -E mainVS -Fo %t-vs.o %t/vertex.hlsl

--- a/test/Feature/Textures/Texture2D.Sampler.filter.test.yaml
+++ b/test/Feature/Textures/Texture2D.Sampler.filter.test.yaml
@@ -131,7 +131,7 @@ Results:
 #--- end
 
 # Unimplemented: https://github.com/llvm/offload-test-suite/issues/664
-# XFAIL: DirectX || Metal
+# XFAIL: Metal
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T vs_6_0 -E mainVS -Fo %t-vs.o %t/vertex.hlsl


### PR DESCRIPTION
Adds support for samplers in DX12.
This change is a lot larger than you would expect from adding samplers.
This is because samplers need to live in a separate DescriptorHeap which cascaded into a couple of issues:
* Building the descriptor tables requires building tables for both sampler and CBV/SRV/UAV descriptors.
* The binding of descriptor tables can no longer be implied based on the DescriptorSets defined in .test file
* A layout must be generated when the root signature is generated based on the bindings
* In case of root signatures defined in the shader, the layout must be extracted from that root signature by deserializing it.

Adding this feature does allow more tests to succeed on DX12.

resolves #664 