### PR TITLE
Add InterlockedXor tests

### DIFF
--- a/test/Feature/HLSLLib/InterlockedMax.resources.32.test
+++ b/test/Feature/HLSLLib/InterlockedMax.resources.32.test
@@ -73,6 +73,7 @@ Buffers:
     Format: UInt32
     Stride: 4
     FillSize: 4
+    FillValue: 137  # trash non-zero initialization data
   - Name: ExpectedSBufU
     Format: UInt32
     Stride: 4
@@ -81,6 +82,7 @@ Buffers:
     Format: Int32
     Stride: 4
     FillSize: 4
+    FillValue: 137  # trash non-zero initialization data
   - Name: ExpectedSBufI
     Format: Int32
     Stride: 4
@@ -89,6 +91,7 @@ Buffers:
     Format: UInt32
     Channels: 1
     FillSize: 4
+    FillValue: 137  # trash non-zero initialization data
   - Name: ExpectedTBufU
     Format: UInt32
     Channels: 1
@@ -97,6 +100,7 @@ Buffers:
     Format: UInt32
     Channels: 1
     FillSize: 4
+    FillValue: 137  # trash non-zero initialization data
     OutputProps:
       Height: 1
       Width: 1
@@ -113,6 +117,7 @@ Buffers:
     Format: UInt32
     Stride: 4
     FillSize: 8
+    FillValue: 137  # trash non-zero initialization data
   - Name: ExpectedBABuf
     Format: UInt32
     Stride: 4

--- a/test/Feature/HLSLLib/InterlockedMax.resources.int64.test
+++ b/test/Feature/HLSLLib/InterlockedMax.resources.int64.test
@@ -69,6 +69,7 @@ Buffers:
     Format: UInt64
     Stride: 8
     FillSize: 8
+    FillValue: 137  # trash non-zero initialization data
   - Name: ExpectedSBufU
     Format: UInt64
     Stride: 8
@@ -77,6 +78,7 @@ Buffers:
     Format: Int64
     Stride: 8
     FillSize: 8
+    FillValue: 137  # trash non-zero initialization data
   - Name: ExpectedSBufI
     Format: Int64
     Stride: 8
@@ -85,6 +87,7 @@ Buffers:
     Format: UInt64
     Stride: 8
     FillSize: 16
+    FillValue: 137  # trash non-zero initialization data
   - Name: ExpectedBABuf
     Format: UInt64
     Stride: 8

--- a/test/Feature/HLSLLib/InterlockedMin.resources.32.test
+++ b/test/Feature/HLSLLib/InterlockedMin.resources.32.test
@@ -72,6 +72,7 @@ Buffers:
     Format: UInt32
     Stride: 4
     FillSize: 4
+    FillValue: 137  # trash non-zero initialization data
   - Name: ExpectedSBufU
     Format: UInt32
     Stride: 4
@@ -80,6 +81,7 @@ Buffers:
     Format: Int32
     Stride: 4
     FillSize: 4
+    FillValue: 137  # trash non-zero initialization data
   - Name: ExpectedSBufI
     Format: Int32
     Stride: 4
@@ -88,6 +90,7 @@ Buffers:
     Format: UInt32
     Channels: 1
     FillSize: 4
+    FillValue: 137  # trash non-zero initialization data
   - Name: ExpectedTBufU
     Format: UInt32
     Channels: 1
@@ -96,6 +99,7 @@ Buffers:
     Format: UInt32
     Channels: 1
     FillSize: 4
+    FillValue: 137  # trash non-zero initialization data
     OutputProps:
       Height: 1
       Width: 1
@@ -112,6 +116,7 @@ Buffers:
     Format: UInt32
     Stride: 4
     FillSize: 8
+    FillValue: 137  # trash non-zero initialization data
   - Name: ExpectedBABuf
     Format: UInt32
     Stride: 4

--- a/test/Feature/HLSLLib/InterlockedMin.resources.int64.test
+++ b/test/Feature/HLSLLib/InterlockedMin.resources.int64.test
@@ -65,6 +65,7 @@ Buffers:
     Format: UInt64
     Stride: 8
     FillSize: 8
+    FillValue: 137  # trash non-zero initialization data
   - Name: ExpectedSBufU
     Format: UInt64
     Stride: 8
@@ -73,6 +74,7 @@ Buffers:
     Format: Int64
     Stride: 8
     FillSize: 8
+    FillValue: 137  # trash non-zero initialization data
   - Name: ExpectedSBufI
     Format: Int64
     Stride: 8
@@ -81,6 +83,7 @@ Buffers:
     Format: UInt64
     Stride: 8
     FillSize: 16
+    FillValue: 137  # trash non-zero initialization data
   - Name: ExpectedBABuf
     Format: UInt64
     Stride: 8

