### PR TITLE
Make `test-all` mutually exclusive to `test-dx-all` and `test-vk-all`

### DIFF
--- a/.github/workflows/pr-matrix.yaml
+++ b/.github/workflows/pr-matrix.yaml
@@ -100,7 +100,9 @@ jobs:
     permissions:
       contents: read
       checks: write
-    if: contains( github.event.pull_request.labels.*.name, 'test-dx-all')
+    if: >-
+      contains(github.event.pull_request.labels.*.name, 'test-dx-all')
+      && !contains(github.event.pull_request.labels.*.name, 'test-all')
     strategy:
       fail-fast: false
       matrix:
@@ -120,7 +122,9 @@ jobs:
     permissions:
       contents: read
       checks: write
-    if: contains( github.event.pull_request.labels.*.name, 'test-vk-all')
+    if: >-
+      contains(github.event.pull_request.labels.*.name, 'test-vk-all')
+      && !contains(github.event.pull_request.labels.*.name, 'test-all')
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This PR makes the `test-all` label mutually exclusive to `test-dx-all` and `test-vk-all`.

As it currently stands, if a PR gets labelled with `test-all` and `test-dx-all` or `test-vk-all`, there will be redundant test runs.
This PR makes it so that if the `test-all` label is used, then the `test-dx-all` and `test-vk-all` labels will have no effect.