### PR TITLE
[VK] XFAIL `matrix_swizzle_one_based.test` and `matrix_swizzle_zero_based.test` on Clang Vulkan

### DIFF
--- a/test/Basic/Matrix/matrix_swizzle_one_based.test
+++ b/test/Basic/Matrix/matrix_swizzle_one_based.test
@@ -112,6 +112,8 @@ DescriptorSets:
 ...
 #--- end
 
+# Unimplemented https://github.com/llvm/llvm-project/issues/209310
+# XFAIL: Clang && Vulkan
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl

--- a/test/Basic/Matrix/matrix_swizzle_zero_based.test
+++ b/test/Basic/Matrix/matrix_swizzle_zero_based.test
@@ -112,6 +112,8 @@ DescriptorSets:
 ...
 #--- end
 
+# Unimplemented https://github.com/llvm/llvm-project/issues/209310
+# XFAIL: Clang && Vulkan
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl


### PR DESCRIPTION
SPIRV's `createExitVariable` does not handle switch terminators yet, which is why these tests are crashing on Clang ([log](https://github.com/llvm/offload-test-suite/actions/runs/29267901253/job/86887038489#step:13:164)). Implementation of switch support will be tracked [here](https://github.com/llvm/llvm-project/issues/209310).

*Note: These tests started failing after llvm/llvm-project#205433 landed, which fixed behavior that previously masked the missing switch support.*