### PR TITLE
Add InterlockedMax tests

### DIFF
--- a/test/Feature/HLSLLib/InterlockedMax.32.test
+++ b/test/Feature/HLSLLib/InterlockedMax.32.test
@@ -1,7 +1,7 @@
 #--- source.hlsl
 
 // This test exercises InterlockedMax against non-resource (groupshared)
-// destinations. A single threadgroup of 64 threads concurrently updates
+// destinations. A single threadgroup of 256 threads concurrently updates
 // shared counters, so the test actually exercises atomic behavior.
 //
 // Both the 2-argument and 3-argument overloads are covered for int and uint.
@@ -38,7 +38,7 @@ groupshared int  MaxIntNoOrig;    // 2-arg form, signed
 groupshared uint MaxUIntNoOrig;   // 2-arg form, unsigned
 groupshared int  SignedCounter;   // 2-arg form reaching a positive maximum
 
-[numthreads(64, 1, 1)]
+[numthreads(256, 1, 1)]
 void main(uint3 GTID : SV_GroupThreadID) {
   if (GTID.x == 0) {
     MaxInt = -1000;
@@ -49,7 +49,7 @@ void main(uint3 GTID : SV_GroupThreadID) {
   }
   GroupMemoryBarrierWithGroupSync();
 
-  // 3-argument form. Proposals span -32..31, max = 31. The concurrent
+  // 3-argument form. Proposals span -32..223, max = 223. The concurrent
   // re-read must never fall below the observed original (monotonic
   // non-decrease).
   int origI;
@@ -57,27 +57,27 @@ void main(uint3 GTID : SV_GroupThreadID) {
   int afterI = MaxInt;
   OutMonoInt[GTID.x] = (afterI >= origI) ? 1u : 0u;
 
-  // 3-argument form, unsigned. Proposals span 0..63, max = 63.
+  // 3-argument form, unsigned. Proposals span 0..255, max = 255.
   uint origU;
   InterlockedMax(MaxUInt, GTID.x, origU);
   uint afterU = MaxUInt;
   OutMonoUInt[GTID.x] = (afterU >= origU) ? 1u : 0u;
 
-  // 2-argument form. Proposals span 0..-63, max = 0.
+  // 2-argument form. Proposals span 0..-255, max = 0.
   InterlockedMax(MaxIntNoOrig, -(int)GTID.x);
-  // 2-argument form, unsigned. Proposals span 100..163, max = 163.
+  // 2-argument form, unsigned. Proposals span 100..355, max = 355.
   InterlockedMax(MaxUIntNoOrig, GTID.x + 100u);
-  // 2-argument form reaching a positive maximum. Proposals span 937..1000.
+  // 2-argument form reaching a positive maximum. Proposals span 937..1192.
   InterlockedMax(SignedCounter, (int)GTID.x + 937);
 
   GroupMemoryBarrierWithGroupSync();
 
   if (GTID.x == 0) {
-    OutFinal[0] = MaxInt;             // 31
-    OutFinal[1] = (int)MaxUInt;       // 63
+    OutFinal[0] = MaxInt;             // 223
+    OutFinal[1] = (int)MaxUInt;       // 255
     OutFinal[2] = MaxIntNoOrig;       // 0
-    OutFinal[3] = (int)MaxUIntNoOrig; // 163
-    OutFinal[4] = SignedCounter;      // 1000
+    OutFinal[3] = (int)MaxUIntNoOrig; // 355
+    OutFinal[4] = SignedCounter;      // 1192
   }
 }
 
@@ -91,22 +91,46 @@ Buffers:
   - Name: OutMonoInt
     Format: UInt32
     Stride: 4
-    FillSize: 256
+    FillSize: 1024
   - Name: ExpectedMonoInt
     Format: UInt32
     Stride: 4
     Data: [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ]
   - Name: OutMonoUInt
     Format: UInt32
     Stride: 4
-    FillSize: 256
+    FillSize: 1024
   - Name: ExpectedMonoUInt
     Format: UInt32
     Stride: 4
     Data: [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ]
@@ -117,7 +141,7 @@ Buffers:
   - Name: ExpectedFinal
     Format: Int32
     Stride: 4
-    Data: [ 31, 63, 0, 163, 1000 ]
+    Data: [ 223, 255, 0, 355, 1192 ]
 Results:
   - Result: TestMonoInt
     Rule: BufferExact

--- a/test/Feature/HLSLLib/InterlockedMax.32.test
+++ b/test/Feature/HLSLLib/InterlockedMax.32.test
@@ -1,8 +1,8 @@
 #--- source.hlsl
 
 // This test exercises InterlockedMax against non-resource (groupshared)
-// destinations. A single threadgroup of 256 threads concurrently updates
-// shared counters, so the test actually exercises atomic behavior.
+// destinations. A set of 256 threads concurrently updates shared counters,
+// so the test actually exercises atomic behavior.
 //
 // Both the 2-argument and 3-argument overloads are covered for int and uint.
 //

--- a/test/Feature/HLSLLib/InterlockedMax.32.test
+++ b/test/Feature/HLSLLib/InterlockedMax.32.test
@@ -1,0 +1,165 @@
+#--- source.hlsl
+
+// This test exercises InterlockedMax against non-resource (groupshared)
+// destinations. A single threadgroup of 64 threads concurrently updates
+// shared counters, so the test actually exercises atomic behavior.
+//
+// Both the 2-argument and 3-argument overloads are covered for int and uint.
+//
+// Atomicity is verified two independent ways for all interlocked max tests:
+//
+//   1. Final value. Each counter's deterministic final value is the maximum
+//      over all participating threads (and the initial value). A non-atomic
+//      read-modify-write can lose the highest write: a thread reads the
+//      pre-maximum value, then stores its smaller proposal *after* the
+//      maximum was written, clobbering it. So the final value can only equal
+//      the true maximum if no atomic max update is lost.
+//
+//   2. Monotonicity (3-argument form). Under correct atomic semantics the
+//      counter is monotonically non-decreasing: once a value is written it
+//      can only get larger. So immediately after this thread's atomic max
+//      returns `orig`, a fresh re-read of the counter must be >= `orig` --
+//      the counter can never drop back below the value this thread observed.
+//      A racy implementation can transiently *lower* the counter (a thread
+//      reads an old value, then writes its smaller max back after a larger
+//      value was already stored); a thread whose `orig` sits above that
+//      dropped value would then observe re-read < `orig`. Unlike a predicate
+//      on `orig` alone, this correlates `orig` with a fresh observation of
+//      shared memory and checks every thread, so a correct implementation
+//      yields all-ones.
+
+RWStructuredBuffer<uint> OutMonoInt : register(u0);
+RWStructuredBuffer<uint> OutMonoUInt : register(u1);
+RWStructuredBuffer<int> OutFinal : register(u2);
+
+groupshared int  MaxInt;          // 3-arg form, signed
+groupshared uint MaxUInt;         // 3-arg form, unsigned
+groupshared int  MaxIntNoOrig;    // 2-arg form, signed
+groupshared uint MaxUIntNoOrig;   // 2-arg form, unsigned
+groupshared int  SignedCounter;   // 2-arg form reaching a positive maximum
+
+[numthreads(64, 1, 1)]
+void main(uint3 GTID : SV_GroupThreadID) {
+  if (GTID.x == 0) {
+    MaxInt = -1000;
+    MaxUInt = 0u;
+    MaxIntNoOrig = -1000;
+    MaxUIntNoOrig = 0u;
+    SignedCounter = -1000;
+  }
+  GroupMemoryBarrierWithGroupSync();
+
+  // 3-argument form. Proposals span -32..31, max = 31. The concurrent
+  // re-read must never fall below the observed original (monotonic
+  // non-decrease).
+  int origI;
+  InterlockedMax(MaxInt, (int)GTID.x - 32, origI);
+  int afterI = MaxInt;
+  OutMonoInt[GTID.x] = (afterI >= origI) ? 1u : 0u;
+
+  // 3-argument form, unsigned. Proposals span 0..63, max = 63.
+  uint origU;
+  InterlockedMax(MaxUInt, GTID.x, origU);
+  uint afterU = MaxUInt;
+  OutMonoUInt[GTID.x] = (afterU >= origU) ? 1u : 0u;
+
+  // 2-argument form. Proposals span 0..-63, max = 0.
+  InterlockedMax(MaxIntNoOrig, -(int)GTID.x);
+  // 2-argument form, unsigned. Proposals span 100..163, max = 163.
+  InterlockedMax(MaxUIntNoOrig, GTID.x + 100u);
+  // 2-argument form reaching a positive maximum. Proposals span 937..1000.
+  InterlockedMax(SignedCounter, (int)GTID.x + 937);
+
+  GroupMemoryBarrierWithGroupSync();
+
+  if (GTID.x == 0) {
+    OutFinal[0] = MaxInt;             // 31
+    OutFinal[1] = (int)MaxUInt;       // 63
+    OutFinal[2] = MaxIntNoOrig;       // 0
+    OutFinal[3] = (int)MaxUIntNoOrig; // 163
+    OutFinal[4] = SignedCounter;      // 1000
+  }
+}
+
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+Buffers:
+  - Name: OutMonoInt
+    Format: UInt32
+    Stride: 4
+    FillSize: 256
+  - Name: ExpectedMonoInt
+    Format: UInt32
+    Stride: 4
+    Data: [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ]
+  - Name: OutMonoUInt
+    Format: UInt32
+    Stride: 4
+    FillSize: 256
+  - Name: ExpectedMonoUInt
+    Format: UInt32
+    Stride: 4
+    Data: [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ]
+  - Name: OutFinal
+    Format: Int32
+    Stride: 4
+    FillSize: 20
+  - Name: ExpectedFinal
+    Format: Int32
+    Stride: 4
+    Data: [ 31, 63, 0, 163, 1000 ]
+Results:
+  - Result: TestMonoInt
+    Rule: BufferExact
+    Actual: OutMonoInt
+    Expected: ExpectedMonoInt
+  - Result: TestMonoUInt
+    Rule: BufferExact
+    Actual: OutMonoUInt
+    Expected: ExpectedMonoUInt
+  - Result: TestFinal
+    Rule: BufferExact
+    Actual: OutFinal
+    Expected: ExpectedFinal
+DescriptorSets:
+  - Resources:
+    - Name: OutMonoInt
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: OutMonoUInt
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+    - Name: OutFinal
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 2
+        Space: 0
+      VulkanBinding:
+        Binding: 2
+...
+#--- end
+
+# Unimplemented: https://github.com/llvm/llvm-project/issues/99124
+# XFAIL: Clang
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/InterlockedMax.int64.test
+++ b/test/Feature/HLSLLib/InterlockedMax.int64.test
@@ -1,7 +1,7 @@
 #--- source.hlsl
 
 // This test exercises InterlockedMax against non-resource (groupshared)
-// destinations using 64-bit integer types. A single threadgroup of 64
+// destinations using 64-bit integer types. A single threadgroup of 256
 // threads concurrently updates shared counters, so the test actually
 // exercises atomic behavior.
 //
@@ -19,7 +19,7 @@ groupshared uint64_t MaxUIntNoOrig;   // 2-arg form, unsigned
 groupshared int64_t  SignedCounter;   // 2-arg form reaching a positive maximum
 groupshared uint64_t LargeCounter;    // 2-arg form exercising the upper 32 bits
 
-[numthreads(64, 1, 1)]
+[numthreads(256, 1, 1)]
 void main(uint3 GTID : SV_GroupThreadID) {
   if (GTID.x == 0) {
     MaxInt = -1000;
@@ -31,7 +31,7 @@ void main(uint3 GTID : SV_GroupThreadID) {
   }
   GroupMemoryBarrierWithGroupSync();
 
-  // 3-argument form. Proposals span -32..31, max = 31. The concurrent
+  // 3-argument form. Proposals span -32..223, max = 223. The concurrent
   // re-read must never fall below the observed original (monotonic
   // non-decrease).
   int64_t origI;
@@ -39,31 +39,31 @@ void main(uint3 GTID : SV_GroupThreadID) {
   int64_t afterI = MaxInt;
   OutMonoInt[GTID.x] = (afterI >= origI) ? 1u : 0u;
 
-  // 3-argument form, unsigned. Proposals span 0..63, max = 63.
+  // 3-argument form, unsigned. Proposals span 0..255, max = 255.
   uint64_t origU;
   InterlockedMax(MaxUInt, (uint64_t)GTID.x, origU);
   uint64_t afterU = MaxUInt;
   OutMonoUInt[GTID.x] = (afterU >= origU) ? 1u : 0u;
 
-  // 2-argument form. Proposals span 0..-63, max = 0.
+  // 2-argument form. Proposals span 0..-255, max = 0.
   InterlockedMax(MaxIntNoOrig, -(int64_t)GTID.x);
-  // 2-argument form, unsigned. Proposals span 100..163, max = 163.
+  // 2-argument form, unsigned. Proposals span 100..355, max = 355.
   InterlockedMax(MaxUIntNoOrig, (uint64_t)GTID.x + 100);
-  // 2-argument form reaching a positive maximum. Proposals span 937..1000.
+  // 2-argument form reaching a positive maximum. Proposals span 937..1192.
   InterlockedMax(SignedCounter, (int64_t)GTID.x + 937);
   // 2-argument form with a value that exercises the upper 32 bits,
-  // max = 2^32 + 63.
+  // max = 2^32 + 255.
   InterlockedMax(LargeCounter, 0x100000000ull + (uint64_t)GTID.x);
 
   GroupMemoryBarrierWithGroupSync();
 
   if (GTID.x == 0) {
-    OutFinal[0] = MaxInt;                 // 31
-    OutFinal[1] = (int64_t)MaxUInt;       // 63
+    OutFinal[0] = MaxInt;                 // 223
+    OutFinal[1] = (int64_t)MaxUInt;       // 255
     OutFinal[2] = MaxIntNoOrig;           // 0
-    OutFinal[3] = (int64_t)MaxUIntNoOrig; // 163
-    OutFinal[4] = SignedCounter;          // 1000
-    OutFinal[5] = (int64_t)LargeCounter;  // 2^32 + 63 = 4294967359
+    OutFinal[3] = (int64_t)MaxUIntNoOrig; // 355
+    OutFinal[4] = SignedCounter;          // 1192
+    OutFinal[5] = (int64_t)LargeCounter;  // 2^32 + 255 = 4294967551
   }
 }
 
@@ -77,22 +77,46 @@ Buffers:
   - Name: OutMonoInt
     Format: UInt32
     Stride: 4
-    FillSize: 256
+    FillSize: 1024
   - Name: ExpectedMonoInt
     Format: UInt32
     Stride: 4
     Data: [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ]
   - Name: OutMonoUInt
     Format: UInt32
     Stride: 4
-    FillSize: 256
+    FillSize: 1024
   - Name: ExpectedMonoUInt
     Format: UInt32
     Stride: 4
     Data: [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ]
@@ -103,7 +127,7 @@ Buffers:
   - Name: ExpectedFinal
     Format: Int64
     Stride: 8
-    Data: [ 31, 63, 0, 163, 1000, 4294967359 ]
+    Data: [ 223, 255, 0, 355, 1192, 4294967551 ]
 
 Results:
   - Result: TestMonoInt

--- a/test/Feature/HLSLLib/InterlockedMax.int64.test
+++ b/test/Feature/HLSLLib/InterlockedMax.int64.test
@@ -1,0 +1,157 @@
+#--- source.hlsl
+
+// This test exercises InterlockedMax against non-resource (groupshared)
+// destinations using 64-bit integer types. A single threadgroup of 64
+// threads concurrently updates shared counters, so the test actually
+// exercises atomic behavior.
+//
+// Both the 2-argument and 3-argument overloads are covered for int64_t
+// and uint64_t.
+
+RWStructuredBuffer<uint> OutMonoInt : register(u0);
+RWStructuredBuffer<uint> OutMonoUInt : register(u1);
+RWStructuredBuffer<int64_t> OutFinal : register(u2);
+
+groupshared int64_t  MaxInt;          // 3-arg form, signed
+groupshared uint64_t MaxUInt;         // 3-arg form, unsigned
+groupshared int64_t  MaxIntNoOrig;    // 2-arg form, signed
+groupshared uint64_t MaxUIntNoOrig;   // 2-arg form, unsigned
+groupshared int64_t  SignedCounter;   // 2-arg form reaching a positive maximum
+groupshared uint64_t LargeCounter;    // 2-arg form exercising the upper 32 bits
+
+[numthreads(64, 1, 1)]
+void main(uint3 GTID : SV_GroupThreadID) {
+  if (GTID.x == 0) {
+    MaxInt = -1000;
+    MaxUInt = 0;
+    MaxIntNoOrig = -1000;
+    MaxUIntNoOrig = 0;
+    SignedCounter = -1000;
+    LargeCounter = 0; // grows into the upper 32 bits
+  }
+  GroupMemoryBarrierWithGroupSync();
+
+  // 3-argument form. Proposals span -32..31, max = 31. The concurrent
+  // re-read must never fall below the observed original (monotonic
+  // non-decrease).
+  int64_t origI;
+  InterlockedMax(MaxInt, (int64_t)GTID.x - 32, origI);
+  int64_t afterI = MaxInt;
+  OutMonoInt[GTID.x] = (afterI >= origI) ? 1u : 0u;
+
+  // 3-argument form, unsigned. Proposals span 0..63, max = 63.
+  uint64_t origU;
+  InterlockedMax(MaxUInt, (uint64_t)GTID.x, origU);
+  uint64_t afterU = MaxUInt;
+  OutMonoUInt[GTID.x] = (afterU >= origU) ? 1u : 0u;
+
+  // 2-argument form. Proposals span 0..-63, max = 0.
+  InterlockedMax(MaxIntNoOrig, -(int64_t)GTID.x);
+  // 2-argument form, unsigned. Proposals span 100..163, max = 163.
+  InterlockedMax(MaxUIntNoOrig, (uint64_t)GTID.x + 100);
+  // 2-argument form reaching a positive maximum. Proposals span 937..1000.
+  InterlockedMax(SignedCounter, (int64_t)GTID.x + 937);
+  // 2-argument form with a value that exercises the upper 32 bits,
+  // max = 2^32 + 63.
+  InterlockedMax(LargeCounter, 0x100000000ull + (uint64_t)GTID.x);
+
+  GroupMemoryBarrierWithGroupSync();
+
+  if (GTID.x == 0) {
+    OutFinal[0] = MaxInt;                 // 31
+    OutFinal[1] = (int64_t)MaxUInt;       // 63
+    OutFinal[2] = MaxIntNoOrig;           // 0
+    OutFinal[3] = (int64_t)MaxUIntNoOrig; // 163
+    OutFinal[4] = SignedCounter;          // 1000
+    OutFinal[5] = (int64_t)LargeCounter;  // 2^32 + 63 = 4294967359
+  }
+}
+
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+Buffers:
+  - Name: OutMonoInt
+    Format: UInt32
+    Stride: 4
+    FillSize: 256
+  - Name: ExpectedMonoInt
+    Format: UInt32
+    Stride: 4
+    Data: [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ]
+  - Name: OutMonoUInt
+    Format: UInt32
+    Stride: 4
+    FillSize: 256
+  - Name: ExpectedMonoUInt
+    Format: UInt32
+    Stride: 4
+    Data: [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ]
+  - Name: OutFinal
+    Format: Int64
+    Stride: 8
+    FillSize: 48
+  - Name: ExpectedFinal
+    Format: Int64
+    Stride: 8
+    Data: [ 31, 63, 0, 163, 1000, 4294967359 ]
+
+Results:
+  - Result: TestMonoInt
+    Rule: BufferExact
+    Actual: OutMonoInt
+    Expected: ExpectedMonoInt
+  - Result: TestMonoUInt
+    Rule: BufferExact
+    Actual: OutMonoUInt
+    Expected: ExpectedMonoUInt
+  - Result: TestFinal
+    Rule: BufferExact
+    Actual: OutFinal
+    Expected: ExpectedFinal
+DescriptorSets:
+  - Resources:
+    - Name: OutMonoInt
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: OutMonoUInt
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+    - Name: OutFinal
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 2
+        Space: 0
+      VulkanBinding:
+        Binding: 2
+...
+#--- end
+
+# REQUIRES: Int64 && Int64GroupSharedAtomics && SM_6_6
+
+# Unimplemented: https://github.com/llvm/llvm-project/issues/99124
+# XFAIL: Clang
+
+# Bug: https://github.com/llvm/offload-test-suite/issues/1164
+# XFAIL: DXC && Metal
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -HV 202x -T cs_6_6 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/InterlockedMax.int64.test
+++ b/test/Feature/HLSLLib/InterlockedMax.int64.test
@@ -1,9 +1,9 @@
 #--- source.hlsl
 
 // This test exercises InterlockedMax against non-resource (groupshared)
-// destinations using 64-bit integer types. A single threadgroup of 256
-// threads concurrently updates shared counters, so the test actually
-// exercises atomic behavior.
+// destinations using 64-bit integer types. A set of 256 threads
+// concurrently updates shared counters, so the test actually exercises
+// atomic behavior.
 //
 // Both the 2-argument and 3-argument overloads are covered for int64_t
 // and uint64_t.

--- a/test/Feature/HLSLLib/InterlockedMax.resources.32.test
+++ b/test/Feature/HLSLLib/InterlockedMax.resources.32.test
@@ -9,7 +9,7 @@
 //   * RWTexture2D<uint>[coord]             (free function on typed UAV)
 //   * RWByteAddressBuffer::InterlockedMax  (method, 2-arg and 3-arg)
 //
-// For each destination, 32 threads of a single threadgroup atomically take
+// For each destination, 256 threads of a single threadgroup atomically take
 // the maximum of their per-thread proposal and a single accumulator slot.
 
 RWStructuredBuffer<uint> SBufU : register(u0);
@@ -21,7 +21,7 @@ RWByteAddressBuffer      BABuf : register(u4);
 RWStructuredBuffer<uint> OutMonoSBufI : register(u5);
 RWStructuredBuffer<uint> OutMonoBABuf : register(u6);
 
-[numthreads(32, 1, 1)]
+[numthreads(256, 1, 1)]
 void main(uint3 GTID : SV_GroupThreadID) {
   if (GTID.x == 0) {
     SBufU[0] = 0u;
@@ -33,12 +33,12 @@ void main(uint3 GTID : SV_GroupThreadID) {
   }
   DeviceMemoryBarrierWithGroupSync();
 
-  // RWStructuredBuffer<uint>: 2-argument free function. Proposals 0..31,
-  // max = 31.
+  // RWStructuredBuffer<uint>: 2-argument free function. Proposals 0..255,
+  // max = 255.
   InterlockedMax(SBufU[0], GTID.x);
 
   // RWStructuredBuffer<int>: 3-argument free function (signed). Proposals
-  // 0..31, max = 31 (a positive proposal must beat the -1000 initializer).
+  // 0..255, max = 255 (a positive proposal must beat the -1000 initializer).
   // The concurrent re-read must never fall below the observed original
   // (monotonic non-decrease).
   int OrigI;
@@ -76,7 +76,7 @@ Buffers:
   - Name: ExpectedSBufU
     Format: UInt32
     Stride: 4
-    Data: [ 31 ]
+    Data: [ 255 ]
   - Name: SBufI
     Format: Int32
     Stride: 4
@@ -84,7 +84,7 @@ Buffers:
   - Name: ExpectedSBufI
     Format: Int32
     Stride: 4
-    Data: [ 31 ]
+    Data: [ 255 ]
   - Name: TBufU
     Format: UInt32
     Channels: 1
@@ -92,7 +92,7 @@ Buffers:
   - Name: ExpectedTBufU
     Format: UInt32
     Channels: 1
-    Data: [ 31 ]
+    Data: [ 255 ]
   - Name: Tex2D
     Format: UInt32
     Channels: 1
@@ -104,7 +104,7 @@ Buffers:
   - Name: ExpectedTex2D
     Format: UInt32
     Channels: 1
-    Data: [ 31 ]
+    Data: [ 255 ]
     OutputProps:
       Height: 1
       Width: 1
@@ -116,20 +116,34 @@ Buffers:
   - Name: ExpectedBABuf
     Format: UInt32
     Stride: 4
-    Data: [ 31, 31 ]
+    Data: [ 255, 255 ]
   - Name: OutMonoSBufI
     Format: UInt32
     Stride: 4
-    FillSize: 128
+    FillSize: 1024
   - Name: ExpectedMono
     Format: UInt32
     Stride: 4
     Data: [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ]
   - Name: OutMonoBABuf
     Format: UInt32
     Stride: 4
-    FillSize: 128
+    FillSize: 1024
 Results:
   - Result: TestSBufU
     Rule: BufferExact

--- a/test/Feature/HLSLLib/InterlockedMax.resources.32.test
+++ b/test/Feature/HLSLLib/InterlockedMax.resources.32.test
@@ -9,7 +9,7 @@
 //   * RWTexture2D<uint>[coord]             (free function on typed UAV)
 //   * RWByteAddressBuffer::InterlockedMax  (method, 2-arg and 3-arg)
 //
-// For each destination, 256 threads of a single threadgroup atomically take
+// For each destination, a set of 256 threads atomically take
 // the maximum of their per-thread proposal and a single accumulator slot.
 
 RWStructuredBuffer<uint> SBufU : register(u0);

--- a/test/Feature/HLSLLib/InterlockedMax.resources.32.test
+++ b/test/Feature/HLSLLib/InterlockedMax.resources.32.test
@@ -1,0 +1,224 @@
+#--- source.hlsl
+
+// This test exercises InterlockedMax against the full set of HLSL-legal
+// non-groupshared (resource) destination types:
+//
+//   * RWStructuredBuffer<uint>[i]          (free function, 2-arg)
+//   * RWStructuredBuffer<int>[i]           (free function, 3-arg, signed)
+//   * RWBuffer<uint>[i]                    (free function on typed UAV)
+//   * RWTexture2D<uint>[coord]             (free function on typed UAV)
+//   * RWByteAddressBuffer::InterlockedMax  (method, 2-arg and 3-arg)
+//
+// For each destination, 32 threads of a single threadgroup atomically take
+// the maximum of their per-thread proposal and a single accumulator slot.
+
+RWStructuredBuffer<uint> SBufU : register(u0);
+RWStructuredBuffer<int>  SBufI : register(u1);
+RWBuffer<uint>           TBufU : register(u2);
+RWTexture2D<uint>        Tex2D : register(u3);
+RWByteAddressBuffer      BABuf : register(u4);
+
+RWStructuredBuffer<uint> OutMonoSBufI : register(u5);
+RWStructuredBuffer<uint> OutMonoBABuf : register(u6);
+
+[numthreads(32, 1, 1)]
+void main(uint3 GTID : SV_GroupThreadID) {
+  if (GTID.x == 0) {
+    SBufU[0] = 0u;
+    SBufI[0] = -1000;
+    TBufU[0] = 0u;
+    Tex2D[uint2(0, 0)] = 0u;
+    BABuf.Store(0, 0u);    // accumulator for 2-arg method form
+    BABuf.Store(4, 0u);    // accumulator for 3-arg method form
+  }
+  DeviceMemoryBarrierWithGroupSync();
+
+  // RWStructuredBuffer<uint>: 2-argument free function. Proposals 0..31,
+  // max = 31.
+  InterlockedMax(SBufU[0], GTID.x);
+
+  // RWStructuredBuffer<int>: 3-argument free function (signed). Proposals
+  // 0..31, max = 31 (a positive proposal must beat the -1000 initializer).
+  // The concurrent re-read must never fall below the observed original
+  // (monotonic non-decrease).
+  int OrigI;
+  InterlockedMax(SBufI[0], (int)GTID.x, OrigI);
+  int AfterI = SBufI[0];
+  OutMonoSBufI[GTID.x] = (AfterI >= OrigI) ? 1u : 0u;
+
+  // RWBuffer<uint> (typed buffer UAV): 2-argument free function.
+  InterlockedMax(TBufU[0], GTID.x);
+
+  // RWTexture2D<uint>: 2-argument free function.
+  InterlockedMax(Tex2D[uint2(0, 0)], GTID.x);
+
+  // RWByteAddressBuffer method: 2-argument form.
+  BABuf.InterlockedMax(0, GTID.x);
+
+  // RWByteAddressBuffer method: 3-argument form.
+  uint OrigBA;
+  BABuf.InterlockedMax(4, GTID.x, OrigBA);
+  uint AfterBA = BABuf.Load(4);
+  OutMonoBABuf[GTID.x] = (AfterBA >= OrigBA) ? 1u : 0u;
+}
+
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+Buffers:
+  - Name: SBufU
+    Format: UInt32
+    Stride: 4
+    FillSize: 4
+  - Name: ExpectedSBufU
+    Format: UInt32
+    Stride: 4
+    Data: [ 31 ]
+  - Name: SBufI
+    Format: Int32
+    Stride: 4
+    FillSize: 4
+  - Name: ExpectedSBufI
+    Format: Int32
+    Stride: 4
+    Data: [ 31 ]
+  - Name: TBufU
+    Format: UInt32
+    Channels: 1
+    FillSize: 4
+  - Name: ExpectedTBufU
+    Format: UInt32
+    Channels: 1
+    Data: [ 31 ]
+  - Name: Tex2D
+    Format: UInt32
+    Channels: 1
+    FillSize: 4
+    OutputProps:
+      Height: 1
+      Width: 1
+      Depth: 1
+  - Name: ExpectedTex2D
+    Format: UInt32
+    Channels: 1
+    Data: [ 31 ]
+    OutputProps:
+      Height: 1
+      Width: 1
+      Depth: 1
+  - Name: BABuf
+    Format: UInt32
+    Stride: 4
+    FillSize: 8
+  - Name: ExpectedBABuf
+    Format: UInt32
+    Stride: 4
+    Data: [ 31, 31 ]
+  - Name: OutMonoSBufI
+    Format: UInt32
+    Stride: 4
+    FillSize: 128
+  - Name: ExpectedMono
+    Format: UInt32
+    Stride: 4
+    Data: [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ]
+  - Name: OutMonoBABuf
+    Format: UInt32
+    Stride: 4
+    FillSize: 128
+Results:
+  - Result: TestSBufU
+    Rule: BufferExact
+    Actual: SBufU
+    Expected: ExpectedSBufU
+  - Result: TestSBufI
+    Rule: BufferExact
+    Actual: SBufI
+    Expected: ExpectedSBufI
+  - Result: TestTBufU
+    Rule: BufferExact
+    Actual: TBufU
+    Expected: ExpectedTBufU
+  - Result: TestTex2D
+    Rule: BufferExact
+    Actual: Tex2D
+    Expected: ExpectedTex2D
+  - Result: TestBABuf
+    Rule: BufferExact
+    Actual: BABuf
+    Expected: ExpectedBABuf
+  - Result: TestMonoSBufI
+    Rule: BufferExact
+    Actual: OutMonoSBufI
+    Expected: ExpectedMono
+  - Result: TestMonoBABuf
+    Rule: BufferExact
+    Actual: OutMonoBABuf
+    Expected: ExpectedMono
+DescriptorSets:
+  - Resources:
+    - Name: SBufU
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: SBufI
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+    - Name: TBufU
+      Kind: RWBuffer
+      DirectXBinding:
+        Register: 2
+        Space: 0
+      VulkanBinding:
+        Binding: 2
+    - Name: Tex2D
+      Kind: RWTexture2D
+      DirectXBinding:
+        Register: 3
+        Space: 0
+      VulkanBinding:
+        Binding: 3
+    - Name: BABuf
+      Kind: RWByteAddressBuffer
+      DirectXBinding:
+        Register: 4
+        Space: 0
+      VulkanBinding:
+        Binding: 4
+    - Name: OutMonoSBufI
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 5
+        Space: 0
+      VulkanBinding:
+        Binding: 5
+    - Name: OutMonoBABuf
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 6
+        Space: 0
+      VulkanBinding:
+        Binding: 6
+...
+#--- end
+
+# Unimplemented: https://github.com/llvm/llvm-project/issues/99124
+# XFAIL: Clang
+
+# Bug: https://github.com/llvm/offload-test-suite/issues/1164
+# XFAIL: Metal && DXC
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/InterlockedMax.resources.int64.test
+++ b/test/Feature/HLSLLib/InterlockedMax.resources.int64.test
@@ -12,7 +12,7 @@
 // "AtomicInt64OnTypedResource" capability and are intentionally not
 // covered here, to keep this test portable across implementations.
 //
-// For each destination, 64 threads of a single threadgroup atomically take
+// For each destination, 256 threads of a single threadgroup atomically take
 // the maximum of their per-thread proposal and a single accumulator slot.
 // Every proposal sets bits in the upper 32 bits (0x100000000 + tid), so the
 // operation genuinely exercises all 64 bits rather than degenerating to a
@@ -25,7 +25,7 @@ RWByteAddressBuffer          BABuf : register(u2);
 RWStructuredBuffer<uint> OutMonoSBufI : register(u3);
 RWStructuredBuffer<uint> OutMonoBABuf : register(u4);
 
-[numthreads(64, 1, 1)]
+[numthreads(256, 1, 1)]
 void main(uint3 GTID : SV_GroupThreadID) {
   if (GTID.x == 0) {
     SBufU[0] = 0;
@@ -36,13 +36,13 @@ void main(uint3 GTID : SV_GroupThreadID) {
   DeviceMemoryBarrierWithGroupSync();
 
   // RWStructuredBuffer<uint64_t>: 2-argument free function. Proposals
-  // 2^32..2^32+63, max = 2^32 + 63.
+  // 2^32..2^32+255, max = 2^32 + 255.
   InterlockedMax(SBufU[0], 0x100000000ull + (uint64_t)GTID.x);
 
   // RWStructuredBuffer<int64_t>: 3-argument free function (signed).
-  // Proposals 2^32..2^32+63, max = 2^32 + 63 (a large positive proposal must
-  // beat the -1000 initializer). The concurrent re-read must never fall below
-  // the observed original (monotonic non-decrease).
+  // Proposals 2^32..2^32+255, max = 2^32 + 255 (a large positive proposal
+  // must beat the -1000 initializer). The concurrent re-read must never fall
+  // below the observed original (monotonic non-decrease).
   int64_t OrigI;
   InterlockedMax(SBufI[0], 0x100000000ll + (int64_t)GTID.x, OrigI);
   int64_t AfterI = SBufI[0];
@@ -72,7 +72,7 @@ Buffers:
   - Name: ExpectedSBufU
     Format: UInt64
     Stride: 8
-    Data: [ 4294967359 ]
+    Data: [ 4294967551 ]
   - Name: SBufI
     Format: Int64
     Stride: 8
@@ -80,7 +80,7 @@ Buffers:
   - Name: ExpectedSBufI
     Format: Int64
     Stride: 8
-    Data: [ 4294967359 ]
+    Data: [ 4294967551 ]
   - Name: BABuf
     Format: UInt64
     Stride: 8
@@ -88,22 +88,34 @@ Buffers:
   - Name: ExpectedBABuf
     Format: UInt64
     Stride: 8
-    Data: [ 4294967359, 4294967359 ]
+    Data: [ 4294967551, 4294967551 ]
   - Name: OutMonoSBufI
     Format: UInt32
     Stride: 4
-    FillSize: 256
+    FillSize: 1024
   - Name: ExpectedMono
     Format: UInt32
     Stride: 4
     Data: [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ]
   - Name: OutMonoBABuf
     Format: UInt32
     Stride: 4
-    FillSize: 256
+    FillSize: 1024
 Results:
   - Result: TestSBufU
     Rule: BufferExact

--- a/test/Feature/HLSLLib/InterlockedMax.resources.int64.test
+++ b/test/Feature/HLSLLib/InterlockedMax.resources.int64.test
@@ -1,0 +1,180 @@
+#--- source.hlsl
+
+// This test exercises InterlockedMax against the HLSL-legal 64-bit
+// non-groupshared (resource) destination types. 64-bit atomics on UAVs
+// were introduced in Shader Model 6.6.
+//
+//   * RWStructuredBuffer<uint64_t>[i]        (free function, 2-arg)
+//   * RWStructuredBuffer<int64_t>[i]         (free function, 3-arg, signed)
+//   * RWByteAddressBuffer::InterlockedMax64  (method, 2-arg and 3-arg)
+//
+// 64-bit atomics on typed RWBuffer / RWTexture require the optional
+// "AtomicInt64OnTypedResource" capability and are intentionally not
+// covered here, to keep this test portable across implementations.
+//
+// For each destination, 64 threads of a single threadgroup atomically take
+// the maximum of their per-thread proposal and a single accumulator slot.
+// Every proposal sets bits in the upper 32 bits (0x100000000 + tid), so the
+// operation genuinely exercises all 64 bits rather than degenerating to a
+// 32-bit update.
+
+RWStructuredBuffer<uint64_t> SBufU : register(u0);
+RWStructuredBuffer<int64_t>  SBufI : register(u1);
+RWByteAddressBuffer          BABuf : register(u2);
+
+RWStructuredBuffer<uint> OutMonoSBufI : register(u3);
+RWStructuredBuffer<uint> OutMonoBABuf : register(u4);
+
+[numthreads(64, 1, 1)]
+void main(uint3 GTID : SV_GroupThreadID) {
+  if (GTID.x == 0) {
+    SBufU[0] = 0;
+    SBufI[0] = -1000;
+    BABuf.Store<uint64_t>(0, 0); // accumulator for 2-arg method form
+    BABuf.Store<uint64_t>(8, 0); // accumulator for 3-arg method form
+  }
+  DeviceMemoryBarrierWithGroupSync();
+
+  // RWStructuredBuffer<uint64_t>: 2-argument free function. Proposals
+  // 2^32..2^32+63, max = 2^32 + 63.
+  InterlockedMax(SBufU[0], 0x100000000ull + (uint64_t)GTID.x);
+
+  // RWStructuredBuffer<int64_t>: 3-argument free function (signed).
+  // Proposals 2^32..2^32+63, max = 2^32 + 63 (a large positive proposal must
+  // beat the -1000 initializer). The concurrent re-read must never fall below
+  // the observed original (monotonic non-decrease).
+  int64_t OrigI;
+  InterlockedMax(SBufI[0], 0x100000000ll + (int64_t)GTID.x, OrigI);
+  int64_t AfterI = SBufI[0];
+  OutMonoSBufI[GTID.x] = (AfterI >= OrigI) ? 1u : 0u;
+
+  // RWByteAddressBuffer 64-bit method: 2-argument form.
+  BABuf.InterlockedMax64(0, 0x100000000ull + (uint64_t)GTID.x);
+
+  // RWByteAddressBuffer 64-bit method: 3-argument form.
+  uint64_t OrigBA;
+  BABuf.InterlockedMax64(8, 0x100000000ull + (uint64_t)GTID.x, OrigBA);
+  uint64_t AfterBA = BABuf.Load<uint64_t>(8);
+  OutMonoBABuf[GTID.x] = (AfterBA >= OrigBA) ? 1u : 0u;
+}
+
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+Buffers:
+  - Name: SBufU
+    Format: UInt64
+    Stride: 8
+    FillSize: 8
+  - Name: ExpectedSBufU
+    Format: UInt64
+    Stride: 8
+    Data: [ 4294967359 ]
+  - Name: SBufI
+    Format: Int64
+    Stride: 8
+    FillSize: 8
+  - Name: ExpectedSBufI
+    Format: Int64
+    Stride: 8
+    Data: [ 4294967359 ]
+  - Name: BABuf
+    Format: UInt64
+    Stride: 8
+    FillSize: 16
+  - Name: ExpectedBABuf
+    Format: UInt64
+    Stride: 8
+    Data: [ 4294967359, 4294967359 ]
+  - Name: OutMonoSBufI
+    Format: UInt32
+    Stride: 4
+    FillSize: 256
+  - Name: ExpectedMono
+    Format: UInt32
+    Stride: 4
+    Data: [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ]
+  - Name: OutMonoBABuf
+    Format: UInt32
+    Stride: 4
+    FillSize: 256
+Results:
+  - Result: TestSBufU
+    Rule: BufferExact
+    Actual: SBufU
+    Expected: ExpectedSBufU
+  - Result: TestSBufI
+    Rule: BufferExact
+    Actual: SBufI
+    Expected: ExpectedSBufI
+  - Result: TestBABuf
+    Rule: BufferExact
+    Actual: BABuf
+    Expected: ExpectedBABuf
+  - Result: TestMonoSBufI
+    Rule: BufferExact
+    Actual: OutMonoSBufI
+    Expected: ExpectedMono
+  - Result: TestMonoBABuf
+    Rule: BufferExact
+    Actual: OutMonoBABuf
+    Expected: ExpectedMono
+DescriptorSets:
+  - Resources:
+    - Name: SBufU
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: SBufI
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+    - Name: BABuf
+      Kind: RWByteAddressBuffer
+      DirectXBinding:
+        Register: 2
+        Space: 0
+      VulkanBinding:
+        Binding: 2
+    - Name: OutMonoSBufI
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 3
+        Space: 0
+      VulkanBinding:
+        Binding: 3
+    - Name: OutMonoBABuf
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 4
+        Space: 0
+      VulkanBinding:
+        Binding: 4
+...
+#--- end
+
+# Unimplemented: https://github.com/llvm/llvm-project/issues/99124
+# XFAIL: Clang
+
+# Bug: https://github.com/llvm/offload-test-suite/issues/1164
+# XFAIL: Metal && DXC
+
+# Unimplemented: https://github.com/microsoft/DirectXShaderCompiler/issues/8451
+# XFAIL: Vulkan && DXC
+
+# REQUIRES: Int64 && SM_6_6 && (!Vulkan || VulkanInt64BufferAtomics)
+# RUN: split-file %s %t
+# RUN: %dxc_target -HV 202x -T cs_6_6 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/InterlockedMax.resources.int64.test
+++ b/test/Feature/HLSLLib/InterlockedMax.resources.int64.test
@@ -12,7 +12,7 @@
 // "AtomicInt64OnTypedResource" capability and are intentionally not
 // covered here, to keep this test portable across implementations.
 //
-// For each destination, 256 threads of a single threadgroup atomically take
+// For each destination, a set of 256 threads atomically take
 // the maximum of their per-thread proposal and a single accumulator slot.
 // Every proposal sets bits in the upper 32 bits (0x100000000 + tid), so the
 // operation genuinely exercises all 64 bits rather than degenerating to a

--- a/test/Feature/HLSLLib/InterlockedMax.resources.typed.int64.test
+++ b/test/Feature/HLSLLib/InterlockedMax.resources.typed.int64.test
@@ -17,7 +17,7 @@
 //   * RWBuffer<uint64_t>[i]  (free function, 2-arg)
 //   * RWBuffer<int64_t>[i]   (free function, 3-arg, signed)
 //
-// 256 threads of a single threadgroup atomically take the maximum of their
+// A set of 256 threads atomically take the maximum of their
 // per-thread proposal and a single accumulator slot.
 
 RWBuffer<uint64_t> TBufU : register(u0);

--- a/test/Feature/HLSLLib/InterlockedMax.resources.typed.int64.test
+++ b/test/Feature/HLSLLib/InterlockedMax.resources.typed.int64.test
@@ -1,0 +1,130 @@
+#--- source.hlsl
+
+// This test exercises InterlockedMax on 64-bit typed RWBuffer resources.
+// 64-bit atomics on typed UAVs are an optional Shader Model 6.6 capability:
+//
+//   * DirectX:  cap AtomicInt64OnTypedResourceSupported
+//   * Vulkan:   shaderImageInt64Atomics, from the (non-core) extension
+//               VK_EXT_shader_image_atomic_int64. RWBuffer<T> in HLSL maps
+//               to a SPIR-V image (not an SSBO), so RWBuffer atomics on
+//               Vulkan require this image-atomics extension, not
+//               shaderBufferInt64Atomics. The same Vulkan feature also
+//               covers RWTexture<int64_t> typed-image atomics; this test
+//               only exercises RWBuffer.
+//
+// Both are surfaced to lit as `Int64TypedResourceAtomics`.
+//
+//   * RWBuffer<uint64_t>[i]  (free function, 2-arg)
+//   * RWBuffer<int64_t>[i]   (free function, 3-arg, signed)
+//
+// 64 threads of a single threadgroup atomically take the maximum of their
+// per-thread proposal and a single accumulator slot.
+
+RWBuffer<uint64_t> TBufU : register(u0);
+RWBuffer<int64_t>  TBufI : register(u1);
+
+RWStructuredBuffer<uint> OutMonoTBufI : register(u2);
+
+[numthreads(64, 1, 1)]
+void main(uint3 GTID : SV_GroupThreadID) {
+  if (GTID.x == 0) {
+    TBufU[0] = 0;
+    TBufI[0] = -1000;
+  }
+  DeviceMemoryBarrierWithGroupSync();
+
+  // RWBuffer<uint64_t>: 2-argument free function. Proposals 0..63, max = 63.
+  InterlockedMax(TBufU[0], (uint64_t)GTID.x);
+
+  // RWBuffer<int64_t>: 3-argument free function (signed). Proposals 0..63,
+  // max = 63 (a positive proposal must beat the -1000 initializer). The
+  // concurrent re-read must never fall below the observed original (monotonic
+  // non-decrease).
+  int64_t OrigI;
+  InterlockedMax(TBufI[0], (int64_t)GTID.x, OrigI);
+  int64_t AfterI = TBufI[0];
+  OutMonoTBufI[GTID.x] = (AfterI >= OrigI) ? 1u : 0u;
+}
+
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+Buffers:
+  - Name: TBufU
+    Format: UInt64
+    Channels: 1
+    FillSize: 8
+    FillValue: 137  # trash non-zero initialization data
+  - Name: ExpectedTBufU
+    Format: UInt64
+    Channels: 1
+    Data: [ 63 ]
+  - Name: TBufI
+    Format: Int64
+    Channels: 1
+    FillSize: 8
+    FillValue: 137  # trash non-zero initialization data
+  - Name: ExpectedTBufI
+    Format: Int64
+    Channels: 1
+    Data: [ 63 ]
+  - Name: OutMonoTBufI
+    Format: UInt32
+    Stride: 4
+    FillSize: 256
+  - Name: ExpectedMono
+    Format: UInt32
+    Stride: 4
+    Data: [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ]
+Results:
+  - Result: TestTBufU
+    Rule: BufferExact
+    Actual: TBufU
+    Expected: ExpectedTBufU
+  - Result: TestTBufI
+    Rule: BufferExact
+    Actual: TBufI
+    Expected: ExpectedTBufI
+  - Result: TestMonoTBufI
+    Rule: BufferExact
+    Actual: OutMonoTBufI
+    Expected: ExpectedMono
+DescriptorSets:
+  - Resources:
+    - Name: TBufU
+      Kind: RWBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: TBufI
+      Kind: RWBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+    - Name: OutMonoTBufI
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 2
+        Space: 0
+      VulkanBinding:
+        Binding: 2
+...
+#--- end
+
+# Unimplemented: https://github.com/llvm/llvm-project/issues/99124
+# XFAIL: Clang
+
+# REQUIRES: Int64TypedResourceAtomics && SM_6_6
+# RUN: split-file %s %t
+# RUN: %dxc_target -HV 202x -T cs_6_6 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/InterlockedMax.resources.typed.int64.test
+++ b/test/Feature/HLSLLib/InterlockedMax.resources.typed.int64.test
@@ -17,7 +17,7 @@
 //   * RWBuffer<uint64_t>[i]  (free function, 2-arg)
 //   * RWBuffer<int64_t>[i]   (free function, 3-arg, signed)
 //
-// 64 threads of a single threadgroup atomically take the maximum of their
+// 256 threads of a single threadgroup atomically take the maximum of their
 // per-thread proposal and a single accumulator slot.
 
 RWBuffer<uint64_t> TBufU : register(u0);
@@ -25,7 +25,7 @@ RWBuffer<int64_t>  TBufI : register(u1);
 
 RWStructuredBuffer<uint> OutMonoTBufI : register(u2);
 
-[numthreads(64, 1, 1)]
+[numthreads(256, 1, 1)]
 void main(uint3 GTID : SV_GroupThreadID) {
   if (GTID.x == 0) {
     TBufU[0] = 0;
@@ -33,11 +33,11 @@ void main(uint3 GTID : SV_GroupThreadID) {
   }
   DeviceMemoryBarrierWithGroupSync();
 
-  // RWBuffer<uint64_t>: 2-argument free function. Proposals 0..63, max = 63.
+  // RWBuffer<uint64_t>: 2-argument free function. Proposals 0..255, max = 255.
   InterlockedMax(TBufU[0], (uint64_t)GTID.x);
 
-  // RWBuffer<int64_t>: 3-argument free function (signed). Proposals 0..63,
-  // max = 63 (a positive proposal must beat the -1000 initializer). The
+  // RWBuffer<int64_t>: 3-argument free function (signed). Proposals 0..255,
+  // max = 255 (a positive proposal must beat the -1000 initializer). The
   // concurrent re-read must never fall below the observed original (monotonic
   // non-decrease).
   int64_t OrigI;
@@ -61,7 +61,7 @@ Buffers:
   - Name: ExpectedTBufU
     Format: UInt64
     Channels: 1
-    Data: [ 63 ]
+    Data: [ 255 ]
   - Name: TBufI
     Format: Int64
     Channels: 1
@@ -70,15 +70,27 @@ Buffers:
   - Name: ExpectedTBufI
     Format: Int64
     Channels: 1
-    Data: [ 63 ]
+    Data: [ 255 ]
   - Name: OutMonoTBufI
     Format: UInt32
     Stride: 4
-    FillSize: 256
+    FillSize: 1024
   - Name: ExpectedMono
     Format: UInt32
     Stride: 4
     Data: [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ]

--- a/test/Feature/HLSLLib/InterlockedMin.32.test
+++ b/test/Feature/HLSLLib/InterlockedMin.32.test
@@ -1,8 +1,8 @@
 #--- source.hlsl
 
 // This test exercises InterlockedMin against non-resource (groupshared)
-// destinations. A single threadgroup of 64 threads concurrently updates
-// shared counters, so the test actually exercises atomic behavior.
+// destinations. A set of 256 threads concurrently updates shared counters,
+// so the test actually exercises atomic behavior.
 //
 // Both the 2-argument and 3-argument overloads are covered for int and uint.
 //

--- a/test/Feature/HLSLLib/InterlockedMin.int64.test
+++ b/test/Feature/HLSLLib/InterlockedMin.int64.test
@@ -1,9 +1,9 @@
 #--- source.hlsl
 
 // This test exercises InterlockedMin against non-resource (groupshared)
-// destinations using 64-bit integer types. A single threadgroup of 64
-// threads concurrently updates shared counters, so the test actually
-// exercises atomic behavior.
+// destinations using 64-bit integer types. A set of 256 threads
+// concurrently updates shared counters, so the test actually exercises
+// atomic behavior.
 //
 // Both the 2-argument and 3-argument overloads are covered for int64_t
 // and uint64_t.

--- a/test/Feature/HLSLLib/InterlockedMin.resources.32.test
+++ b/test/Feature/HLSLLib/InterlockedMin.resources.32.test
@@ -9,7 +9,7 @@
 //   * RWTexture2D<uint>[coord]             (free function on typed UAV)
 //   * RWByteAddressBuffer::InterlockedMin  (method, 2-arg and 3-arg)
 //
-// For each destination, 256 threads of a single threadgroup atomically take
+// For each destination, a set of 256 threads atomically take
 // the minimum of their per-thread proposal and a single accumulator slot.
 
 RWStructuredBuffer<uint> SBufU : register(u0);

--- a/test/Feature/HLSLLib/InterlockedMin.resources.int64.test
+++ b/test/Feature/HLSLLib/InterlockedMin.resources.int64.test
@@ -12,7 +12,7 @@
 // "AtomicInt64OnTypedResource" capability and are intentionally not
 // covered here, to keep this test portable across implementations.
 //
-// For each destination, 256 threads of a single threadgroup atomically take
+// For each destination, a set of 256 threads atomically take
 // the minimum of their per-thread proposal and a single accumulator slot.
 
 RWStructuredBuffer<uint64_t> SBufU : register(u0);

--- a/test/Feature/HLSLLib/InterlockedMin.resources.typed.int64.test
+++ b/test/Feature/HLSLLib/InterlockedMin.resources.typed.int64.test
@@ -17,7 +17,7 @@
 //   * RWBuffer<uint64_t>[i]  (free function, 2-arg)
 //   * RWBuffer<int64_t>[i]   (free function, 3-arg, signed)
 //
-// 256 threads of a single threadgroup atomically take the minimum of their
+// A set of 256 threads atomically take the minimum of their
 // per-thread proposal and a single accumulator slot.
 
 RWBuffer<uint64_t> TBufU : register(u0);


### PR DESCRIPTION
This PR adds tests for the InterlockedMax function.
Adds 32 bit and 64 bit signed/unsigned integer tests, along with some resource member function tests.
Fixes https://github.com/llvm/offload-test-suite/issues/103
Assisted by: Github Copilot