--- a/test/Feature/HLSLLib/InterlockedXor.32.test
+++ b/test/Feature/HLSLLib/InterlockedXor.32.test
@@ -1,0 +1,202 @@
+#--- source.hlsl
+
+// This test exercises InterlockedXor against non-resource (groupshared)
+// destinations. A set of 256 threads concurrently updates shared words, so
+// the test actually exercises atomic behavior.
+//
+// Both the 2-argument and 3-argument overloads are covered for int and uint.
+//
+// XOR is not monotonic in general -- XORing the same value into a single slot
+// just toggles a bit up and down -- so the InterlockedMax-style "re-read is
+// larger" check cannot be applied to one shared accumulator. Instead every
+// thread is assigned a *distinct* bit that starts at zero: thread t flips bit
+// (t % 32) of word (t / 32). Because each bit is owned by exactly one thread
+// and starts clear, XOR only ever sets bits (0 -> 1) and never clears them.
+// This makes the construction both deterministic and race-detecting, and
+// atomicity is verified two independent ways:
+//
+//   1. Final value. Each 32-bit word is touched by exactly 32 threads, one per
+//      bit, so its deterministic final value is all-ones (0xFFFFFFFF). A
+//      non-atomic read-modify-write can lose an update: two threads read the
+//      same word, each flips its own bit, and one write clobbers the other,
+//      leaving a bit clear. So a word can equal 0xFFFFFFFF only if no atomic
+//      XOR was lost.
+//
+//   2. Monotonicity (3-argument form). Because every XOR only sets a
+//      previously-zero bit, the word is strictly increasing in the unsigned
+//      bit domain. Immediately after this thread's atomic XOR returns `orig`,
+//      a fresh re-read of the word must be strictly greater than `orig` -- no
+//      other thread can clear a bit, so the observed value can never drop back
+//      to or below `orig`. A racy implementation that loses or reorders a
+//      sub-operation can make the re-read fail to exceed `orig`. Signed slots
+//      are compared in the unsigned bit domain because setting the sign bit
+//      makes the two's-complement value negative even though its bit pattern
+//      still grows. This correlates `orig` with a fresh observation of shared
+//      memory and checks every thread, so a correct implementation yields
+//      all-ones.
+
+RWStructuredBuffer<uint> OutMonoUInt : register(u0);
+RWStructuredBuffer<uint> OutMonoInt  : register(u1);
+RWStructuredBuffer<uint> OutFinal    : register(u2);
+
+groupshared uint XorUInt3[8];   // 3-arg form, unsigned
+groupshared int  XorInt3[8];    // 3-arg form, signed
+groupshared uint XorUInt2[8];   // 2-arg form, unsigned
+groupshared int  XorInt2[8];    // 2-arg form, signed
+
+[numthreads(256, 1, 1)]
+void main(uint3 GTID : SV_GroupThreadID) {
+  uint Tid  = GTID.x;
+  uint Word = Tid / 32;         // 0..7, one 32-bit word per 32 threads
+  uint Bit  = Tid % 32;         // 0..31, this thread's unique bit
+  uint MyBit = 1u << Bit;
+
+  if (Tid < 8) {
+    XorUInt3[Tid] = 0u;
+    XorInt3[Tid]  = 0;
+    XorUInt2[Tid] = 0u;
+    XorInt2[Tid]  = 0;
+  }
+  GroupMemoryBarrierWithGroupSync();
+
+  // 3-argument form, unsigned. Setting a previously-zero bit makes the word
+  // strictly larger, so the concurrent re-read must exceed the observed orig.
+  uint OrigU;
+  InterlockedXor(XorUInt3[Word], MyBit, OrigU);
+  uint AfterU = XorUInt3[Word];
+  OutMonoUInt[Tid] = (AfterU > OrigU) ? 1u : 0u;
+
+  // 3-argument form, signed. Compared in the unsigned bit domain because the
+  // sign bit flips the value negative even though its bit pattern still grows.
+  int OrigI;
+  InterlockedXor(XorInt3[Word], (int)MyBit, OrigI);
+  int AfterI = XorInt3[Word];
+  OutMonoInt[Tid] = (asuint(AfterI) > asuint(OrigI)) ? 1u : 0u;
+
+  // 2-argument forms.
+  InterlockedXor(XorUInt2[Word], MyBit);
+  InterlockedXor(XorInt2[Word], (int)MyBit);
+
+  GroupMemoryBarrierWithGroupSync();
+
+  if (Tid < 8) {
+    OutFinal[Tid]      = XorUInt3[Tid];        // 0xFFFFFFFF
+    OutFinal[8 + Tid]  = asuint(XorInt3[Tid]); // 0xFFFFFFFF
+    OutFinal[16 + Tid] = XorUInt2[Tid];        // 0xFFFFFFFF
+    OutFinal[24 + Tid] = asuint(XorInt2[Tid]); // 0xFFFFFFFF
+  }
+}
+
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+Buffers:
+  - Name: OutMonoUInt
+    Format: UInt32
+    Stride: 4
+    FillSize: 1024
+  - Name: ExpectedMonoUInt
+    Format: UInt32
+    Stride: 4
+    Data: [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ]
+  - Name: OutMonoInt
+    Format: UInt32
+    Stride: 4
+    FillSize: 1024
+  - Name: ExpectedMonoInt
+    Format: UInt32
+    Stride: 4
+    Data: [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ]
+  - Name: OutFinal
+    Format: UInt32
+    Stride: 4
+    FillSize: 128
+  - Name: ExpectedFinal
+    Format: UInt32
+    Stride: 4
+    Data: [ 4294967295, 4294967295, 4294967295, 4294967295,
+            4294967295, 4294967295, 4294967295, 4294967295,
+            4294967295, 4294967295, 4294967295, 4294967295,
+            4294967295, 4294967295, 4294967295, 4294967295,
+            4294967295, 4294967295, 4294967295, 4294967295,
+            4294967295, 4294967295, 4294967295, 4294967295,
+            4294967295, 4294967295, 4294967295, 4294967295,
+            4294967295, 4294967295, 4294967295, 4294967295 ]
+Results:
+  - Result: TestMonoUInt
+    Rule: BufferExact
+    Actual: OutMonoUInt
+    Expected: ExpectedMonoUInt
+  - Result: TestMonoInt
+    Rule: BufferExact
+    Actual: OutMonoInt
+    Expected: ExpectedMonoInt
+  - Result: TestFinal
+    Rule: BufferExact
+    Actual: OutFinal
+    Expected: ExpectedFinal
+DescriptorSets:
+  - Resources:
+    - Name: OutMonoUInt
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: OutMonoInt
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+    - Name: OutFinal
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 2
+        Space: 0
+      VulkanBinding:
+        Binding: 2
+...
+#--- end
+
+# Unimplemented: https://github.com/llvm/llvm-project/issues/99127
+# XFAIL: Clang
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/InterlockedXor.int64.test
+++ b/test/Feature/HLSLLib/InterlockedXor.int64.test
@@ -1,0 +1,182 @@
+#--- source.hlsl
+
+// This test exercises InterlockedXor against non-resource (groupshared)
+// destinations using 64-bit integer types. A set of 256 threads concurrently
+// updates shared words, so the test actually exercises atomic behavior. See
+// InterlockedXor.32.test for a full description of the unique-bit atomicity
+// construction; here each thread flips bit (t % 64) of word (t / 64), so every
+// bit (including the upper 32) is exercised and each word ends at all-ones.
+//
+// Both the 2-argument and 3-argument overloads are covered for int64_t and
+// uint64_t.
+
+RWStructuredBuffer<uint> OutMonoUInt : register(u0);
+RWStructuredBuffer<uint> OutMonoInt  : register(u1);
+RWStructuredBuffer<uint64_t> OutFinal : register(u2);
+
+groupshared uint64_t XorUInt3[4];   // 3-arg form, unsigned
+groupshared int64_t  XorInt3[4];    // 3-arg form, signed
+groupshared uint64_t XorUInt2[4];   // 2-arg form, unsigned
+groupshared int64_t  XorInt2[4];    // 2-arg form, signed
+
+[numthreads(256, 1, 1)]
+void main(uint3 GTID : SV_GroupThreadID) {
+  uint Tid  = GTID.x;
+  uint Word = Tid / 64;         // 0..3, one 64-bit word per 64 threads
+  uint Bit  = Tid % 64;         // 0..63, this thread's unique bit
+  uint64_t MyBit = 1ull << Bit;
+
+  if (Tid < 4) {
+    XorUInt3[Tid] = 0;
+    XorInt3[Tid]  = 0;
+    XorUInt2[Tid] = 0;
+    XorInt2[Tid]  = 0;
+  }
+  GroupMemoryBarrierWithGroupSync();
+
+  // 3-argument form, unsigned. Setting a previously-zero bit makes the word
+  // strictly larger, so the concurrent re-read must exceed the observed orig.
+  uint64_t OrigU;
+  InterlockedXor(XorUInt3[Word], MyBit, OrigU);
+  uint64_t AfterU = XorUInt3[Word];
+  OutMonoUInt[Tid] = (AfterU > OrigU) ? 1u : 0u;
+
+  // 3-argument form, signed. Compared in the unsigned bit domain because the
+  // sign bit flips the value negative even though its bit pattern still grows.
+  int64_t OrigI;
+  InterlockedXor(XorInt3[Word], (int64_t)MyBit, OrigI);
+  int64_t AfterI = XorInt3[Word];
+  OutMonoInt[Tid] = ((uint64_t)AfterI > (uint64_t)OrigI) ? 1u : 0u;
+
+  // 2-argument forms.
+  InterlockedXor(XorUInt2[Word], MyBit);
+  InterlockedXor(XorInt2[Word], (int64_t)MyBit);
+
+  GroupMemoryBarrierWithGroupSync();
+
+  if (Tid < 4) {
+    OutFinal[Tid]     = XorUInt3[Tid];           // 0xFFFFFFFFFFFFFFFF
+    OutFinal[4 + Tid] = (uint64_t)XorInt3[Tid];  // 0xFFFFFFFFFFFFFFFF
+    OutFinal[8 + Tid] = XorUInt2[Tid];           // 0xFFFFFFFFFFFFFFFF
+    OutFinal[12 + Tid] = (uint64_t)XorInt2[Tid]; // 0xFFFFFFFFFFFFFFFF
+  }
+}
+
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+Buffers:
+  - Name: OutMonoUInt
+    Format: UInt32
+    Stride: 4
+    FillSize: 1024
+  - Name: ExpectedMonoUInt
+    Format: UInt32
+    Stride: 4
+    Data: [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ]
+  - Name: OutMonoInt
+    Format: UInt32
+    Stride: 4
+    FillSize: 1024
+  - Name: ExpectedMonoInt
+    Format: UInt32
+    Stride: 4
+    Data: [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ]
+  - Name: OutFinal
+    Format: UInt64
+    Stride: 8
+    FillSize: 128
+  - Name: ExpectedFinal
+    Format: UInt64
+    Stride: 8
+    Data: [ 18446744073709551615, 18446744073709551615,
+            18446744073709551615, 18446744073709551615,
+            18446744073709551615, 18446744073709551615,
+            18446744073709551615, 18446744073709551615,
+            18446744073709551615, 18446744073709551615,
+            18446744073709551615, 18446744073709551615,
+            18446744073709551615, 18446744073709551615,
+            18446744073709551615, 18446744073709551615 ]
+Results:
+  - Result: TestMonoUInt
+    Rule: BufferExact
+    Actual: OutMonoUInt
+    Expected: ExpectedMonoUInt
+  - Result: TestMonoInt
+    Rule: BufferExact
+    Actual: OutMonoInt
+    Expected: ExpectedMonoInt
+  - Result: TestFinal
+    Rule: BufferExact
+    Actual: OutFinal
+    Expected: ExpectedFinal
+DescriptorSets:
+  - Resources:
+    - Name: OutMonoUInt
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: OutMonoInt
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+    - Name: OutFinal
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 2
+        Space: 0
+      VulkanBinding:
+        Binding: 2
+...
+#--- end
+
+# REQUIRES: Int64 && Int64GroupSharedAtomics && SM_6_6
+
+# Unimplemented: https://github.com/llvm/llvm-project/issues/99127
+# XFAIL: Clang
+
+# Bug: https://github.com/llvm/offload-test-suite/issues/1164
+# XFAIL: DXC && Metal
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -HV 202x -T cs_6_6 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/InterlockedXor.resources.32.test
+++ b/test/Feature/HLSLLib/InterlockedXor.resources.32.test
@@ -1,0 +1,251 @@
+#--- source.hlsl
+
+// This test exercises InterlockedXor against the full set of HLSL-legal
+// non-groupshared (resource) destination types:
+//
+//   * RWStructuredBuffer<uint>[i]          (free function, 2-arg)
+//   * RWStructuredBuffer<int>[i]           (free function, 3-arg, signed)
+//   * RWBuffer<uint>[i]                    (free function on typed UAV)
+//   * RWTexture2D<uint>[coord]             (free function on typed UAV)
+//   * RWByteAddressBuffer::InterlockedXor  (method, 2-arg and 3-arg)
+//
+// See InterlockedXor.32.test for a full description of the unique-bit
+// atomicity construction: each destination holds eight 32-bit words, thread t
+// flips bit (t % 32) of word (t / 32), so every word ends at all-ones
+// (0xFFFFFFFF) and each 3-arg re-read must strictly exceed the observed orig.
+
+RWStructuredBuffer<uint> SBufU : register(u0);
+RWStructuredBuffer<int>  SBufI : register(u1);
+RWBuffer<uint>           TBufU : register(u2);
+RWTexture2D<uint>        Tex2D : register(u3);
+RWByteAddressBuffer      BABuf : register(u4);
+
+RWStructuredBuffer<uint> OutMonoSBufI : register(u5);
+RWStructuredBuffer<uint> OutMonoBABuf : register(u6);
+
+[numthreads(256, 1, 1)]
+void main(uint3 GTID : SV_GroupThreadID) {
+  uint Tid  = GTID.x;
+  uint Word = Tid / 32;         // 0..7, one 32-bit slot per 32 threads
+  uint Bit  = Tid % 32;         // 0..31, this thread's unique bit
+  uint MyBit = 1u << Bit;
+  uint Off2  = Word * 4;        // BAB 2-arg region: byte offsets 0..28
+  uint Off3  = 32 + Word * 4;   // BAB 3-arg region: byte offsets 32..60
+
+  if (Tid < 8) {
+    SBufU[Tid] = 0u;
+    SBufI[Tid] = 0;
+    TBufU[Tid] = 0u;
+    Tex2D[uint2(Tid, 0)] = 0u;
+    BABuf.Store(Tid * 4, 0u);       // 2-arg accumulator words
+    BABuf.Store(32 + Tid * 4, 0u);  // 3-arg accumulator words
+  }
+  DeviceMemoryBarrierWithGroupSync();
+
+  // RWStructuredBuffer<uint>: 2-argument free function.
+  InterlockedXor(SBufU[Word], MyBit);
+
+  // RWStructuredBuffer<int>: 3-argument free function (signed). Compared in the
+  // unsigned bit domain; setting a previously-zero bit strictly grows the
+  // pattern, so the concurrent re-read must exceed the observed original.
+  int OrigI;
+  InterlockedXor(SBufI[Word], (int)MyBit, OrigI);
+  int AfterI = SBufI[Word];
+  OutMonoSBufI[Tid] = (asuint(AfterI) > asuint(OrigI)) ? 1u : 0u;
+
+  // RWBuffer<uint> (typed buffer UAV): 2-argument free function.
+  InterlockedXor(TBufU[Word], MyBit);
+
+  // RWTexture2D<uint>: 2-argument free function.
+  InterlockedXor(Tex2D[uint2(Word, 0)], MyBit);
+
+  // RWByteAddressBuffer method: 2-argument form.
+  BABuf.InterlockedXor(Off2, MyBit);
+
+  // RWByteAddressBuffer method: 3-argument form.
+  uint OrigBA;
+  BABuf.InterlockedXor(Off3, MyBit, OrigBA);
+  uint AfterBA = BABuf.Load(Off3);
+  OutMonoBABuf[Tid] = (AfterBA > OrigBA) ? 1u : 0u;
+}
+
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+Buffers:
+  - Name: SBufU
+    Format: UInt32
+    Stride: 4
+    FillSize: 32
+  - Name: ExpectedSBufU
+    Format: UInt32
+    Stride: 4
+    Data: [ 4294967295, 4294967295, 4294967295, 4294967295,
+            4294967295, 4294967295, 4294967295, 4294967295 ]
+  - Name: SBufI
+    Format: Int32
+    Stride: 4
+    FillSize: 32
+  - Name: ExpectedSBufI
+    Format: Int32
+    Stride: 4
+    Data: [ -1, -1, -1, -1, -1, -1, -1, -1 ]
+  - Name: TBufU
+    Format: UInt32
+    Channels: 1
+    FillSize: 32
+  - Name: ExpectedTBufU
+    Format: UInt32
+    Channels: 1
+    Data: [ 4294967295, 4294967295, 4294967295, 4294967295,
+            4294967295, 4294967295, 4294967295, 4294967295 ]
+  - Name: Tex2D
+    Format: UInt32
+    Channels: 1
+    FillSize: 32
+    OutputProps:
+      Height: 1
+      Width: 8
+      Depth: 1
+  - Name: ExpectedTex2D
+    Format: UInt32
+    Channels: 1
+    Data: [ 4294967295, 4294967295, 4294967295, 4294967295,
+            4294967295, 4294967295, 4294967295, 4294967295 ]
+    OutputProps:
+      Height: 1
+      Width: 8
+      Depth: 1
+  - Name: BABuf
+    Format: UInt32
+    Stride: 4
+    FillSize: 64
+  - Name: ExpectedBABuf
+    Format: UInt32
+    Stride: 4
+    Data: [ 4294967295, 4294967295, 4294967295, 4294967295,
+            4294967295, 4294967295, 4294967295, 4294967295,
+            4294967295, 4294967295, 4294967295, 4294967295,
+            4294967295, 4294967295, 4294967295, 4294967295 ]
+  - Name: OutMonoSBufI
+    Format: UInt32
+    Stride: 4
+    FillSize: 1024
+  - Name: ExpectedMono
+    Format: UInt32
+    Stride: 4
+    Data: [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ]
+  - Name: OutMonoBABuf
+    Format: UInt32
+    Stride: 4
+    FillSize: 1024
+Results:
+  - Result: TestSBufU
+    Rule: BufferExact
+    Actual: SBufU
+    Expected: ExpectedSBufU
+  - Result: TestSBufI
+    Rule: BufferExact
+    Actual: SBufI
+    Expected: ExpectedSBufI
+  - Result: TestTBufU
+    Rule: BufferExact
+    Actual: TBufU
+    Expected: ExpectedTBufU
+  - Result: TestTex2D
+    Rule: BufferExact
+    Actual: Tex2D
+    Expected: ExpectedTex2D
+  - Result: TestBABuf
+    Rule: BufferExact
+    Actual: BABuf
+    Expected: ExpectedBABuf
+  - Result: TestMonoSBufI
+    Rule: BufferExact
+    Actual: OutMonoSBufI
+    Expected: ExpectedMono
+  - Result: TestMonoBABuf
+    Rule: BufferExact
+    Actual: OutMonoBABuf
+    Expected: ExpectedMono
+DescriptorSets:
+  - Resources:
+    - Name: SBufU
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: SBufI
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+    - Name: TBufU
+      Kind: RWBuffer
+      DirectXBinding:
+        Register: 2
+        Space: 0
+      VulkanBinding:
+        Binding: 2
+    - Name: Tex2D
+      Kind: RWTexture2D
+      DirectXBinding:
+        Register: 3
+        Space: 0
+      VulkanBinding:
+        Binding: 3
+    - Name: BABuf
+      Kind: RWByteAddressBuffer
+      DirectXBinding:
+        Register: 4
+        Space: 0
+      VulkanBinding:
+        Binding: 4
+    - Name: OutMonoSBufI
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 5
+        Space: 0
+      VulkanBinding:
+        Binding: 5
+    - Name: OutMonoBABuf
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 6
+        Space: 0
+      VulkanBinding:
+        Binding: 6
+...
+#--- end
+
+# Unimplemented: https://github.com/llvm/llvm-project/issues/99127
+# XFAIL: Clang
+
+# Bug: https://github.com/llvm/offload-test-suite/issues/1164
+# XFAIL: Metal && DXC
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/InterlockedXor.resources.32.test
+++ b/test/Feature/HLSLLib/InterlockedXor.resources.32.test
@@ -10,8 +10,9 @@
 //   * RWByteAddressBuffer::InterlockedXor  (method, 2-arg and 3-arg)
 //
 // See InterlockedXor.32.test for a full description of the unique-bit
