### PR TITLE
OffloadMigration: Fix `-Wchanges-meaning` errors from newer GCC

### DIFF
--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -2271,8 +2271,8 @@ public:
       for (auto &R : T.Resources) {
         for (const auto &Set : R.second) {
           D3D12_CPU_DESCRIPTOR_HANDLE DescriptorHandle = {};
-          if (Set.Buffer != nullptr) {
-            const DXBuffer &BufferDX = llvm::cast<DXBuffer>(*Set.Buffer.get());
+          if (Set.Buf != nullptr) {
+            const DXBuffer &BufferDX = llvm::cast<DXBuffer>(*Set.Buf.get());
             switch (getDescriptorKind(R.first->Kind)) {
             case DescriptorKind::SRV:
               assert(BufferDX.SRVHandle.ptr != 0 &&
@@ -2293,9 +2293,8 @@ public:
               llvm_unreachable("Invalid DescriptorKind for a Buffer.");
               break;
             }
-          } else if (Set.Texture != nullptr) {
-            const DXTexture &TextureDX =
-                llvm::cast<DXTexture>(*Set.Texture.get());
+          } else if (Set.Tex != nullptr) {
+            const DXTexture &TextureDX = llvm::cast<DXTexture>(*Set.Tex.get());
             switch (getDescriptorKind(R.first->Kind)) {
             case DescriptorKind::SRV:
               assert(TextureDX.SRVHandle.ptr != 0 &&
@@ -2382,7 +2381,7 @@ public:
                 "Root descriptor cannot refer to resource arrays.");
 
           const DXBuffer *BufferDX = llvm::cast_if_present<DXBuffer>(
-              RootDescIt->second.back().Buffer.get());
+              RootDescIt->second.back().Buf.get());
           if (!BufferDX) {
             return llvm::createStringError(
                 std::errc::value_too_large,

--- a/lib/Support/OffloadMigration.cpp
+++ b/lib/Support/OffloadMigration.cpp
@@ -3,6 +3,8 @@
 #include "API/Device.h"
 #include "API/FormatConversion.h"
 
+#include "llvm/ADT/STLForwardCompat.h"
+
 namespace offloadtest {
 
 static BufferUsage bufferUsageFromResourceKind(ResourceKind Kind) {
@@ -37,7 +39,7 @@ static BufferShaderAccessType bufferShaderAccessTypeFromResourceKind(
         toFormat(Resource.BufferPtr->Format, Resource.BufferPtr->Channels);
     if (!FmtOrErr) {
       printf("Invalid format! FMT: %d, CHANNELS: %d\n",
-             static_cast<int>(Resource.BufferPtr->Format),
+             llvm::to_underlying(Resource.BufferPtr->Format),
              Resource.BufferPtr->Channels);
       assert(false && "Invalid format.");
     }
@@ -81,8 +83,7 @@ llvm::Error copyBackResource(offloadtest::ComputeEncoder &ReadbackEncoder,
       if (RS.Readback == nullptr)
         continue;
 
-      if (auto Err =
-              ReadbackEncoder.copyTextureToBuffer(*RS.Texture, *RS.Readback))
+      if (auto Err = ReadbackEncoder.copyTextureToBuffer(*RS.Tex, *RS.Readback))
         return Err;
     }
   } else if (R.first->isBuffer()) {
@@ -91,14 +92,14 @@ llvm::Error copyBackResource(offloadtest::ComputeEncoder &ReadbackEncoder,
         continue;
 
       if (auto Err = ReadbackEncoder.copyBufferToBuffer(
-              *RS.Buffer, 0, *RS.Readback, 0, RS.Buffer->getSizeInBytes()))
+              *RS.Buf, 0, *RS.Readback, 0, RS.Buf->getSizeInBytes()))
         return Err;
 
-      if (!RS.Buffer->getDesc().HasCounter)
+      if (!RS.Buf->getDesc().HasCounter)
         continue;
 
-      if (auto Err = ReadbackEncoder.copyCounterToBuffer(*RS.Buffer,
-                                                         *RS.CounterReadback))
+      if (auto Err =
+              ReadbackEncoder.copyCounterToBuffer(*RS.Buf, *RS.CounterReadback))
         return Err;
     }
   }
@@ -122,7 +123,7 @@ llvm::Error readBack(Device &Dev, Pipeline &P, SharedInvocationState &IS) {
       const void *DataPtr = *DataPtrOrErr;
 
       if (R.first->isTexture()) {
-        const TextureCreateDesc &Desc = RSIt->Texture->getDesc();
+        const TextureCreateDesc &Desc = RSIt->Tex->getDesc();
         const uint32_t SrcStrideInBytes =
             Dev.getTextureUploadRowStrideInBytes(Desc);
         const uint32_t DstStrideInBytes =

--- a/lib/Support/OffloadMigration.h
+++ b/lib/Support/OffloadMigration.h
@@ -34,8 +34,8 @@ class Texture;
 
 struct ResourceSet {
   std::unique_ptr<MemoryHeap> BackingMemory;
-  std::unique_ptr<Buffer> Buffer;
-  std::unique_ptr<Texture> Texture;
+  std::unique_ptr<Buffer> Buf;
+  std::unique_ptr<Texture> Tex;
   std::unique_ptr<offloadtest::Buffer> Readback;
   std::unique_ptr<offloadtest::Buffer> CounterReadback;
 
@@ -46,13 +46,13 @@ struct ResourceSet {
               std::unique_ptr<MemoryHeap> BackingMemory,
               std::unique_ptr<offloadtest::Buffer> Readback,
               std::unique_ptr<offloadtest::Buffer> CounterReadback)
-      : BackingMemory(std::move(BackingMemory)), Buffer(std::move(Buffer)),
+      : BackingMemory(std::move(BackingMemory)), Buf(std::move(Buffer)),
         Readback(std::move(Readback)),
         CounterReadback(std::move(CounterReadback)) {}
   ResourceSet(std::unique_ptr<offloadtest::Texture> Texture,
               std::unique_ptr<MemoryHeap> BackingMemory,
               std::unique_ptr<offloadtest::Buffer> Readback)
-      : BackingMemory(std::move(BackingMemory)), Texture(std::move(Texture)),
+      : BackingMemory(std::move(BackingMemory)), Tex(std::move(Texture)),
         Readback(std::move(Readback)) {}
   explicit ResourceSet(AccelerationStructure *AS) : AS(AS) {}
 
@@ -60,13 +60,13 @@ struct ResourceSet {
   ResourceSet &operator=(const ResourceSet &) = delete;
 
   ResourceSet(ResourceSet &&A)
-      : BackingMemory(std::move(A.BackingMemory)), Buffer(std::move(A.Buffer)),
-        Texture(std::move(A.Texture)), Readback(std::move(A.Readback)),
+      : BackingMemory(std::move(A.BackingMemory)), Buf(std::move(A.Buf)),
+        Tex(std::move(A.Tex)), Readback(std::move(A.Readback)),
         CounterReadback(std::move(A.CounterReadback)), AS(A.AS) {}
   ResourceSet &operator=(ResourceSet &&A) {
     BackingMemory = std::move(A.BackingMemory);
-    Buffer = std::move(A.Buffer);
-    Texture = std::move(A.Texture);
+    Buf = std::move(A.Buf);
+    Tex = std::move(A.Tex);
     Readback = std::move(A.Readback);
     CounterReadback = std::move(A.CounterReadback);
     AS = A.AS;


### PR DESCRIPTION
Simply shorten the field names from `Buffer` -> `Buf` and `Texture` -> `Tex` so that they no longer conflict with the same type name, allowing the framework to be compiled once again.  A similar issue was fixed earlier in #1095.

