### PR TITLE
[DX][NV] Remove XFAILs from 64-bit firstbitlow and firstbithigh tests

### DIFF
--- a/test/Feature/HLSLLib/firstbithigh.64.test
+++ b/test/Feature/HLSLLib/firstbithigh.64.test
@@ -94,9 +94,6 @@ DescriptorSets:
 # Bug https://github.com/llvm/offload-test-suite/issues/567
 # XFAIL: QC && Vulkan && Clang
 
-# Bug https://github.com/llvm/offload-test-suite/issues/324
-# XFAIL: NV && DirectX
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/firstbitlow.64.test
+++ b/test/Feature/HLSLLib/firstbitlow.64.test
@@ -85,9 +85,6 @@ DescriptorSets:
 # Bug https://github.com/llvm/offload-test-suite/issues/1024
 # XFAIL: QC && Vulkan && Clang
 
-# Bug https://github.com/llvm/offload-test-suite/issues/324
-# XFAIL: NV && DirectX
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
Seems the drivers in the NVIDIA machine were recently updated so the tests are now passing on DirectX