-// atomicity construction: each destination holds eight 32-bit words, thread t
-// flips bit (t % 32) of word (t / 32), so every word ends at all-ones
+// atomicity construction: SBufU, SBufI, TBufU and Tex2D hold eight 32-bit
+// words each while BABuf holds sixteen (two 8-word accumulator regions);
+// thread t flips bit (t % 32) of word (t / 32), so every word ends at all-ones
 // (0xFFFFFFFF) and each 3-arg re-read must strictly exceed the observed orig.
 
 RWStructuredBuffer<uint> SBufU : register(u0);
@@ -80,6 +81,7 @@ Buffers:
     Format: UInt32
     Stride: 4
     FillSize: 32
+    FillValue: 137  # trash non-zero initialization data
   - Name: ExpectedSBufU
     Format: UInt32
     Stride: 4
@@ -89,6 +91,7 @@ Buffers:
     Format: Int32
     Stride: 4
     FillSize: 32
+    FillValue: 137  # trash non-zero initialization data
   - Name: ExpectedSBufI
     Format: Int32
     Stride: 4
@@ -97,6 +100,7 @@ Buffers:
     Format: UInt32
     Channels: 1
     FillSize: 32
+    FillValue: 137  # trash non-zero initialization data
   - Name: ExpectedTBufU
     Format: UInt32
     Channels: 1
