### PR TITLE
[Intel][Texture2D] Enable SRV to UAV tests

### DIFF
--- a/test/Feature/Textures/Texture2D.SRVToUAV.array.test.yaml
+++ b/test/Feature/Textures/Texture2D.SRVToUAV.array.test.yaml
@@ -90,9 +90,6 @@ DescriptorSets:
 # Unimplemented https://github.com/llvm/llvm-project/issues/133835
 # XFAIL: Clang
 
-# Bug https://github.com/llvm/offload-test-suite/issues/1295
-# XFAIL: DXC && Vulkan && Intel-Gen-Current
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/Textures/Texture2D.SRVToUAV.test.yaml
+++ b/test/Feature/Textures/Texture2D.SRVToUAV.test.yaml
@@ -72,9 +72,6 @@ DescriptorSets:
 # Unimplemented: https://github.com/llvm/llvm-project/issues/175630 (for SPIRV)
 # XFAIL: Clang
 
-# Bug https://github.com/llvm/offload-test-suite/issues/1295
-# XFAIL: DXC && Vulkan && Intel-Gen-Current
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
resolve #1295

These tests started passing on Intel. Remove the XFAILs.