### PR TITLE
[NV] XFAIL `PartiallyMappedResources.test`

### DIFF
--- a/test/Feature/HLSLLib/PartiallyMappedResources.test
+++ b/test/Feature/HLSLLib/PartiallyMappedResources.test
@@ -149,6 +149,9 @@ DescriptorSets:
 # Bug https://github.com/llvm/offload-test-suite/issues/485
 # XFAIL: Intel
 
+# Bug https://github.com/llvm/offload-test-suite/issues/1365
+# XFAIL: NV
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
This test is failing on NVIDIA on both Clang and DXC.