@@ -106,6 +110,7 @@ Buffers:
     Format: UInt32
     Channels: 1
     FillSize: 32
+    FillValue: 137  # trash non-zero initialization data
     OutputProps:
       Height: 1
       Width: 8
@@ -123,6 +128,7 @@ Buffers:
     Format: UInt32
     Stride: 4
     FillSize: 64
+    FillValue: 137  # trash non-zero initialization data
   - Name: ExpectedBABuf
     Format: UInt32
     Stride: 4

--- a/test/Feature/HLSLLib/InterlockedXor.resources.int64.test
+++ b/test/Feature/HLSLLib/InterlockedXor.resources.int64.test
@@ -13,8 +13,9 @@
 // covered here, to keep this test portable across implementations.
 //
 // See InterlockedXor.32.test for a full description of the unique-bit
-// atomicity construction: each destination holds four 64-bit words, thread t
-// flips bit (t % 64) of word (t / 64), so every word ends at all-ones
+// atomicity construction: SBufU and SBufI hold four 64-bit words each while
+// BABuf holds eight (two 4-word accumulator regions); thread t flips bit
+// (t % 64) of word (t / 64), so every word ends at all-ones
 // (0xFFFFFFFFFFFFFFFF) and each 3-arg re-read must strictly exceed orig.
 // Because every thread with (t % 64) >= 32 sets a bit in the upper 32 bits,
 // the operation genuinely exercises all 64 bits rather than degenerating to a
