### PR TITLE
Update Clang XFAILs for Texture2D SRVtoUAV tests

### DIFF
--- a/test/Feature/Textures/Texture2D.SRVToUAV.array.test.yaml
+++ b/test/Feature/Textures/Texture2D.SRVToUAV.array.test.yaml
@@ -86,10 +86,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Resource arrays are not yet implemented in Clang:
-# Unimplemented https://github.com/llvm/llvm-project/issues/133835
-# XFAIL: Clang
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/Textures/Texture2D.SRVToUAV.array.test.yaml
+++ b/test/Feature/Textures/Texture2D.SRVToUAV.array.test.yaml
@@ -87,7 +87,7 @@ DescriptorSets:
 #--- end
 
 # Unimplemented https://github.com/llvm/llvm-project/issues/194930
-# XFAIL: Clang && DirectX
+# XFAIL: Clang && !Vulkan
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl

--- a/test/Feature/Textures/Texture2D.SRVToUAV.array.test.yaml
+++ b/test/Feature/Textures/Texture2D.SRVToUAV.array.test.yaml
@@ -86,6 +86,9 @@ DescriptorSets:
 ...
 #--- end
 
+# Unimplemented https://github.com/llvm/llvm-project/issues/194930
+# XFAIL: Clang && DirectX
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/Textures/Texture2D.SRVToUAV.test.yaml
+++ b/test/Feature/Textures/Texture2D.SRVToUAV.test.yaml
@@ -69,9 +69,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Unimplemented: https://github.com/llvm/llvm-project/issues/175630 (for SPIRV)
-# XFAIL: Clang
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/Textures/Texture2D.SRVToUAV.test.yaml
+++ b/test/Feature/Textures/Texture2D.SRVToUAV.test.yaml
@@ -69,6 +69,9 @@ DescriptorSets:
 ...
 #--- end
 
+# Unimplemented https://github.com/llvm/llvm-project/issues/194930
+# XFAIL: Clang && DirectX
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/Textures/Texture2D.SRVToUAV.test.yaml
+++ b/test/Feature/Textures/Texture2D.SRVToUAV.test.yaml
@@ -70,7 +70,7 @@ DescriptorSets:
 #--- end
 
 # Unimplemented https://github.com/llvm/llvm-project/issues/194930
-# XFAIL: Clang && DirectX
+# XFAIL: Clang && !Vulkan
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl


### PR DESCRIPTION
The previously linked issues are closed and the tests now pass on Vulkan. They still fail on DirectX because texture store support has not been implemented.