### PR TITLE
Add a few tests for ConstantBuffer<T>

### DIFF
--- a/test/Feature/CBuffer/structs.test
+++ b/test/Feature/CBuffer/structs.test
@@ -97,7 +97,7 @@ DescriptorSets:
 ...
 #--- end
 
-# Unimplemented https://github.com/llvm/llvm-project/issues/186465
+# Bug: https://github.com/llvm/llvm-project/issues/180600
 # XFAIL: Clang && Vulkan
 
 # Bug https://github.com/KhronosGroup/SPIRV-Cross/issues/2595

--- a/test/Feature/ConstantBufferT/arrays.test
+++ b/test/Feature/ConstantBufferT/arrays.test
@@ -1,12 +1,5 @@
 #--- source.hlsl
 
-cbuffer CBArrays : register(b0) {
-  float c1[2];
-  int4 c2[2][2];
-  bool c3[2];
-  int3 c4[2][2];
-}
-
 struct Arrays {
   float c1[2];
   int4 c2[2][2];
@@ -14,18 +7,18 @@ struct Arrays {
   int3 c4[2][2];
 };
 
+ConstantBuffer<Arrays> CBArrays : register(b0);
 RWStructuredBuffer<Arrays> Out : register(u1);
 
 [numthreads(1,1,1)]
 void main() {
-  Out[0].c1 = c1;
-  Out[0].c2 = c2;
-  Out[0].c3 = c3;
-  Out[0].c4 = c4;
+  Out[0].c1 = CBArrays.c1;
+  Out[0].c2 = CBArrays.c2;
+  Out[0].c3 = CBArrays.c3;
+  Out[0].c4 = CBArrays.c4;
 }
 
 //--- pipeline.yaml
-
 ---
 Shaders:
   - Stage: Compute
@@ -45,7 +38,7 @@ Buffers:
       0x00000010, 0x00000011, 0x00000012, 0x5A5A5A5A,
       0x00000013, 0x00000014, 0x00000015, 0x5A5A5A5A,
       0x00000016, 0x00000017, 0x00000018, 0x5A5A5A5A,
-      0x00000019, 0x0000001A, 0x0000001B, 0x5A5A5A5A
+      0x00000019, 0x0000001A, 0x0000001B, 0x5A5A5A5A,
     ]
   - Name: Out
     Format: Hex32

