### PR TITLE
[SplitBuild] Remove persistent install / dxc-dist directories

### DIFF
--- a/.github/workflows/build-and-test-callable.yaml
+++ b/.github/workflows/build-and-test-callable.yaml
@@ -360,11 +360,6 @@ jobs:
         run: |
             set -euxo pipefail
             cd $GITHUB_WORKSPACE
-            # Self-hosted test runners persist $GITHUB_WORKSPACE between runs.
-            # `tar xf` overlays onto whatever the previous run left behind and
-            # never removes orphan files, so stale tests from an earlier PR
-            # extracted here would survive and be picked up by lit. Wipe the
-            # prefixes first so we run exactly the tests in this PR's tarball.
             rm -rf install dxc-dist
             mkdir -p install dxc-dist
             # Pipe the archive in via stdin and use a relative -C path so

--- a/.github/workflows/build-and-test-callable.yaml
+++ b/.github/workflows/build-and-test-callable.yaml
@@ -266,6 +266,15 @@ jobs:
         shell: bash
         run: |
             set -euxo pipefail
+            # Self-hosted runners persist $GITHUB_WORKSPACE between runs, and
+            # neither `cmake --install` nor `install(DIRECTORY ...)` deletes
+            # files that no longer exist in the source tree -- they only
+            # overlay. Without wiping the prefix first, stale test sources
+            # (e.g. a `.test` from a different PR built earlier on this same
+            # generic builder) linger in install/share/hlsl-test-suite/test/,
+            # get tarred up, shipped to the test runner, and executed by lit.
+            # Start from a clean prefix so the tarball reflects only this PR.
+            rm -rf "$GITHUB_WORKSPACE/install" "$GITHUB_WORKSPACE/dxc-dist"
             cd $GITHUB_WORKSPACE/llvm-project/build
             ninja install-distribution install-offload-tools install-offload-test-suite
             # Stage DXC into a portable bin/+lib/ tree at dxc-dist.
@@ -358,6 +367,12 @@ jobs:
         run: |
             set -euxo pipefail
             cd $GITHUB_WORKSPACE
+            # Self-hosted test runners persist $GITHUB_WORKSPACE between runs.
+            # `tar xf` overlays onto whatever the previous run left behind and
+            # never removes orphan files, so stale tests from an earlier PR
+            # extracted here would survive and be picked up by lit. Wipe the
+            # prefixes first so we run exactly the tests in this PR's tarball.
+            rm -rf install dxc-dist
             mkdir -p install dxc-dist
             # Pipe the archive in via stdin and use a relative -C path so
             # tar doesn't try to parse the Windows drive letter or treat

--- a/.github/workflows/build-and-test-callable.yaml
+++ b/.github/workflows/build-and-test-callable.yaml
@@ -266,14 +266,7 @@ jobs:
         shell: bash
         run: |
             set -euxo pipefail
-            # Self-hosted runners persist $GITHUB_WORKSPACE between runs, and
-            # neither `cmake --install` nor `install(DIRECTORY ...)` deletes
-            # files that no longer exist in the source tree -- they only
-            # overlay. Without wiping the prefix first, stale test sources
-            # (e.g. a `.test` from a different PR built earlier on this same
-            # generic builder) linger in install/share/hlsl-test-suite/test/,
-            # get tarred up, shipped to the test runner, and executed by lit.
-            # Start from a clean prefix so the tarball reflects only this PR.
+            # Prevent stale extraction dirs from previous runs from persisting            
             rm -rf "$GITHUB_WORKSPACE/install" "$GITHUB_WORKSPACE/dxc-dist"
             cd $GITHUB_WORKSPACE/llvm-project/build
             ninja install-distribution install-offload-tools install-offload-test-suite

--- a/docs/offload-distribution.md
+++ b/docs/offload-distribution.md
@@ -131,6 +131,7 @@ Extract both prefixes, then run the configure script with `--dxc-path`
 pointing at the DXC binary in its prefix:
 
 ```
+rm -rf install dxc-dist
 mkdir install dxc-dist
 tar xf llvm-prefix.tar -C install
 tar xf dxc-prefix.tar  -C dxc-dist
@@ -140,6 +141,13 @@ python configure-test-suite.py \
     --suite clang-d3d12 \
     --dxc-path ../../../dxc-dist/bin/dxc[.exe]
 ```
+
+> **Always extract into freshly-cleaned prefixes.** `tar xf` overlays files
+> onto whatever already exists and never removes orphans, so on a reused
+> working directory (e.g. a persistent self-hosted runner) stale `.test`
+> files from a previous build would survive and be run by lit. The `rm -rf`
+> above guarantees lit sees only the tests in this tarball. The build runner
+> likewise wipes its `install`/`dxc-dist` prefixes before installing.
 
 This emits a fully-substituted `run/test/<suite>/lit.site.cfg.py`.
 


### PR DESCRIPTION
An issue is occurring with tests from other branches being run on PRs with branches that don't have those tests defined.
The cause is that the split build feature does not reset its test directories, just overlaying what was extracted instead.
This PR makes sure to delete any existing extraction sites from previous extractions, making sure what will be extracted is strictly from the current branch

Assisted by: Github Copilot
Fixes https://github.com/llvm/offload-test-suite/issues/1338