### PR TITLE
Update XFAILs for fixes to resource handle phis and ConstantBuffer<T>

### DIFF
--- a/test/Feature/ConstantBufferT/indexed-ref.test
+++ b/test/Feature/ConstantBufferT/indexed-ref.test
@@ -63,9 +63,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Unimplemented: https://github.com/llvm/llvm-project/issues/195093
-# XFAIL: Clang
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -fvk-use-dx-layout -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/StructuredBuffer/inc_counter_array.test
+++ b/test/Feature/StructuredBuffer/inc_counter_array.test
@@ -39,9 +39,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug https://github.com/llvm/llvm-project/issues/162841
-# XFAIL: Clang && Vulkan
-
 # Offload tests are missing support for counters and resource arrays on Metal
 # Unimplemented https://github.com/llvm/offload-test-suite/issues/304
 # Unimplemented https://github.com/llvm/offload-test-suite/issues/305


### PR DESCRIPTION
These tests are both now XPASSing:
- llvm/llvm-project#162841 was fixed by llvm/llvm-project#205996
- llvm/llvm-project#195093 was fixed by llvm/llvm-project#205433