--- a/test/Feature/ConstantBufferT/indexed-ref.test
+++ b/test/Feature/ConstantBufferT/indexed-ref.test
@@ -1,0 +1,71 @@
+#--- source.hlsl
+struct S {
+  int a;
+  float4 b;
+};
+
+RWStructuredBuffer<S> Buf : register(u0);
+ConstantBuffer<S> CBs[2] : register(b4);
+
+[numthreads(4,1,1)]
+void main(uint GID : SV_GroupIndex) {
+    ConstantBuffer<S> cb = CBs[NonUniformResourceIndex(GID % 2)];
+    Buf[GID] = cb;
+}
+
+//--- pipeline.yaml
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+Buffers:
+  - Name: CBS
+    Format: Hex32
+    ArraySize: 2
+    Data:
+      - [0x1,        0x5a5a5a5a, 0x5a5a5a5a, 0x5a5a5a5a,
+         0x3f800000, 0x40000000, 0x40400000, 0x40800000]
+      - [0xffffffff, 0x5a5a5a5a, 0x5a5a5a5a, 0x5a5a5a5a,
+         0xbf800000, 0xc0000000, 0xc0400000, 0xc0800000]
+  - Name: Out
+    Format: Hex32
+    Stride: 20
+    FillSize: 80
+  - Name: ExpectedOut
+    Format: Hex32
+    Data: [
+      0x1,        0x3f800000, 0x40000000, 0x40400000, 0x40800000,
+      0xffffffff, 0xbf800000, 0xc0000000, 0xc0400000, 0xc0800000,
+      0x1,        0x3f800000, 0x40000000, 0x40400000, 0x40800000,
+      0xffffffff, 0xbf800000, 0xc0000000, 0xc0400000, 0xc0800000,
+    ]
+Results:
+  - Result: Test
+    Rule: BufferExact
+    Actual: Out
+    Expected: ExpectedOut
+DescriptorSets:
+  - Resources:
+    - Name: Out
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: CBS
+      Kind: ConstantBuffer
+      DirectXBinding:
+        Register: 4
+        Space: 0
+      VulkanBinding:
+        Binding: 4
+...
+#--- end
+
+# Unimplemented: https://github.com/llvm/llvm-project/issues/195093
+# XFAIL: Clang
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -fvk-use-dx-layout -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/ConstantBufferT/nested.test
+++ b/test/Feature/ConstantBufferT/nested.test
@@ -1,0 +1,107 @@
+#--- source.hlsl
+
+struct X {
+  int a1;
+};
+
+struct Y : X {
+  int2 a2;
+};
+
+struct Z {
+  X xs[2];
+  Y y;
+};
+
+struct CBStructs {
+  X x1;
+  X x2;
+  Y y;
+  Z zs[2];
+};
+
+ConstantBuffer<CBStructs> CB : register(b0);
+RWStructuredBuffer<CBStructs> Out : register(u1);
+
+[numthreads(1,1,1)]
+void main() {
+  Out[0].x1.a1 = CB.x1.a1;
+  Out[0].x2.a1 = CB.x2.a1;
+  Out[0].y.a1 = CB.y.a1;
+  Out[0].y.a2 = CB.y.a2;
+  Out[0].zs[0].xs[0].a1 = CB.zs[0].xs[0].a1;
+  Out[0].zs[0].xs[1].a1 = CB.zs[0].xs[1].a1;
+  Out[0].zs[0].y.a1 = CB.zs[0].y.a1;
+  Out[0].zs[0].y.a2 = CB.zs[0].y.a2;
+  Out[0].zs[1].xs[0].a1 = CB.zs[1].xs[0].a1;
+  Out[0].zs[1].xs[1].a1 = CB.zs[1].xs[1].a1;
+  Out[0].zs[1].y.a1 = CB.zs[1].y.a1;
+  Out[0].zs[1].y.a2 = CB.zs[1].y.a2;
+}
+
+//--- pipeline.yaml
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+Buffers:
+  - Name: CB
+    Format: Hex32
+    Data: [
+      0x1, 0x5A5A5A5A, 0x5A5A5A5A, 0x5A5A5A5A,
+      0x2, 0x5A5A5A5A, 0x5A5A5A5A, 0x5A5A5A5A,
+      0x3, 0x4, 0x5, 0x5A5A5A5A,
+      0x6, 0x5A5A5A5A, 0x5A5A5A5A, 0x5A5A5A5A,
+      0x7, 0x5A5A5A5A, 0x5A5A5A5A, 0x5A5A5A5A,
+      0x8, 0x9, 0xA, 0x5A5A5A5A,
+      0xB, 0x5A5A5A5A, 0x5A5A5A5A, 0x5A5A5A5A,
+      0xC, 0x5A5A5A5A, 0x5A5A5A5A, 0x5A5A5A5A,
+      0xD, 0xE, 0xF, 0x5A5A5A5A,
+    ]
+  - Name: Out
+    Format: Hex32
+    Stride: 60
+    FillSize: 60
+  - Name: ExpectedOut
+    Format: Hex32
+    Data: [
+      0x1,
+      0x2,
+      0x3, 0x4, 0x5,
+      0x6,
+      0x7,
+      0x8, 0x9, 0xA,
+      0xB,
+      0xC,
+      0xD, 0xE, 0xF,
+    ]
+Results:
+  - Result: Test
+    Rule: BufferExact
+    Actual: Out
+    Expected: ExpectedOut
+DescriptorSets:
+  - Resources:
+    - Name: CB
+      Kind: ConstantBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: Out
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+...
+#--- end
+
+# Bug: https://github.com/llvm/llvm-project/issues/180600
+# XFAIL: Clang && Vulkan
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -fvk-use-dx-layout -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/ConstantBufferT/vectors.test
+++ b/test/Feature/ConstantBufferT/vectors.test
@@ -1,0 +1,73 @@
+#--- source.hlsl
+
+struct CBVectors {
+  float3 b1;
+  int4 b2;
+  uint2 b3;
+  bool4 b4;
+};
+
+ConstantBuffer<CBVectors> CB : register(b0);
+RWStructuredBuffer<CBVectors> Out : register(u1);
+
+[numthreads(1,1,1)]
+void main() {
+  Out[0].b1 = CB.b1;
+  Out[0].b2 = CB.b2;
+  Out[0].b3 = CB.b3;
+  Out[0].b4 = CB.b4;
+}
+
+//--- pipeline.yaml
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+Buffers:
+  - Name: CB
+    Format: Hex32
+    Data: [
+      0x3f800000, 0x40000000, 0x40400000, 0x5A5A5A5A,
+      0x00000001, 0x00000002, 0x00000003, 0x00000004,
+      0x00000001, 0x00000002, 0x5A5A5A5A, 0x5A5A5A5A,
+      0x00000001, 0x00000000, 0x00000001, 0x00000000
+    ]
+  - Name: Out
+    Format: Hex32
+    Stride: 52
+    FillSize: 52
+  - Name: ExpectedOut
+    Format: Hex32
+    Data: [
+      0x3f800000, 0x40000000, 0x40400000,
+      0x00000001, 0x00000002, 0x00000003, 0x00000004,
+      0x00000001, 0x00000002,
+      0x00000001, 0x00000000, 0x00000001, 0x00000000
+    ]
+Results:
+  - Result: Test
+    Rule: BufferExact
+    Actual: Out
+    Expected: ExpectedOut
+DescriptorSets:
+  - Resources:
+    - Name: CB
+      Kind: ConstantBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: Out
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+...
+#--- end
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -fvk-use-dx-layout -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
A lot of these are fairly similar to the CBuffers tests, but use the resource type `ConstantBuffer<>` instead of the `cbuffer` construct. I also updated a couple of XFAILs that are failing in the same way between the two constructs, as they were out of date.

Fixes llvm/wg-hlsl#200