@@ -76,6 +77,7 @@ Buffers:
     Format: UInt64
     Stride: 8
     FillSize: 32
+    FillValue: 137  # trash non-zero initialization data
   - Name: ExpectedSBufU
     Format: UInt64
     Stride: 8
@@ -85,6 +87,7 @@ Buffers:
     Format: Int64
     Stride: 8
     FillSize: 32
+    FillValue: 137  # trash non-zero initialization data
   - Name: ExpectedSBufI
     Format: Int64
     Stride: 8
@@ -93,6 +96,7 @@ Buffers:
     Format: UInt64
     Stride: 8
     FillSize: 64
+    FillValue: 137  # trash non-zero initialization data
   - Name: ExpectedBABuf
     Format: UInt64
     Stride: 8

--- a/test/Feature/HLSLLib/InterlockedXor.resources.int64.test
+++ b/test/Feature/HLSLLib/InterlockedXor.resources.int64.test
@@ -1,0 +1,203 @@
+#--- source.hlsl
+
+// This test exercises InterlockedXor against the HLSL-legal 64-bit
+// non-groupshared (resource) destination types. 64-bit atomics on UAVs were
+// introduced in Shader Model 6.6.
+//
+//   * RWStructuredBuffer<uint64_t>[i]        (free function, 2-arg)
+//   * RWStructuredBuffer<int64_t>[i]         (free function, 3-arg, signed)
+//   * RWByteAddressBuffer::InterlockedXor64  (method, 2-arg and 3-arg)
+//
+// 64-bit atomics on typed RWBuffer / RWTexture require the optional
+// "AtomicInt64OnTypedResource" capability and are intentionally not
+// covered here, to keep this test portable across implementations.
+//
+// See InterlockedXor.32.test for a full description of the unique-bit
+// atomicity construction: each destination holds four 64-bit words, thread t
+// flips bit (t % 64) of word (t / 64), so every word ends at all-ones
+// (0xFFFFFFFFFFFFFFFF) and each 3-arg re-read must strictly exceed orig.
+// Because every thread with (t % 64) >= 32 sets a bit in the upper 32 bits,
+// the operation genuinely exercises all 64 bits rather than degenerating to a
+// 32-bit update.
+
+RWStructuredBuffer<uint64_t> SBufU : register(u0);
+RWStructuredBuffer<int64_t>  SBufI : register(u1);
+RWByteAddressBuffer          BABuf : register(u2);
+
+RWStructuredBuffer<uint> OutMonoSBufI : register(u3);
+RWStructuredBuffer<uint> OutMonoBABuf : register(u4);
+
+[numthreads(256, 1, 1)]
+void main(uint3 GTID : SV_GroupThreadID) {
+  uint Tid  = GTID.x;
+  uint Word = Tid / 64;         // 0..3, one 64-bit slot per 64 threads
+  uint Bit  = Tid % 64;         // 0..63, this thread's unique bit
+  uint64_t MyBit = 1ull << Bit;
+  uint Off2 = Word * 8;         // BAB 2-arg region: byte offsets 0..24
+  uint Off3 = 32 + Word * 8;    // BAB 3-arg region: byte offsets 32..56
+
+  if (Tid < 4) {
+    SBufU[Tid] = 0;
+    SBufI[Tid] = 0;
+    BABuf.Store<uint64_t>(Tid * 8, 0);       // 2-arg accumulator words
+    BABuf.Store<uint64_t>(32 + Tid * 8, 0);  // 3-arg accumulator words
+  }
+  DeviceMemoryBarrierWithGroupSync();
+
+  // RWStructuredBuffer<uint64_t>: 2-argument free function.
+  InterlockedXor(SBufU[Word], MyBit);
+
+  // RWStructuredBuffer<int64_t>: 3-argument free function (signed). Compared in
+  // the unsigned bit domain; setting a previously-zero bit strictly grows the
+  // pattern, so the concurrent re-read must exceed the observed original.
+  int64_t OrigI;
+  InterlockedXor(SBufI[Word], (int64_t)MyBit, OrigI);
+  int64_t AfterI = SBufI[Word];
+  OutMonoSBufI[Tid] = ((uint64_t)AfterI > (uint64_t)OrigI) ? 1u : 0u;
+
+  // RWByteAddressBuffer 64-bit method: 2-argument form.
+  BABuf.InterlockedXor64(Off2, MyBit);
+
+  // RWByteAddressBuffer 64-bit method: 3-argument form.
+  uint64_t OrigBA;
+  BABuf.InterlockedXor64(Off3, MyBit, OrigBA);
+  uint64_t AfterBA = BABuf.Load<uint64_t>(Off3);
+  OutMonoBABuf[Tid] = (AfterBA > OrigBA) ? 1u : 0u;
+}
+
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+Buffers:
+  - Name: SBufU
+    Format: UInt64
+    Stride: 8
+    FillSize: 32
+  - Name: ExpectedSBufU
+    Format: UInt64
+    Stride: 8
+    Data: [ 18446744073709551615, 18446744073709551615,
+            18446744073709551615, 18446744073709551615 ]
+  - Name: SBufI
+    Format: Int64
+    Stride: 8
+    FillSize: 32
+  - Name: ExpectedSBufI
+    Format: Int64
+    Stride: 8
+    Data: [ -1, -1, -1, -1 ]
+  - Name: BABuf
+    Format: UInt64
+    Stride: 8
+    FillSize: 64
+  - Name: ExpectedBABuf
+    Format: UInt64
+    Stride: 8
+    Data: [ 18446744073709551615, 18446744073709551615,
+            18446744073709551615, 18446744073709551615,
+            18446744073709551615, 18446744073709551615,
+            18446744073709551615, 18446744073709551615 ]
+  - Name: OutMonoSBufI
+    Format: UInt32
+    Stride: 4
+    FillSize: 1024
+  - Name: ExpectedMono
+    Format: UInt32
+    Stride: 4
+    Data: [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ]
+  - Name: OutMonoBABuf
+    Format: UInt32
+    Stride: 4
+    FillSize: 1024
+Results:
+  - Result: TestSBufU
+    Rule: BufferExact
+    Actual: SBufU
+    Expected: ExpectedSBufU
+  - Result: TestSBufI
+    Rule: BufferExact
+    Actual: SBufI
+    Expected: ExpectedSBufI
+  - Result: TestBABuf
+    Rule: BufferExact
+    Actual: BABuf
+    Expected: ExpectedBABuf
+  - Result: TestMonoSBufI
+    Rule: BufferExact
+    Actual: OutMonoSBufI
+    Expected: ExpectedMono
+  - Result: TestMonoBABuf
+    Rule: BufferExact
+    Actual: OutMonoBABuf
+    Expected: ExpectedMono
+DescriptorSets:
+  - Resources:
+    - Name: SBufU
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: SBufI
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+    - Name: BABuf
+      Kind: RWByteAddressBuffer
+      DirectXBinding:
+        Register: 2
+        Space: 0
+      VulkanBinding:
+        Binding: 2
+    - Name: OutMonoSBufI
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 3
+        Space: 0
+      VulkanBinding:
+        Binding: 3
+    - Name: OutMonoBABuf
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 4
+        Space: 0
+      VulkanBinding:
+        Binding: 4
+...
+#--- end
+
+# Unimplemented: https://github.com/llvm/llvm-project/issues/99127
+# XFAIL: Clang
+
+# Bug: https://github.com/llvm/offload-test-suite/issues/1164
+# XFAIL: Metal && DXC
+
+# Unimplemented: https://github.com/microsoft/DirectXShaderCompiler/issues/8451
+# XFAIL: Vulkan && DXC
+
+# REQUIRES: Int64 && SM_6_6 && (!Vulkan || VulkanInt64BufferAtomics)
+# RUN: split-file %s %t
+# RUN: %dxc_target -HV 202x -T cs_6_6 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/InterlockedXor.resources.typed.int64.test
+++ b/test/Feature/HLSLLib/InterlockedXor.resources.typed.int64.test
@@ -1,0 +1,149 @@
+#--- source.hlsl
+
+// This test exercises InterlockedXor on 64-bit typed RWBuffer resources.
+// 64-bit atomics on typed UAVs are an optional Shader Model 6.6 capability:
+//
+//   * DirectX:  cap AtomicInt64OnTypedResourceSupported
+//   * Vulkan:   shaderImageInt64Atomics, from the (non-core) extension
+//               VK_EXT_shader_image_atomic_int64. RWBuffer<T> in HLSL maps
+//               to a SPIR-V image (not an SSBO), so RWBuffer atomics on
+//               Vulkan require this image-atomics extension, not
+//               shaderBufferInt64Atomics. The same Vulkan feature also
+//               covers RWTexture<int64_t> typed-image atomics; this test
+//               only exercises RWBuffer.
+//
+// Both are surfaced to lit as `Int64TypedResourceAtomics`.
+//
+//   * RWBuffer<uint64_t>[i]  (free function, 2-arg)
+//   * RWBuffer<int64_t>[i]   (free function, 3-arg, signed)
+//
+// See InterlockedXor.32.test for a full description of the unique-bit
+// atomicity construction: each buffer holds four 64-bit words, thread t flips
+// bit (t % 64) of word (t / 64), so every word ends at all-ones
+// (0xFFFFFFFFFFFFFFFF) and each 3-arg re-read must strictly exceed orig.
+
+RWBuffer<uint64_t> TBufU : register(u0);
+RWBuffer<int64_t>  TBufI : register(u1);
+
+RWStructuredBuffer<uint> OutMonoTBufI : register(u2);
+
+[numthreads(256, 1, 1)]
+void main(uint3 GTID : SV_GroupThreadID) {
+  uint Tid  = GTID.x;
+  uint Word = Tid / 64;         // 0..3, one 64-bit slot per 64 threads
+  uint Bit  = Tid % 64;         // 0..63, this thread's unique bit
+  uint64_t MyBit = 1ull << Bit;
+
+  if (Tid < 4) {
+    TBufU[Tid] = 0;
+    TBufI[Tid] = 0;
+  }
+  DeviceMemoryBarrierWithGroupSync();
+
+  // RWBuffer<uint64_t>: 2-argument free function.
+  InterlockedXor(TBufU[Word], MyBit);
+
+  // RWBuffer<int64_t>: 3-argument free function (signed). Compared in the
+  // unsigned bit domain; setting a previously-zero bit strictly grows the
+  // pattern, so the concurrent re-read must exceed the observed original.
+  int64_t OrigI;
+  InterlockedXor(TBufI[Word], (int64_t)MyBit, OrigI);
+  int64_t AfterI = TBufI[Word];
+  OutMonoTBufI[Tid] = ((uint64_t)AfterI > (uint64_t)OrigI) ? 1u : 0u;
+}
+
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+Buffers:
+  - Name: TBufU
+    Format: UInt64
+    Channels: 1
+    FillSize: 32
+    FillValue: 137  # trash non-zero initialization data
+  - Name: ExpectedTBufU
+    Format: UInt64
+    Channels: 1
+    Data: [ 18446744073709551615, 18446744073709551615,
+            18446744073709551615, 18446744073709551615 ]
+  - Name: TBufI
+    Format: Int64
+    Channels: 1
+    FillSize: 32
+    FillValue: 137  # trash non-zero initialization data
+  - Name: ExpectedTBufI
+    Format: Int64
+    Channels: 1
+    Data: [ -1, -1, -1, -1 ]
+  - Name: OutMonoTBufI
+    Format: UInt32
+    Stride: 4
+    FillSize: 1024
+  - Name: ExpectedMono
+    Format: UInt32
+    Stride: 4
+    Data: [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ]
+Results:
+  - Result: TestTBufU
+    Rule: BufferExact
+    Actual: TBufU
+    Expected: ExpectedTBufU
+  - Result: TestTBufI
+    Rule: BufferExact
+    Actual: TBufI
+    Expected: ExpectedTBufI
+  - Result: TestMonoTBufI
+    Rule: BufferExact
+    Actual: OutMonoTBufI
+    Expected: ExpectedMono
+DescriptorSets:
+  - Resources:
+    - Name: TBufU
+      Kind: RWBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: TBufI
+      Kind: RWBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+    - Name: OutMonoTBufI
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 2
+        Space: 0
+      VulkanBinding:
+        Binding: 2
+...
+#--- end
+
+# Unimplemented: https://github.com/llvm/llvm-project/issues/99127
+# XFAIL: Clang
+
+# REQUIRES: Int64TypedResourceAtomics && SM_6_6
+# RUN: split-file %s %t
+# RUN: %dxc_target -HV 202x -T cs_6_6 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
This PR implements the tests for the InterlockedXor HLSL function.
Adds 32 bit and 64 bit signed/unsigned integer tests, along with some resource member function tests.

Assisted by: Github Copilot
Fixes: https://github.com/llvm/offload-test-suite/issues/855