### PR TITLE
Add InterlockedMin tests

### DIFF
--- a/test/Feature/HLSLLib/InterlockedMin.32.test
+++ b/test/Feature/HLSLLib/InterlockedMin.32.test
@@ -39,7 +39,7 @@ groupshared int  MinIntNoOrig;    // 2-arg form, signed
 groupshared uint MinUIntNoOrig;   // 2-arg form, unsigned
 groupshared int  SignedCounter;   // 2-arg form reaching a negative minimum
 
-[numthreads(64, 1, 1)]
+[numthreads(256, 1, 1)]
 void main(uint3 GTID : SV_GroupThreadID) {
   if (GTID.x == 0) {
     MinInt = 1000;
@@ -63,7 +63,7 @@ void main(uint3 GTID : SV_GroupThreadID) {
   uint afterU = MinUInt;
   OutMonoUInt[GTID.x] = (afterU <= origU) ? 1u : 0u;
 
-  // 2-argument form. Proposals span 0..-63, min = -63.
+  // 2-argument form. Proposals span 0..-255, min = -255.
   InterlockedMin(MinIntNoOrig, -(int)GTID.x);
   // 2-argument form, unsigned. Proposals span 100..163, min = 100.
   InterlockedMin(MinUIntNoOrig, GTID.x + 100u);
@@ -75,7 +75,7 @@ void main(uint3 GTID : SV_GroupThreadID) {
   if (GTID.x == 0) {
     OutFinal[0] = MinInt;             // -32
     OutFinal[1] = (int)MinUInt;       // 0
-    OutFinal[2] = MinIntNoOrig;       // -63
+    OutFinal[2] = MinIntNoOrig;       // -255
     OutFinal[3] = (int)MinUIntNoOrig; // 100
     OutFinal[4] = SignedCounter;      // -1000
   }
@@ -91,22 +91,46 @@ Buffers:
   - Name: OutMonoInt
     Format: UInt32
     Stride: 4
-    FillSize: 256
+    FillSize: 1024
   - Name: ExpectedMonoInt
     Format: UInt32
     Stride: 4
     Data: [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ]
   - Name: OutMonoUInt
     Format: UInt32
     Stride: 4
-    FillSize: 256
+    FillSize: 1024
   - Name: ExpectedMonoUInt
     Format: UInt32
     Stride: 4
     Data: [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ]
@@ -117,7 +141,7 @@ Buffers:
   - Name: ExpectedFinal
     Format: Int32
     Stride: 4
-    Data: [ -32, 0, -63, 100, -1000 ]
+    Data: [ -32, 0, -255, 100, -1000 ]
 Results:
   - Result: TestMonoInt
     Rule: BufferExact

--- a/test/Feature/HLSLLib/InterlockedMin.32.test
+++ b/test/Feature/HLSLLib/InterlockedMin.32.test
@@ -1,0 +1,164 @@
+#--- source.hlsl
+
+// This test exercises InterlockedMin against non-resource (groupshared)
+// destinations. A single threadgroup of 64 threads concurrently updates
+// shared counters, so the test actually exercises atomic behavior.
+//
+// Both the 2-argument and 3-argument overloads are covered for int and uint.
+//
+// Atomicity is verified two independent ways:
+//
+//   1. Final value. Each counter's deterministic final value is the minimum
+//      over all participating threads (and the initial value). A non-atomic
+//      read-modify-write can lose the lowest write: a thread reads the
+//      pre-minimum value, then stores its larger proposal *after* the
+//      minimum was written, clobbering it. So the final value can only equal
+//      the true minimum if no atomic min update is lost.
+//
+//   2. Monotonicity (3-argument form). Under correct atomic semantics the
+//      counter is monotonically non-increasing: once a value is written it
+//      can only get smaller. So immediately after this thread's atomic min
+//      returns `orig`, a fresh re-read of the counter must be <= `orig` --
+//      the counter can never climb back above the value this thread observed.
+//      A racy implementation can transiently *raise* the counter (a thread
+//      reads an old value, then writes its larger min back after a smaller
+//      value was already stored); a thread whose `orig` sits below that
+//      bumped-up value would then observe re-read > `orig`. Unlike a
+//      predicate on `orig` alone, this correlates `orig` with a fresh
+//      observation of shared memory and checks every thread, so a correct
+//      implementation yields all-ones.
+
+RWStructuredBuffer<uint> OutMonoInt : register(u0);
+RWStructuredBuffer<uint> OutMonoUInt : register(u1);
+RWStructuredBuffer<int> OutFinal : register(u2);
+
+groupshared int  MinInt;          // 3-arg form, signed
+groupshared uint MinUInt;         // 3-arg form, unsigned
+groupshared int  MinIntNoOrig;    // 2-arg form, signed
+groupshared uint MinUIntNoOrig;   // 2-arg form, unsigned
+groupshared int  SignedCounter;   // 2-arg form reaching a negative minimum
+
+[numthreads(64, 1, 1)]
+void main(uint3 GTID : SV_GroupThreadID) {
+  if (GTID.x == 0) {
+    MinInt = 1000;
+    MinUInt = 1000u;
+    MinIntNoOrig = 1000;
+    MinUIntNoOrig = 1000u;
+    SignedCounter = 1000;
+  }
+  GroupMemoryBarrierWithGroupSync();
+
+  // 3-argument form. Proposals span -32..31, min = -32. The concurrent
+  // re-read must never exceed the observed original (monotonic non-increase).
+  int origI;
+  InterlockedMin(MinInt, (int)GTID.x - 32, origI);
+  int afterI = MinInt;
+  OutMonoInt[GTID.x] = (afterI <= origI) ? 1u : 0u;
+
+  // 3-argument form, unsigned. Proposals span 0..63, min = 0.
+  uint origU;
+  InterlockedMin(MinUInt, GTID.x, origU);
+  uint afterU = MinUInt;
+  OutMonoUInt[GTID.x] = (afterU <= origU) ? 1u : 0u;
+
+  // 2-argument form. Proposals span 0..-63, min = -63.
+  InterlockedMin(MinIntNoOrig, -(int)GTID.x);
+  // 2-argument form, unsigned. Proposals span 100..163, min = 100.
+  InterlockedMin(MinUIntNoOrig, GTID.x + 100u);
+  // 2-argument form reaching a negative minimum. Proposals span -1000..-937.
+  InterlockedMin(SignedCounter, (int)GTID.x - 1000);
+
+  GroupMemoryBarrierWithGroupSync();
+
+  if (GTID.x == 0) {
+    OutFinal[0] = MinInt;             // -32
+    OutFinal[1] = (int)MinUInt;       // 0
+    OutFinal[2] = MinIntNoOrig;       // -63
+    OutFinal[3] = (int)MinUIntNoOrig; // 100
+    OutFinal[4] = SignedCounter;      // -1000
+  }
+}
+
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+Buffers:
+  - Name: OutMonoInt
+    Format: UInt32
+    Stride: 4
+    FillSize: 256
+  - Name: ExpectedMonoInt
+    Format: UInt32
+    Stride: 4
+    Data: [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ]
+  - Name: OutMonoUInt
+    Format: UInt32
+    Stride: 4
+    FillSize: 256
+  - Name: ExpectedMonoUInt
+    Format: UInt32
+    Stride: 4
+    Data: [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ]
+  - Name: OutFinal
+    Format: Int32
+    Stride: 4
+    FillSize: 20
+  - Name: ExpectedFinal
+    Format: Int32
+    Stride: 4
+    Data: [ -32, 0, -63, 100, -1000 ]
+Results:
+  - Result: TestMonoInt
+    Rule: BufferExact
+    Actual: OutMonoInt
+    Expected: ExpectedMonoInt
+  - Result: TestMonoUInt
+    Rule: BufferExact
+    Actual: OutMonoUInt
+    Expected: ExpectedMonoUInt
+  - Result: TestFinal
+    Rule: BufferExact
+    Actual: OutFinal
+    Expected: ExpectedFinal
+DescriptorSets:
+  - Resources:
+    - Name: OutMonoInt
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: OutMonoUInt
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+    - Name: OutFinal
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 2
+        Space: 0
+      VulkanBinding:
+        Binding: 2
+...
+#--- end
+
+# Unimplemented: https://github.com/llvm/llvm-project/issues/99123
+# XFAIL: Clang
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/InterlockedMin.32.test
+++ b/test/Feature/HLSLLib/InterlockedMin.32.test
@@ -6,7 +6,8 @@
 //
 // Both the 2-argument and 3-argument overloads are covered for int and uint.
 //
-// Atomicity is verified two independent ways:
+// Atomicity is verified for these interlockedmin intrinsics
+// two independent ways:
 //
 //   1. Final value. Each counter's deterministic final value is the minimum
 //      over all participating threads (and the initial value). A non-atomic

--- a/test/Feature/HLSLLib/InterlockedMin.int64.test
+++ b/test/Feature/HLSLLib/InterlockedMin.int64.test
@@ -7,28 +7,6 @@
 //
 // Both the 2-argument and 3-argument overloads are covered for int64_t
 // and uint64_t.
-//
-// Atomicity is verified two independent ways:
-//
-//   1. Final value. Each counter's deterministic final value is the minimum
-//      over all participating threads (and the initial value). A non-atomic
-//      read-modify-write can lose the lowest write: a thread reads the
-//      pre-minimum value, then stores its larger proposal *after* the
-//      minimum was written, clobbering it. So the final value can only equal
-//      the true minimum if no atomic min update is lost.
-//
-//   2. Monotonicity (3-argument form). Under correct atomic semantics the
-//      counter is monotonically non-increasing: once a value is written it
-//      can only get smaller. So immediately after this thread's atomic min
-//      returns `orig`, a fresh re-read of the counter must be <= `orig` --
-//      the counter can never climb back above the value this thread observed.
-//      A racy implementation can transiently *raise* the counter (a thread
-//      reads an old value, then writes its larger min back after a smaller
-//      value was already stored); a thread whose `orig` sits below that
-//      bumped-up value would then observe re-read > `orig`. Unlike a
-//      predicate on `orig` alone, this correlates `orig` with a fresh
-//      observation of shared memory and checks every thread, so a correct
-//      implementation yields all-ones.
 
 RWStructuredBuffer<uint> OutMonoInt : register(u0);
 RWStructuredBuffer<uint> OutMonoUInt : register(u1);

--- a/test/Feature/HLSLLib/InterlockedMin.int64.test
+++ b/test/Feature/HLSLLib/InterlockedMin.int64.test
@@ -1,0 +1,177 @@
+#--- source.hlsl
+
+// This test exercises InterlockedMin against non-resource (groupshared)
+// destinations using 64-bit integer types. A single threadgroup of 64
+// threads concurrently updates shared counters, so the test actually
+// exercises atomic behavior.
+//
+// Both the 2-argument and 3-argument overloads are covered for int64_t
+// and uint64_t.
+//
+// Atomicity is verified two independent ways:
+//
+//   1. Final value. Each counter's deterministic final value is the minimum
+//      over all participating threads (and the initial value). A non-atomic
+//      read-modify-write can lose the lowest write: a thread reads the
+//      pre-minimum value, then stores its larger proposal *after* the
+//      minimum was written, clobbering it. So the final value can only equal
+//      the true minimum if no atomic min update is lost.
+//
+//   2. Monotonicity (3-argument form). Under correct atomic semantics the
+//      counter is monotonically non-increasing: once a value is written it
+//      can only get smaller. So immediately after this thread's atomic min
+//      returns `orig`, a fresh re-read of the counter must be <= `orig` --
+//      the counter can never climb back above the value this thread observed.
+//      A racy implementation can transiently *raise* the counter (a thread
+//      reads an old value, then writes its larger min back after a smaller
+//      value was already stored); a thread whose `orig` sits below that
+//      bumped-up value would then observe re-read > `orig`. Unlike a
+//      predicate on `orig` alone, this correlates `orig` with a fresh
+//      observation of shared memory and checks every thread, so a correct
+//      implementation yields all-ones.
+
+RWStructuredBuffer<uint> OutMonoInt : register(u0);
+RWStructuredBuffer<uint> OutMonoUInt : register(u1);
+RWStructuredBuffer<int64_t> OutFinal : register(u2);
+
+groupshared int64_t  MinInt;          // 3-arg form, signed
+groupshared uint64_t MinUInt;         // 3-arg form, unsigned
+groupshared int64_t  MinIntNoOrig;    // 2-arg form, signed
+groupshared uint64_t MinUIntNoOrig;   // 2-arg form, unsigned
+groupshared int64_t  SignedCounter;   // 2-arg form reaching a negative minimum
+groupshared uint64_t LargeCounter;    // 2-arg form exercising the upper 32 bits
+
+[numthreads(64, 1, 1)]
+void main(uint3 GTID : SV_GroupThreadID) {
+  if (GTID.x == 0) {
+    MinInt = 1000;
+    MinUInt = 1000;
+    MinIntNoOrig = 1000;
+    MinUIntNoOrig = 1000;
+    SignedCounter = 1000;
+    LargeCounter = 0x10000000000ull; // 2^40
+  }
+  GroupMemoryBarrierWithGroupSync();
+
+  // 3-argument form. Proposals span -32..31, min = -32. The concurrent
+  // re-read must never exceed the observed original (monotonic non-increase).
+  int64_t origI;
+  InterlockedMin(MinInt, (int64_t)GTID.x - 32, origI);
+  int64_t afterI = MinInt;
+  OutMonoInt[GTID.x] = (afterI <= origI) ? 1u : 0u;
+
+  // 3-argument form, unsigned. Proposals span 0..63, min = 0.
+  uint64_t origU;
+  InterlockedMin(MinUInt, (uint64_t)GTID.x, origU);
+  uint64_t afterU = MinUInt;
+  OutMonoUInt[GTID.x] = (afterU <= origU) ? 1u : 0u;
+
+  // 2-argument form. Proposals span 0..-63, min = -63.
+  InterlockedMin(MinIntNoOrig, -(int64_t)GTID.x);
+  // 2-argument form, unsigned. Proposals span 100..163, min = 100.
+  InterlockedMin(MinUIntNoOrig, (uint64_t)GTID.x + 100);
+  // 2-argument form reaching a negative minimum. Proposals span -1000..-937.
+  InterlockedMin(SignedCounter, (int64_t)GTID.x - 1000);
+  // 2-argument form with a value that exercises the upper 32 bits, min = 2^32.
+  InterlockedMin(LargeCounter, 0x100000000ull + (uint64_t)GTID.x);
+
+  GroupMemoryBarrierWithGroupSync();
+
+  if (GTID.x == 0) {
+    OutFinal[0] = MinInt;                 // -32
+    OutFinal[1] = (int64_t)MinUInt;       // 0
+    OutFinal[2] = MinIntNoOrig;           // -63
+    OutFinal[3] = (int64_t)MinUIntNoOrig; // 100
+    OutFinal[4] = SignedCounter;          // -1000
+    OutFinal[5] = (int64_t)LargeCounter;  // 2^32 = 4294967296
+  }
+}
+
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+Buffers:
+  - Name: OutMonoInt
+    Format: UInt32
+    Stride: 4
+    FillSize: 256
+  - Name: ExpectedMonoInt
+    Format: UInt32
+    Stride: 4
+    Data: [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ]
+  - Name: OutMonoUInt
+    Format: UInt32
+    Stride: 4
+    FillSize: 256
+  - Name: ExpectedMonoUInt
+    Format: UInt32
+    Stride: 4
+    Data: [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ]
+  - Name: OutFinal
+    Format: Int64
+    Stride: 8
+    FillSize: 48
+  - Name: ExpectedFinal
+    Format: Int64
+    Stride: 8
+    Data: [ -32, 0, -63, 100, -1000, 4294967296 ]
+
+Results:
+  - Result: TestMonoInt
+    Rule: BufferExact
+    Actual: OutMonoInt
+    Expected: ExpectedMonoInt
+  - Result: TestMonoUInt
+    Rule: BufferExact
+    Actual: OutMonoUInt
+    Expected: ExpectedMonoUInt
+  - Result: TestFinal
+    Rule: BufferExact
+    Actual: OutFinal
+    Expected: ExpectedFinal
+DescriptorSets:
+  - Resources:
+    - Name: OutMonoInt
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: OutMonoUInt
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+    - Name: OutFinal
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 2
+        Space: 0
+      VulkanBinding:
+        Binding: 2
+...
+#--- end
+
+# REQUIRES: Int64 && Int64GroupSharedAtomics && SM_6_6
+
+# Unimplemented: https://github.com/llvm/llvm-project/issues/99123
+# XFAIL: Clang
+
+# Bug: https://github.com/llvm/offload-test-suite/issues/1164
+# XFAIL: DXC && Metal
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -HV 202x -T cs_6_6 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/InterlockedMin.int64.test
+++ b/test/Feature/HLSLLib/InterlockedMin.int64.test
@@ -19,7 +19,7 @@ groupshared uint64_t MinUIntNoOrig;   // 2-arg form, unsigned
 groupshared int64_t  SignedCounter;   // 2-arg form reaching a negative minimum
 groupshared uint64_t LargeCounter;    // 2-arg form exercising the upper 32 bits
 
-[numthreads(64, 1, 1)]
+[numthreads(256, 1, 1)]
 void main(uint3 GTID : SV_GroupThreadID) {
   if (GTID.x == 0) {
     MinInt = 1000;
@@ -44,7 +44,7 @@ void main(uint3 GTID : SV_GroupThreadID) {
   uint64_t afterU = MinUInt;
   OutMonoUInt[GTID.x] = (afterU <= origU) ? 1u : 0u;
 
-  // 2-argument form. Proposals span 0..-63, min = -63.
+  // 2-argument form. Proposals span 0..-255, min = -255.
   InterlockedMin(MinIntNoOrig, -(int64_t)GTID.x);
   // 2-argument form, unsigned. Proposals span 100..163, min = 100.
   InterlockedMin(MinUIntNoOrig, (uint64_t)GTID.x + 100);
@@ -58,7 +58,7 @@ void main(uint3 GTID : SV_GroupThreadID) {
   if (GTID.x == 0) {
     OutFinal[0] = MinInt;                 // -32
     OutFinal[1] = (int64_t)MinUInt;       // 0
-    OutFinal[2] = MinIntNoOrig;           // -63
+    OutFinal[2] = MinIntNoOrig;           // -255
     OutFinal[3] = (int64_t)MinUIntNoOrig; // 100
     OutFinal[4] = SignedCounter;          // -1000
     OutFinal[5] = (int64_t)LargeCounter;  // 2^32 = 4294967296
@@ -75,22 +75,46 @@ Buffers:
   - Name: OutMonoInt
     Format: UInt32
     Stride: 4
-    FillSize: 256
+    FillSize: 1024
   - Name: ExpectedMonoInt
     Format: UInt32
     Stride: 4
     Data: [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ]
   - Name: OutMonoUInt
     Format: UInt32
     Stride: 4
-    FillSize: 256
+    FillSize: 1024
   - Name: ExpectedMonoUInt
     Format: UInt32
     Stride: 4
     Data: [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ]
@@ -101,7 +125,7 @@ Buffers:
   - Name: ExpectedFinal
     Format: Int64
     Stride: 8
-    Data: [ -32, 0, -63, 100, -1000, 4294967296 ]
+    Data: [ -32, 0, -255, 100, -1000, 4294967296 ]
 
 Results:
   - Result: TestMonoInt

--- a/test/Feature/HLSLLib/InterlockedMin.resources.32.test
+++ b/test/Feature/HLSLLib/InterlockedMin.resources.32.test
@@ -237,6 +237,9 @@ DescriptorSets:
 # Unimplemented: https://github.com/llvm/llvm-project/issues/99123
 # XFAIL: Clang
 
+# Bug: https://github.com/llvm/offload-test-suite/issues/1164
+# XFAIL: Metal && DXC
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/InterlockedMin.resources.32.test
+++ b/test/Feature/HLSLLib/InterlockedMin.resources.32.test
@@ -1,0 +1,242 @@
+#--- source.hlsl
+
+// This test exercises InterlockedMin against the full set of HLSL-legal
+// non-groupshared (resource) destination types:
+//
+//   * RWStructuredBuffer<uint>[i]          (free function, 2-arg)
+//   * RWStructuredBuffer<int>[i]           (free function, 3-arg, signed)
+//   * RWBuffer<uint>[i]                    (free function on typed UAV)
+//   * RWTexture2D<uint>[coord]             (free function on typed UAV)
+//   * RWByteAddressBuffer::InterlockedMin  (method, 2-arg and 3-arg)
+//
+// For each destination, 32 threads of a single threadgroup atomically take
+// the minimum of their per-thread proposal and a single accumulator slot.
+//
+// Atomicity is verified two independent ways:
+//
+//   1. Final value. Each accumulator's deterministic final value is the
+//      minimum over all participating threads (and the initial value). A
+//      non-atomic read-modify-write can lose the lowest write: a thread
+//      reads the pre-minimum value, then stores its larger proposal *after*
+//      the minimum was written, clobbering it. So the final value can only
+//      equal the true minimum if no atomic min update is lost.
+//
+//   2. Monotonicity (3-argument form). Under correct atomic semantics the
+//      accumulator is monotonically non-increasing: once a value is written
+//      it can only get smaller. So immediately after this thread's atomic
+//      min returns `orig`, a fresh re-read of the accumulator must be <=
+//      `orig` -- it can never climb back above the value this thread
+//      observed. A racy implementation can transiently *raise* the value (a
+//      thread reads an old value, then writes its larger min back after a
+//      smaller value was already stored); a thread whose `orig` sits below
+//      that bumped-up value would then observe re-read > `orig`. Unlike a
+//      predicate on `orig` alone, this correlates `orig` with a fresh
+//      observation of memory and checks every thread, so a correct
+//      implementation yields all-ones.
+
+RWStructuredBuffer<uint> SBufU : register(u0);
+RWStructuredBuffer<int>  SBufI : register(u1);
+RWBuffer<uint>           TBufU : register(u2);
+RWTexture2D<uint>        Tex2D : register(u3);
+RWByteAddressBuffer      BABuf : register(u4);
+
+RWStructuredBuffer<uint> OutMonoSBufI : register(u5);
+RWStructuredBuffer<uint> OutMonoBABuf : register(u6);
+
+[numthreads(32, 1, 1)]
+void main(uint3 GTID : SV_GroupThreadID) {
+  if (GTID.x == 0) {
+    SBufU[0] = 0xFFFFFFFFu;
+    SBufI[0] = 1000;
+    TBufU[0] = 0xFFFFFFFFu;
+    Tex2D[uint2(0, 0)] = 0xFFFFFFFFu;
+    BABuf.Store(0, 0xFFFFFFFFu); // accumulator for 2-arg method form
+    BABuf.Store(4, 1000u);       // accumulator for 3-arg method form
+  }
+  DeviceMemoryBarrierWithGroupSync();
+
+  // RWStructuredBuffer<uint>: 2-argument free function. Proposals 0..31,
+  // min = 0.
+  InterlockedMin(SBufU[0], GTID.x);
+
+  // RWStructuredBuffer<int>: 3-argument free function (signed). Proposals
+  // -31..0, min = -31. The concurrent re-read must never exceed the observed
+  // original (monotonic non-increase).
+  int OrigI;
+  InterlockedMin(SBufI[0], (int)GTID.x - 31, OrigI);
+  int AfterI = SBufI[0];
+  OutMonoSBufI[GTID.x] = (AfterI <= OrigI) ? 1u : 0u;
+
+  // RWBuffer<uint> (typed buffer UAV): 2-argument free function.
+  InterlockedMin(TBufU[0], GTID.x);
+
+  // RWTexture2D<uint>: 2-argument free function.
+  InterlockedMin(Tex2D[uint2(0, 0)], GTID.x);
+
+  // RWByteAddressBuffer method: 2-argument form.
+  BABuf.InterlockedMin(0, GTID.x);
+
+  // RWByteAddressBuffer method: 3-argument form.
+  uint OrigBA;
+  BABuf.InterlockedMin(4, GTID.x, OrigBA);
+  uint AfterBA = BABuf.Load(4);
+  OutMonoBABuf[GTID.x] = (AfterBA <= OrigBA) ? 1u : 0u;
+}
+
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+Buffers:
+  - Name: SBufU
+    Format: UInt32
+    Stride: 4
+    FillSize: 4
+  - Name: ExpectedSBufU
+    Format: UInt32
+    Stride: 4
+    Data: [ 0 ]
+  - Name: SBufI
+    Format: Int32
+    Stride: 4
+    FillSize: 4
+  - Name: ExpectedSBufI
+    Format: Int32
+    Stride: 4
+    Data: [ -31 ]
+  - Name: TBufU
+    Format: UInt32
+    Channels: 1
+    FillSize: 4
+  - Name: ExpectedTBufU
+    Format: UInt32
+    Channels: 1
+    Data: [ 0 ]
+  - Name: Tex2D
+    Format: UInt32
+    Channels: 1
+    FillSize: 4
+    OutputProps:
+      Height: 1
+      Width: 1
+      Depth: 1
+  - Name: ExpectedTex2D
+    Format: UInt32
+    Channels: 1
+    Data: [ 0 ]
+    OutputProps:
+      Height: 1
+      Width: 1
+      Depth: 1
+  - Name: BABuf
+    Format: UInt32
+    Stride: 4
+    FillSize: 8
+  - Name: ExpectedBABuf
+    Format: UInt32
+    Stride: 4
+    Data: [ 0, 0 ]
+  - Name: OutMonoSBufI
+    Format: UInt32
+    Stride: 4
+    FillSize: 128
+  - Name: ExpectedMono
+    Format: UInt32
+    Stride: 4
+    Data: [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ]
+  - Name: OutMonoBABuf
+    Format: UInt32
+    Stride: 4
+    FillSize: 128
+Results:
+  - Result: TestSBufU
+    Rule: BufferExact
+    Actual: SBufU
+    Expected: ExpectedSBufU
+  - Result: TestSBufI
+    Rule: BufferExact
+    Actual: SBufI
+    Expected: ExpectedSBufI
+  - Result: TestTBufU
+    Rule: BufferExact
+    Actual: TBufU
+    Expected: ExpectedTBufU
+  - Result: TestTex2D
+    Rule: BufferExact
+    Actual: Tex2D
+    Expected: ExpectedTex2D
+  - Result: TestBABuf
+    Rule: BufferExact
+    Actual: BABuf
+    Expected: ExpectedBABuf
+  - Result: TestMonoSBufI
+    Rule: BufferExact
+    Actual: OutMonoSBufI
+    Expected: ExpectedMono
+  - Result: TestMonoBABuf
+    Rule: BufferExact
+    Actual: OutMonoBABuf
+    Expected: ExpectedMono
+DescriptorSets:
+  - Resources:
+    - Name: SBufU
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: SBufI
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+    - Name: TBufU
+      Kind: RWBuffer
+      DirectXBinding:
+        Register: 2
+        Space: 0
+      VulkanBinding:
+        Binding: 2
+    - Name: Tex2D
+      Kind: RWTexture2D
+      DirectXBinding:
+        Register: 3
+        Space: 0
+      VulkanBinding:
+        Binding: 3
+    - Name: BABuf
+      Kind: RWByteAddressBuffer
+      DirectXBinding:
+        Register: 4
+        Space: 0
+      VulkanBinding:
+        Binding: 4
+    - Name: OutMonoSBufI
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 5
+        Space: 0
+      VulkanBinding:
+        Binding: 5
+    - Name: OutMonoBABuf
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 6
+        Space: 0
+      VulkanBinding:
+        Binding: 6
+...
+#--- end
+
+# Unimplemented: https://github.com/llvm/llvm-project/issues/99123
+# XFAIL: Clang
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/InterlockedMin.resources.32.test
+++ b/test/Feature/HLSLLib/InterlockedMin.resources.32.test
@@ -9,7 +9,7 @@
 //   * RWTexture2D<uint>[coord]             (free function on typed UAV)
 //   * RWByteAddressBuffer::InterlockedMin  (method, 2-arg and 3-arg)
 //
-// For each destination, 32 threads of a single threadgroup atomically take
+// For each destination, 256 threads of a single threadgroup atomically take
 // the minimum of their per-thread proposal and a single accumulator slot.
 
 RWStructuredBuffer<uint> SBufU : register(u0);
@@ -21,7 +21,7 @@ RWByteAddressBuffer      BABuf : register(u4);
 RWStructuredBuffer<uint> OutMonoSBufI : register(u5);
 RWStructuredBuffer<uint> OutMonoBABuf : register(u6);
 
-[numthreads(32, 1, 1)]
+[numthreads(256, 1, 1)]
 void main(uint3 GTID : SV_GroupThreadID) {
   if (GTID.x == 0) {
     SBufU[0] = 0xFFFFFFFFu;
@@ -33,12 +33,12 @@ void main(uint3 GTID : SV_GroupThreadID) {
   }
   DeviceMemoryBarrierWithGroupSync();
 
-  // RWStructuredBuffer<uint>: 2-argument free function. Proposals 0..31,
+  // RWStructuredBuffer<uint>: 2-argument free function. Proposals 0..255,
   // min = 0.
   InterlockedMin(SBufU[0], GTID.x);
 
   // RWStructuredBuffer<int>: 3-argument free function (signed). Proposals
-  // -31..0, min = -31. The concurrent re-read must never exceed the observed
+  // -31..224, min = -31. The concurrent re-read must never exceed the observed
   // original (monotonic non-increase).
   int OrigI;
   InterlockedMin(SBufI[0], (int)GTID.x - 31, OrigI);
@@ -119,16 +119,30 @@ Buffers:
   - Name: OutMonoSBufI
     Format: UInt32
     Stride: 4
-    FillSize: 128
+    FillSize: 1024
   - Name: ExpectedMono
     Format: UInt32
     Stride: 4
     Data: [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ]
   - Name: OutMonoBABuf
     Format: UInt32
     Stride: 4
-    FillSize: 128
+    FillSize: 1024
 Results:
   - Result: TestSBufU
     Rule: BufferExact

--- a/test/Feature/HLSLLib/InterlockedMin.resources.32.test
+++ b/test/Feature/HLSLLib/InterlockedMin.resources.32.test
@@ -11,28 +11,6 @@
 //
 // For each destination, 32 threads of a single threadgroup atomically take
 // the minimum of their per-thread proposal and a single accumulator slot.
-//
-// Atomicity is verified two independent ways:
-//
-//   1. Final value. Each accumulator's deterministic final value is the
-//      minimum over all participating threads (and the initial value). A
-//      non-atomic read-modify-write can lose the lowest write: a thread
-//      reads the pre-minimum value, then stores its larger proposal *after*
-//      the minimum was written, clobbering it. So the final value can only
-//      equal the true minimum if no atomic min update is lost.
-//
-//   2. Monotonicity (3-argument form). Under correct atomic semantics the
-//      accumulator is monotonically non-increasing: once a value is written
-//      it can only get smaller. So immediately after this thread's atomic
-//      min returns `orig`, a fresh re-read of the accumulator must be <=
-//      `orig` -- it can never climb back above the value this thread
-//      observed. A racy implementation can transiently *raise* the value (a
-//      thread reads an old value, then writes its larger min back after a
-//      smaller value was already stored); a thread whose `orig` sits below
-//      that bumped-up value would then observe re-read > `orig`. Unlike a
-//      predicate on `orig` alone, this correlates `orig` with a fresh
-//      observation of memory and checks every thread, so a correct
-//      implementation yields all-ones.
 
 RWStructuredBuffer<uint> SBufU : register(u0);
 RWStructuredBuffer<int>  SBufI : register(u1);

--- a/test/Feature/HLSLLib/InterlockedMin.resources.int64.test
+++ b/test/Feature/HLSLLib/InterlockedMin.resources.int64.test
@@ -1,0 +1,198 @@
+#--- source.hlsl
+
+// This test exercises InterlockedMin against the HLSL-legal 64-bit
+// non-groupshared (resource) destination types. 64-bit atomics on UAVs
+// were introduced in Shader Model 6.6.
+//
+//   * RWStructuredBuffer<uint64_t>[i]        (free function, 2-arg)
+//   * RWStructuredBuffer<int64_t>[i]         (free function, 3-arg, signed)
+//   * RWByteAddressBuffer::InterlockedMin64  (method, 2-arg and 3-arg)
+//
+// 64-bit atomics on typed RWBuffer / RWTexture require the optional
+// "AtomicInt64OnTypedResource" capability and are intentionally not
+// covered here, to keep this test portable across implementations.
+//
+// For each destination, 64 threads of a single threadgroup atomically take
+// the minimum of their per-thread proposal and a single accumulator slot.
+//
+// Atomicity is verified two independent ways:
+//
+//   1. Final value. Each accumulator's deterministic final value is the
+//      minimum over all participating threads (and the initial value). A
+//      non-atomic read-modify-write can lose the lowest write: a thread
+//      reads the pre-minimum value, then stores its larger proposal *after*
+//      the minimum was written, clobbering it. So the final value can only
+//      equal the true minimum if no atomic min update is lost.
+//
+//   2. Monotonicity (3-argument form). Under correct atomic semantics the
+//      accumulator is monotonically non-increasing: once a value is written
+//      it can only get smaller. So immediately after this thread's atomic
+//      min returns `orig`, a fresh re-read of the accumulator must be <=
+//      `orig` -- it can never climb back above the value this thread
+//      observed. A racy implementation can transiently *raise* the value (a
+//      thread reads an old value, then writes its larger min back after a
+//      smaller value was already stored); a thread whose `orig` sits below
+//      that bumped-up value would then observe re-read > `orig`. Unlike a
+//      predicate on `orig` alone, this correlates `orig` with a fresh
+//      observation of memory and checks every thread, so a correct
+//      implementation yields all-ones.
+
+RWStructuredBuffer<uint64_t> SBufU : register(u0);
+RWStructuredBuffer<int64_t>  SBufI : register(u1);
+RWByteAddressBuffer          BABuf : register(u2);
+
+RWStructuredBuffer<uint> OutMonoSBufI : register(u3);
+RWStructuredBuffer<uint> OutMonoBABuf : register(u4);
+
+[numthreads(64, 1, 1)]
+void main(uint3 GTID : SV_GroupThreadID) {
+  if (GTID.x == 0) {
+    SBufU[0] = 0xFFFFFFFFFFFFFFFFull;
+    SBufI[0] = 1000;
+    BABuf.Store<uint64_t>(0, 0xFFFFFFFFFFFFFFFFull); // accumulator for 2-arg method form
+    BABuf.Store<uint64_t>(8, 1000);                  // accumulator for 3-arg method form
+  }
+  DeviceMemoryBarrierWithGroupSync();
+
+  // RWStructuredBuffer<uint64_t>: 2-argument free function. Proposals 0..63,
+  // min = 0.
+  InterlockedMin(SBufU[0], (uint64_t)GTID.x);
+
+  // RWStructuredBuffer<int64_t>: 3-argument free function (signed).
+  // Proposals -63..0, min = -63. The concurrent re-read must never exceed
+  // the observed original (monotonic non-increase).
+  int64_t OrigI;
+  InterlockedMin(SBufI[0], (int64_t)GTID.x - 63, OrigI);
+  int64_t AfterI = SBufI[0];
+  OutMonoSBufI[GTID.x] = (AfterI <= OrigI) ? 1u : 0u;
+
+  // RWByteAddressBuffer 64-bit method: 2-argument form.
+  BABuf.InterlockedMin64(0, (uint64_t)GTID.x);
+
+  // RWByteAddressBuffer 64-bit method: 3-argument form.
+  uint64_t OrigBA;
+  BABuf.InterlockedMin64(8, (uint64_t)GTID.x, OrigBA);
+  uint64_t AfterBA = BABuf.Load<uint64_t>(8);
+  OutMonoBABuf[GTID.x] = (AfterBA <= OrigBA) ? 1u : 0u;
+}
+
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+Buffers:
+  - Name: SBufU
+    Format: UInt64
+    Stride: 8
+    FillSize: 8
+  - Name: ExpectedSBufU
+    Format: UInt64
+    Stride: 8
+    Data: [ 0 ]
+  - Name: SBufI
+    Format: Int64
+    Stride: 8
+    FillSize: 8
+  - Name: ExpectedSBufI
+    Format: Int64
+    Stride: 8
+    Data: [ -63 ]
+  - Name: BABuf
+    Format: UInt64
+    Stride: 8
+    FillSize: 16
+  - Name: ExpectedBABuf
+    Format: UInt64
+    Stride: 8
+    Data: [ 0, 0 ]
+  - Name: OutMonoSBufI
+    Format: UInt32
+    Stride: 4
+    FillSize: 256
+  - Name: ExpectedMono
+    Format: UInt32
+    Stride: 4
+    Data: [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ]
+  - Name: OutMonoBABuf
+    Format: UInt32
+    Stride: 4
+    FillSize: 256
+Results:
+  - Result: TestSBufU
+    Rule: BufferExact
+    Actual: SBufU
+    Expected: ExpectedSBufU
+  - Result: TestSBufI
+    Rule: BufferExact
+    Actual: SBufI
+    Expected: ExpectedSBufI
+  - Result: TestBABuf
+    Rule: BufferExact
+    Actual: BABuf
+    Expected: ExpectedBABuf
+  - Result: TestMonoSBufI
+    Rule: BufferExact
+    Actual: OutMonoSBufI
+    Expected: ExpectedMono
+  - Result: TestMonoBABuf
+    Rule: BufferExact
+    Actual: OutMonoBABuf
+    Expected: ExpectedMono
+DescriptorSets:
+  - Resources:
+    - Name: SBufU
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: SBufI
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+    - Name: BABuf
+      Kind: RWByteAddressBuffer
+      DirectXBinding:
+        Register: 2
+        Space: 0
+      VulkanBinding:
+        Binding: 2
+    - Name: OutMonoSBufI
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 3
+        Space: 0
+      VulkanBinding:
+        Binding: 3
+    - Name: OutMonoBABuf
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 4
+        Space: 0
+      VulkanBinding:
+        Binding: 4
+...
+#--- end
+
+# Unimplemented: https://github.com/llvm/llvm-project/issues/99123
+# XFAIL: Clang
+
+# Bug: https://github.com/llvm/offload-test-suite/issues/1164
+# XFAIL: Metal && DXC
+
+# Unimplemented: https://github.com/microsoft/DirectXShaderCompiler/issues/8451
+# XFAIL: Vulkan && DXC
+
+# REQUIRES: Int64 && SM_6_6 && (!Vulkan || VulkanInt64BufferAtomics)
+# RUN: split-file %s %t
+# RUN: %dxc_target -HV 202x -T cs_6_6 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/InterlockedMin.resources.int64.test
+++ b/test/Feature/HLSLLib/InterlockedMin.resources.int64.test
@@ -14,28 +14,6 @@
 //
 // For each destination, 64 threads of a single threadgroup atomically take
 // the minimum of their per-thread proposal and a single accumulator slot.
-//
-// Atomicity is verified two independent ways:
-//
-//   1. Final value. Each accumulator's deterministic final value is the
-//      minimum over all participating threads (and the initial value). A
-//      non-atomic read-modify-write can lose the lowest write: a thread
-//      reads the pre-minimum value, then stores its larger proposal *after*
-//      the minimum was written, clobbering it. So the final value can only
-//      equal the true minimum if no atomic min update is lost.
-//
-//   2. Monotonicity (3-argument form). Under correct atomic semantics the
-//      accumulator is monotonically non-increasing: once a value is written
-//      it can only get smaller. So immediately after this thread's atomic
-//      min returns `orig`, a fresh re-read of the accumulator must be <=
-//      `orig` -- it can never climb back above the value this thread
-//      observed. A racy implementation can transiently *raise* the value (a
-//      thread reads an old value, then writes its larger min back after a
-//      smaller value was already stored); a thread whose `orig` sits below
-//      that bumped-up value would then observe re-read > `orig`. Unlike a
-//      predicate on `orig` alone, this correlates `orig` with a fresh
-//      observation of memory and checks every thread, so a correct
-//      implementation yields all-ones.
 
 RWStructuredBuffer<uint64_t> SBufU : register(u0);
 RWStructuredBuffer<int64_t>  SBufI : register(u1);

--- a/test/Feature/HLSLLib/InterlockedMin.resources.int64.test
+++ b/test/Feature/HLSLLib/InterlockedMin.resources.int64.test
@@ -12,7 +12,7 @@
 // "AtomicInt64OnTypedResource" capability and are intentionally not
 // covered here, to keep this test portable across implementations.
 //
-// For each destination, 64 threads of a single threadgroup atomically take
+// For each destination, 256 threads of a single threadgroup atomically take
 // the minimum of their per-thread proposal and a single accumulator slot.
 
 RWStructuredBuffer<uint64_t> SBufU : register(u0);
@@ -22,7 +22,7 @@ RWByteAddressBuffer          BABuf : register(u2);
 RWStructuredBuffer<uint> OutMonoSBufI : register(u3);
 RWStructuredBuffer<uint> OutMonoBABuf : register(u4);
 
-[numthreads(64, 1, 1)]
+[numthreads(256, 1, 1)]
 void main(uint3 GTID : SV_GroupThreadID) {
   if (GTID.x == 0) {
     SBufU[0] = 0xFFFFFFFFFFFFFFFFull;
@@ -32,12 +32,12 @@ void main(uint3 GTID : SV_GroupThreadID) {
   }
   DeviceMemoryBarrierWithGroupSync();
 
-  // RWStructuredBuffer<uint64_t>: 2-argument free function. Proposals 0..63,
+  // RWStructuredBuffer<uint64_t>: 2-argument free function. Proposals 0..255,
   // min = 0.
   InterlockedMin(SBufU[0], (uint64_t)GTID.x);
 
   // RWStructuredBuffer<int64_t>: 3-argument free function (signed).
-  // Proposals -63..0, min = -63. The concurrent re-read must never exceed
+  // Proposals -63..192, min = -63. The concurrent re-read must never exceed
   // the observed original (monotonic non-increase).
   int64_t OrigI;
   InterlockedMin(SBufI[0], (int64_t)GTID.x - 63, OrigI);
@@ -88,18 +88,30 @@ Buffers:
   - Name: OutMonoSBufI
     Format: UInt32
     Stride: 4
-    FillSize: 256
+    FillSize: 1024
   - Name: ExpectedMono
     Format: UInt32
     Stride: 4
     Data: [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ]
   - Name: OutMonoBABuf
     Format: UInt32
     Stride: 4
-    FillSize: 256
+    FillSize: 1024
 Results:
   - Result: TestSBufU
     Rule: BufferExact

--- a/test/Feature/HLSLLib/InterlockedMin.resources.typed.int64.test
+++ b/test/Feature/HLSLLib/InterlockedMin.resources.typed.int64.test
@@ -1,0 +1,151 @@
+#--- source.hlsl
+
+// This test exercises InterlockedMin on 64-bit typed RWBuffer resources.
+// 64-bit atomics on typed UAVs are an optional Shader Model 6.6 capability:
+//
+//   * DirectX:  cap AtomicInt64OnTypedResourceSupported
+//   * Vulkan:   shaderImageInt64Atomics, from the (non-core) extension
+//               VK_EXT_shader_image_atomic_int64. RWBuffer<T> in HLSL maps
+//               to a SPIR-V image (not an SSBO), so RWBuffer atomics on
+//               Vulkan require this image-atomics extension, not
+//               shaderBufferInt64Atomics. The same Vulkan feature also
+//               covers RWTexture<int64_t> typed-image atomics; this test
+//               only exercises RWBuffer.
+//
+// Both are surfaced to lit as `Int64TypedResourceAtomics`.
+//
+//   * RWBuffer<uint64_t>[i]  (free function, 2-arg)
+//   * RWBuffer<int64_t>[i]   (free function, 3-arg, signed)
+//
+// 64 threads of a single threadgroup atomically take the minimum of their
+// per-thread proposal and a single accumulator slot.
+//
+// Atomicity is verified two independent ways:
+//
+//   1. Final value. Each accumulator's deterministic final value is the
+//      minimum over all participating threads (and the initial value). A
+//      non-atomic read-modify-write can lose the lowest write: a thread
+//      reads the pre-minimum value, then stores its larger proposal *after*
+//      the minimum was written, clobbering it. So the final value can only
+//      equal the true minimum if no atomic min update is lost.
+//
+//   2. Monotonicity (3-argument form). Under correct atomic semantics the
+//      accumulator is monotonically non-increasing: once a value is written
+//      it can only get smaller. So immediately after this thread's atomic
+//      min returns `orig`, a fresh re-read of the accumulator must be <=
+//      `orig` -- it can never climb back above the value this thread
+//      observed. A racy implementation can transiently *raise* the value (a
+//      thread reads an old value, then writes its larger min back after a
+//      smaller value was already stored); a thread whose `orig` sits below
+//      that bumped-up value would then observe re-read > `orig`. Unlike a
+//      predicate on `orig` alone, this correlates `orig` with a fresh
+//      observation of memory and checks every thread, so a correct
+//      implementation yields all-ones.
+
+RWBuffer<uint64_t> TBufU : register(u0);
+RWBuffer<int64_t>  TBufI : register(u1);
+
+RWStructuredBuffer<uint> OutMonoTBufI : register(u2);
+
+[numthreads(64, 1, 1)]
+void main(uint3 GTID : SV_GroupThreadID) {
+  if (GTID.x == 0) {
+    TBufU[0] = 0xFFFFFFFFFFFFFFFFull;
+    TBufI[0] = 1000;
+  }
+  DeviceMemoryBarrierWithGroupSync();
+
+  // RWBuffer<uint64_t>: 2-argument free function. Proposals 0..63, min = 0.
+  InterlockedMin(TBufU[0], (uint64_t)GTID.x);
+
+  // RWBuffer<int64_t>: 3-argument free function (signed). Proposals -63..0,
+  // min = -63. The concurrent re-read must never exceed the observed original
+  // (monotonic non-increase).
+  int64_t OrigI;
+  InterlockedMin(TBufI[0], (int64_t)GTID.x - 63, OrigI);
+  int64_t AfterI = TBufI[0];
+  OutMonoTBufI[GTID.x] = (AfterI <= OrigI) ? 1u : 0u;
+}
+
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+Buffers:
+  - Name: TBufU
+    Format: UInt64
+    Channels: 1
+    FillSize: 8
+    FillValue: 137  # trash non-zero initialization data
+  - Name: ExpectedTBufU
+    Format: UInt64
+    Channels: 1
+    Data: [ 0 ]
+  - Name: TBufI
+    Format: Int64
+    Channels: 1
+    FillSize: 8
+    FillValue: 137  # trash non-zero initialization data
+  - Name: ExpectedTBufI
+    Format: Int64
+    Channels: 1
+    Data: [ -63 ]
+  - Name: OutMonoTBufI
+    Format: UInt32
+    Stride: 4
+    FillSize: 256
+  - Name: ExpectedMono
+    Format: UInt32
+    Stride: 4
+    Data: [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ]
+Results:
+  - Result: TestTBufU
+    Rule: BufferExact
+    Actual: TBufU
+    Expected: ExpectedTBufU
+  - Result: TestTBufI
+    Rule: BufferExact
+    Actual: TBufI
+    Expected: ExpectedTBufI
+  - Result: TestMonoTBufI
+    Rule: BufferExact
+    Actual: OutMonoTBufI
+    Expected: ExpectedMono
+DescriptorSets:
+  - Resources:
+    - Name: TBufU
+      Kind: RWBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: TBufI
+      Kind: RWBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+    - Name: OutMonoTBufI
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 2
+        Space: 0
+      VulkanBinding:
+        Binding: 2
+...
+#--- end
+
+# Unimplemented: https://github.com/llvm/llvm-project/issues/99123
+# XFAIL: Clang
+
+# REQUIRES: Int64TypedResourceAtomics && SM_6_6
+# RUN: split-file %s %t
+# RUN: %dxc_target -HV 202x -T cs_6_6 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/InterlockedMin.resources.typed.int64.test
+++ b/test/Feature/HLSLLib/InterlockedMin.resources.typed.int64.test
@@ -17,7 +17,7 @@
 //   * RWBuffer<uint64_t>[i]  (free function, 2-arg)
 //   * RWBuffer<int64_t>[i]   (free function, 3-arg, signed)
 //
-// 64 threads of a single threadgroup atomically take the minimum of their
+// 256 threads of a single threadgroup atomically take the minimum of their
 // per-thread proposal and a single accumulator slot.
 
 RWBuffer<uint64_t> TBufU : register(u0);
@@ -25,7 +25,7 @@ RWBuffer<int64_t>  TBufI : register(u1);
 
 RWStructuredBuffer<uint> OutMonoTBufI : register(u2);
 
-[numthreads(64, 1, 1)]
+[numthreads(256, 1, 1)]
 void main(uint3 GTID : SV_GroupThreadID) {
   if (GTID.x == 0) {
     TBufU[0] = 0xFFFFFFFFFFFFFFFFull;
@@ -33,10 +33,10 @@ void main(uint3 GTID : SV_GroupThreadID) {
   }
   DeviceMemoryBarrierWithGroupSync();
 
-  // RWBuffer<uint64_t>: 2-argument free function. Proposals 0..63, min = 0.
+  // RWBuffer<uint64_t>: 2-argument free function. Proposals 0..255, min = 0.
   InterlockedMin(TBufU[0], (uint64_t)GTID.x);
 
-  // RWBuffer<int64_t>: 3-argument free function (signed). Proposals -63..0,
+  // RWBuffer<int64_t>: 3-argument free function (signed). Proposals -63..192,
   // min = -63. The concurrent re-read must never exceed the observed original
   // (monotonic non-increase).
   int64_t OrigI;
@@ -73,11 +73,23 @@ Buffers:
   - Name: OutMonoTBufI
     Format: UInt32
     Stride: 4
-    FillSize: 256
+    FillSize: 1024
   - Name: ExpectedMono
     Format: UInt32
     Stride: 4
     Data: [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ]

--- a/test/Feature/HLSLLib/InterlockedMin.resources.typed.int64.test
+++ b/test/Feature/HLSLLib/InterlockedMin.resources.typed.int64.test
@@ -19,28 +19,6 @@
 //
 // 64 threads of a single threadgroup atomically take the minimum of their
 // per-thread proposal and a single accumulator slot.
-//
-// Atomicity is verified two independent ways:
-//
-//   1. Final value. Each accumulator's deterministic final value is the
-//      minimum over all participating threads (and the initial value). A
-//      non-atomic read-modify-write can lose the lowest write: a thread
-//      reads the pre-minimum value, then stores its larger proposal *after*
-//      the minimum was written, clobbering it. So the final value can only
-//      equal the true minimum if no atomic min update is lost.
-//
-//   2. Monotonicity (3-argument form). Under correct atomic semantics the
-//      accumulator is monotonically non-increasing: once a value is written
-//      it can only get smaller. So immediately after this thread's atomic
-//      min returns `orig`, a fresh re-read of the accumulator must be <=
-//      `orig` -- it can never climb back above the value this thread
-//      observed. A racy implementation can transiently *raise* the value (a
-//      thread reads an old value, then writes its larger min back after a
-//      smaller value was already stored); a thread whose `orig` sits below
-//      that bumped-up value would then observe re-read > `orig`. Unlike a
-//      predicate on `orig` alone, this correlates `orig` with a fresh
-//      observation of memory and checks every thread, so a correct
-//      implementation yields all-ones.
 
 RWBuffer<uint64_t> TBufU : register(u0);
 RWBuffer<int64_t>  TBufI : register(u1);


### PR DESCRIPTION
This PR adds tests for InterlockedMin
Adds 32 bit and 64 bit signed/unsigned integer tests, along with some resource member function tests.
Fixes https://github.com/llvm/offload-test-suite/issues/104
Assisted by: Github Copilot