### PR TITLE
[NFC] Fix clang-tidy issues

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,13 @@
-Checks: '-*,clang-diagnostic-*,llvm-*,misc-*,-misc-use-anonymous-namespace,-misc-include-cleaner,-misc-non-private-member-variables-in-classes,readability-identifier-naming'
+Checks: >
+        -*,
+        clang-diagnostic-*,
+        llvm-*,
+        -llvm-header-guard,
+        misc-*,
+        -misc-use-anonymous-namespace,
+        -misc-include-cleaner,
+        -misc-non-private-member-variables-in-classes,
+        readability-identifier-naming
 WarningsAsErrors: '*'
 CheckOptions:
   - key:             readability-identifier-naming.ClassCase

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -7,6 +7,7 @@ Checks: >
         -misc-use-anonymous-namespace,
         -misc-include-cleaner,
         -misc-non-private-member-variables-in-classes,
+        -misc-const-correctness,
         readability-identifier-naming
 WarningsAsErrors: '*'
 CheckOptions:

--- a/.github/workflows/macos-clang-mtl.yaml
+++ b/.github/workflows/macos-clang-mtl.yaml
@@ -22,4 +22,3 @@ jobs:
       SKU: macos
       TestTarget: check-hlsl-clang-mtl
       OffloadTest-branch: ${{ github.ref }}
-      LLVM-ExtraCMakeArgs: -DOFFLOADTEST_USE_CLANG_TIDY=ON

--- a/.github/workflows/macos-clang-mtl.yaml
+++ b/.github/workflows/macos-clang-mtl.yaml
@@ -22,3 +22,4 @@ jobs:
       SKU: macos
       TestTarget: check-hlsl-clang-mtl
       OffloadTest-branch: ${{ github.ref }}
+      LLVM-ExtraCMakeArgs: -DOFFLOADTEST_USE_CLANG_TIDY=ON

--- a/.github/workflows/macos-dxc-mtl.yaml
+++ b/.github/workflows/macos-dxc-mtl.yaml
@@ -22,4 +22,3 @@ jobs:
       SKU: macos
       TestTarget: check-hlsl-mtl
       OffloadTest-branch: ${{ github.ref }}
-      LLVM-ExtraCMakeArgs: -DOFFLOADTEST_USE_CLANG_TIDY=ON

--- a/.github/workflows/macos-dxc-mtl.yaml
+++ b/.github/workflows/macos-dxc-mtl.yaml
@@ -22,3 +22,4 @@ jobs:
       SKU: macos
       TestTarget: check-hlsl-mtl
       OffloadTest-branch: ${{ github.ref }}
+      LLVM-ExtraCMakeArgs: -DOFFLOADTEST_USE_CLANG_TIDY=ON

--- a/.github/workflows/pr-matrix.yaml
+++ b/.github/workflows/pr-matrix.yaml
@@ -34,7 +34,7 @@ jobs:
       TestTarget: ${{ matrix.TestTarget }}
       OffloadTest-branch: ${{ github.event.pull_request.head.sha }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl
 
   Exec-Tests-Windows-Warp:
     permissions:
@@ -56,7 +56,7 @@ jobs:
       TestTarget: ${{ matrix.TestTarget }}
       OffloadTest-branch: ${{ github.event.pull_request.head.sha }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl
 
   Exec-Tests-Extra:
     permissions:
@@ -81,7 +81,7 @@ jobs:
       TestTarget: ${{ matrix.TestTarget }}
       OffloadTest-branch: ${{ github.event.pull_request.head.sha }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl
 
   Exec-Tests-Extra-Lavapipe:
     permissions:
@@ -103,7 +103,7 @@ jobs:
       TestTarget: ${{ matrix.TestTarget }}
       OffloadTest-branch: ${{ github.event.pull_request.head.sha }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl
 
   Exec-Tests-Extra-DX-All:
     permissions:
@@ -125,7 +125,7 @@ jobs:
       TestTarget: ${{ matrix.TestTarget }}
       OffloadTest-branch: ${{ github.event.pull_request.head.sha }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl
 
   Exec-Tests-Extra-VK-All:
     permissions:
@@ -150,7 +150,7 @@ jobs:
       TestTarget: ${{ matrix.TestTarget }}
       OffloadTest-branch: ${{ github.event.pull_request.head.sha }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl
 
   Exec-Tests-MacOS:
     permissions:

--- a/.github/workflows/pr-matrix.yaml
+++ b/.github/workflows/pr-matrix.yaml
@@ -34,7 +34,7 @@ jobs:
       TestTarget: ${{ matrix.TestTarget }}
       OffloadTest-branch: ${{ github.event.pull_request.head.sha }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON
 
   Exec-Tests-Windows-Warp:
     permissions:
@@ -56,7 +56,7 @@ jobs:
       TestTarget: ${{ matrix.TestTarget }}
       OffloadTest-branch: ${{ github.event.pull_request.head.sha }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON
 
   Exec-Tests-Extra:
     permissions:
@@ -81,7 +81,7 @@ jobs:
       TestTarget: ${{ matrix.TestTarget }}
       OffloadTest-branch: ${{ github.event.pull_request.head.sha }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON
 
   Exec-Tests-Extra-Lavapipe:
     permissions:
@@ -103,7 +103,7 @@ jobs:
       TestTarget: ${{ matrix.TestTarget }}
       OffloadTest-branch: ${{ github.event.pull_request.head.sha }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON
 
   Exec-Tests-Extra-DX-All:
     permissions:
@@ -125,7 +125,7 @@ jobs:
       TestTarget: ${{ matrix.TestTarget }}
       OffloadTest-branch: ${{ github.event.pull_request.head.sha }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON
 
   Exec-Tests-Extra-VK-All:
     permissions:
@@ -150,7 +150,7 @@ jobs:
       TestTarget: ${{ matrix.TestTarget }}
       OffloadTest-branch: ${{ github.event.pull_request.head.sha }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON
 
   Exec-Tests-MacOS:
     permissions:

--- a/.github/workflows/pr-matrix.yaml
+++ b/.github/workflows/pr-matrix.yaml
@@ -34,7 +34,7 @@ jobs:
       TestTarget: ${{ matrix.TestTarget }}
       OffloadTest-branch: ${{ github.event.pull_request.head.sha }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=On
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON
 
   Exec-Tests-Windows-Warp:
     permissions:
@@ -56,7 +56,7 @@ jobs:
       TestTarget: ${{ matrix.TestTarget }}
       OffloadTest-branch: ${{ github.event.pull_request.head.sha }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=On
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON
 
   Exec-Tests-Extra:
     permissions:
@@ -81,7 +81,7 @@ jobs:
       TestTarget: ${{ matrix.TestTarget }}
       OffloadTest-branch: ${{ github.event.pull_request.head.sha }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=On
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON
 
   Exec-Tests-Extra-Lavapipe:
     permissions:
@@ -103,7 +103,7 @@ jobs:
       TestTarget: ${{ matrix.TestTarget }}
       OffloadTest-branch: ${{ github.event.pull_request.head.sha }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=On
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON
 
   Exec-Tests-Extra-DX-All:
     permissions:
@@ -125,7 +125,7 @@ jobs:
       TestTarget: ${{ matrix.TestTarget }}
       OffloadTest-branch: ${{ github.event.pull_request.head.sha }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=On
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON
 
   Exec-Tests-Extra-VK-All:
     permissions:
@@ -150,7 +150,7 @@ jobs:
       TestTarget: ${{ matrix.TestTarget }}
       OffloadTest-branch: ${{ github.event.pull_request.head.sha }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=On
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON
 
   Exec-Tests-MacOS:
     permissions:

--- a/.github/workflows/validate-split-build-test.yaml
+++ b/.github/workflows/validate-split-build-test.yaml
@@ -38,7 +38,7 @@ jobs:
       SKU: windows-intel
       TestTarget: ${{ matrix.TestTarget }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON
 
   split-nvidia:
     if: inputs.SKU == 'windows-nvidia'
@@ -55,7 +55,7 @@ jobs:
       SKU: windows-nvidia
       TestTarget: ${{ matrix.TestTarget }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON
 
   split-amd:
     if: inputs.SKU == 'windows-amd'
@@ -72,7 +72,7 @@ jobs:
       SKU: windows-amd
       TestTarget: ${{ matrix.TestTarget }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON
 
   split-qc:
     if: inputs.SKU == 'windows-qc'
@@ -89,7 +89,7 @@ jobs:
       SKU: windows-qc
       TestTarget: ${{ matrix.TestTarget }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON
 
   split-macos:
     if: inputs.SKU == 'macos'

--- a/.github/workflows/validate-split-build-test.yaml
+++ b/.github/workflows/validate-split-build-test.yaml
@@ -38,7 +38,7 @@ jobs:
       SKU: windows-intel
       TestTarget: ${{ matrix.TestTarget }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=On
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON
 
   split-nvidia:
     if: inputs.SKU == 'windows-nvidia'
@@ -55,7 +55,7 @@ jobs:
       SKU: windows-nvidia
       TestTarget: ${{ matrix.TestTarget }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=On
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON
 
   split-amd:
     if: inputs.SKU == 'windows-amd'
@@ -72,7 +72,7 @@ jobs:
       SKU: windows-amd
       TestTarget: ${{ matrix.TestTarget }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=On
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON
 
   split-qc:
     if: inputs.SKU == 'windows-qc'
@@ -89,7 +89,7 @@ jobs:
       SKU: windows-qc
       TestTarget: ${{ matrix.TestTarget }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=On
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON
 
   split-macos:
     if: inputs.SKU == 'macos'

--- a/.github/workflows/validate-split-build-test.yaml
+++ b/.github/workflows/validate-split-build-test.yaml
@@ -38,7 +38,7 @@ jobs:
       SKU: windows-intel
       TestTarget: ${{ matrix.TestTarget }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl
 
   split-nvidia:
     if: inputs.SKU == 'windows-nvidia'
@@ -55,7 +55,7 @@ jobs:
       SKU: windows-nvidia
       TestTarget: ${{ matrix.TestTarget }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl
 
   split-amd:
     if: inputs.SKU == 'windows-amd'
@@ -72,7 +72,7 @@ jobs:
       SKU: windows-amd
       TestTarget: ${{ matrix.TestTarget }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl
 
   split-qc:
     if: inputs.SKU == 'windows-qc'
@@ -89,7 +89,7 @@ jobs:
       SKU: windows-qc
       TestTarget: ${{ matrix.TestTarget }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl
 
   split-macos:
     if: inputs.SKU == 'macos'

--- a/.github/workflows/windows-amd-clang-d3d12-gbv.yaml
+++ b/.github/workflows/windows-amd-clang-d3d12-gbv.yaml
@@ -19,4 +19,4 @@ jobs:
       TestTarget: check-hlsl-clang-d3d12
       OffloadTest-branch: ${{ github.ref }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_ENABLE_VALIDATION=ON
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_ENABLE_VALIDATION=ON -DOFFLOADTEST_USE_CLANG_TIDY=ON

--- a/.github/workflows/windows-amd-clang-d3d12-gbv.yaml
+++ b/.github/workflows/windows-amd-clang-d3d12-gbv.yaml
@@ -19,4 +19,4 @@ jobs:
       TestTarget: check-hlsl-clang-d3d12
       OffloadTest-branch: ${{ github.ref }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_ENABLE_VALIDATION=ON -DOFFLOADTEST_USE_CLANG_TIDY=ON
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_ENABLE_VALIDATION=ON

--- a/.github/workflows/windows-amd-clang-d3d12.yaml
+++ b/.github/workflows/windows-amd-clang-d3d12.yaml
@@ -23,4 +23,4 @@ jobs:
       TestTarget: check-hlsl-clang-d3d12
       OffloadTest-branch: ${{ github.ref }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=On
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON

--- a/.github/workflows/windows-amd-clang-d3d12.yaml
+++ b/.github/workflows/windows-amd-clang-d3d12.yaml
@@ -23,4 +23,4 @@ jobs:
       TestTarget: check-hlsl-clang-d3d12
       OffloadTest-branch: ${{ github.ref }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON

--- a/.github/workflows/windows-amd-clang-d3d12.yaml
+++ b/.github/workflows/windows-amd-clang-d3d12.yaml
@@ -23,4 +23,4 @@ jobs:
       TestTarget: check-hlsl-clang-d3d12
       OffloadTest-branch: ${{ github.ref }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl

--- a/.github/workflows/windows-amd-clang-lavapipe.yaml
+++ b/.github/workflows/windows-amd-clang-lavapipe.yaml
@@ -24,4 +24,4 @@ jobs:
       TestTarget: check-hlsl-clang-vk-lavapipe
       OffloadTest-branch: ${{ github.ref }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl

--- a/.github/workflows/windows-amd-clang-lavapipe.yaml
+++ b/.github/workflows/windows-amd-clang-lavapipe.yaml
@@ -24,4 +24,4 @@ jobs:
       TestTarget: check-hlsl-clang-vk-lavapipe
       OffloadTest-branch: ${{ github.ref }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON

--- a/.github/workflows/windows-amd-clang-vk.yaml
+++ b/.github/workflows/windows-amd-clang-vk.yaml
@@ -23,4 +23,4 @@ jobs:
       TestTarget: check-hlsl-clang-vk
       OffloadTest-branch: ${{ github.ref }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl

--- a/.github/workflows/windows-amd-clang-vk.yaml
+++ b/.github/workflows/windows-amd-clang-vk.yaml
@@ -23,4 +23,4 @@ jobs:
       TestTarget: check-hlsl-clang-vk
       OffloadTest-branch: ${{ github.ref }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON

--- a/.github/workflows/windows-amd-clang-vk.yaml
+++ b/.github/workflows/windows-amd-clang-vk.yaml
@@ -23,4 +23,4 @@ jobs:
       TestTarget: check-hlsl-clang-vk
       OffloadTest-branch: ${{ github.ref }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=On
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON

--- a/.github/workflows/windows-amd-clang-warp-d3d12.yaml
+++ b/.github/workflows/windows-amd-clang-warp-d3d12.yaml
@@ -23,4 +23,4 @@ jobs:
       TestTarget: check-hlsl-clang-warp-d3d12
       OffloadTest-branch: ${{ github.ref }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=On
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON

--- a/.github/workflows/windows-amd-clang-warp-d3d12.yaml
+++ b/.github/workflows/windows-amd-clang-warp-d3d12.yaml
@@ -23,4 +23,4 @@ jobs:
       TestTarget: check-hlsl-clang-warp-d3d12
       OffloadTest-branch: ${{ github.ref }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl

--- a/.github/workflows/windows-amd-clang-warp-d3d12.yaml
+++ b/.github/workflows/windows-amd-clang-warp-d3d12.yaml
@@ -23,4 +23,4 @@ jobs:
       TestTarget: check-hlsl-clang-warp-d3d12
       OffloadTest-branch: ${{ github.ref }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON

--- a/.github/workflows/windows-amd-clang-warp-preview-d3d12.yaml
+++ b/.github/workflows/windows-amd-clang-warp-preview-d3d12.yaml
@@ -22,4 +22,4 @@ jobs:
       TestTarget: check-hlsl-clang-warp-d3d12
       OffloadTest-branch: ${{ github.ref }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DWARP_VERSION=1.0.19-preview
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON -DWARP_VERSION=1.0.19-preview

--- a/.github/workflows/windows-amd-clang-warp-preview-d3d12.yaml
+++ b/.github/workflows/windows-amd-clang-warp-preview-d3d12.yaml
@@ -22,4 +22,4 @@ jobs:
       TestTarget: check-hlsl-clang-warp-d3d12
       OffloadTest-branch: ${{ github.ref }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=On -DWARP_VERSION=1.0.19-preview
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON -DWARP_VERSION=1.0.19-preview

--- a/.github/workflows/windows-amd-clang-warp-preview-d3d12.yaml
+++ b/.github/workflows/windows-amd-clang-warp-preview-d3d12.yaml
@@ -22,4 +22,4 @@ jobs:
       TestTarget: check-hlsl-clang-warp-d3d12
       OffloadTest-branch: ${{ github.ref }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON -DWARP_VERSION=1.0.19-preview
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DWARP_VERSION=1.0.19-preview

--- a/.github/workflows/windows-amd-dxc-d3d12.yaml
+++ b/.github/workflows/windows-amd-dxc-d3d12.yaml
@@ -24,4 +24,4 @@ jobs:
       TestTarget: check-hlsl-d3d12
       OffloadTest-branch: ${{ github.ref }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl

--- a/.github/workflows/windows-amd-dxc-d3d12.yaml
+++ b/.github/workflows/windows-amd-dxc-d3d12.yaml
@@ -24,4 +24,4 @@ jobs:
       TestTarget: check-hlsl-d3d12
       OffloadTest-branch: ${{ github.ref }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON

--- a/.github/workflows/windows-amd-dxc-lavapipe.yaml
+++ b/.github/workflows/windows-amd-dxc-lavapipe.yaml
@@ -24,4 +24,4 @@ jobs:
       TestTarget: check-hlsl-vk-lavapipe
       OffloadTest-branch: ${{ github.ref }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON

--- a/.github/workflows/windows-amd-dxc-lavapipe.yaml
+++ b/.github/workflows/windows-amd-dxc-lavapipe.yaml
@@ -24,4 +24,4 @@ jobs:
       TestTarget: check-hlsl-vk-lavapipe
       OffloadTest-branch: ${{ github.ref }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl

--- a/.github/workflows/windows-amd-dxc-vk.yaml
+++ b/.github/workflows/windows-amd-dxc-vk.yaml
@@ -24,4 +24,4 @@ jobs:
       TestTarget: check-hlsl-vk
       OffloadTest-branch: ${{ github.ref }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON

--- a/.github/workflows/windows-amd-dxc-vk.yaml
+++ b/.github/workflows/windows-amd-dxc-vk.yaml
@@ -24,4 +24,4 @@ jobs:
       TestTarget: check-hlsl-vk
       OffloadTest-branch: ${{ github.ref }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl

--- a/.github/workflows/windows-amd-dxc-warp-d3d12.yaml
+++ b/.github/workflows/windows-amd-dxc-warp-d3d12.yaml
@@ -24,4 +24,4 @@ jobs:
       TestTarget: check-hlsl-warp-d3d12
       OffloadTest-branch: ${{ github.ref }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl

--- a/.github/workflows/windows-amd-dxc-warp-d3d12.yaml
+++ b/.github/workflows/windows-amd-dxc-warp-d3d12.yaml
@@ -24,4 +24,4 @@ jobs:
       TestTarget: check-hlsl-warp-d3d12
       OffloadTest-branch: ${{ github.ref }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON

--- a/.github/workflows/windows-amd-dxc-warp-preview-d3d12.yaml
+++ b/.github/workflows/windows-amd-dxc-warp-preview-d3d12.yaml
@@ -23,4 +23,4 @@ jobs:
       TestTarget: check-hlsl-warp-d3d12
       OffloadTest-branch: ${{ github.ref }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DWARP_VERSION=1.0.19-preview
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DWARP_VERSION=1.0.19-preview -DOFFLOADTEST_USE_CLANG_TIDY=ON

--- a/.github/workflows/windows-amd-dxc-warp-preview-d3d12.yaml
+++ b/.github/workflows/windows-amd-dxc-warp-preview-d3d12.yaml
@@ -23,4 +23,4 @@ jobs:
       TestTarget: check-hlsl-warp-d3d12
       OffloadTest-branch: ${{ github.ref }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DWARP_VERSION=1.0.19-preview -DOFFLOADTEST_USE_CLANG_TIDY=ON
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DWARP_VERSION=1.0.19-preview

--- a/.github/workflows/windows-intel-clang-d3d12.yaml
+++ b/.github/workflows/windows-intel-clang-d3d12.yaml
@@ -23,4 +23,4 @@ jobs:
       TestTarget: check-hlsl-clang-d3d12
       OffloadTest-branch: ${{ github.ref }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=On
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON

--- a/.github/workflows/windows-intel-clang-d3d12.yaml
+++ b/.github/workflows/windows-intel-clang-d3d12.yaml
@@ -23,4 +23,4 @@ jobs:
       TestTarget: check-hlsl-clang-d3d12
       OffloadTest-branch: ${{ github.ref }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON

--- a/.github/workflows/windows-intel-clang-d3d12.yaml
+++ b/.github/workflows/windows-intel-clang-d3d12.yaml
@@ -23,4 +23,4 @@ jobs:
       TestTarget: check-hlsl-clang-d3d12
       OffloadTest-branch: ${{ github.ref }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl

--- a/.github/workflows/windows-intel-clang-vk.yaml
+++ b/.github/workflows/windows-intel-clang-vk.yaml
@@ -23,4 +23,4 @@ jobs:
       TestTarget: check-hlsl-clang-vk
       OffloadTest-branch: ${{ github.ref }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl

--- a/.github/workflows/windows-intel-clang-vk.yaml
+++ b/.github/workflows/windows-intel-clang-vk.yaml
@@ -23,4 +23,4 @@ jobs:
       TestTarget: check-hlsl-clang-vk
       OffloadTest-branch: ${{ github.ref }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON

--- a/.github/workflows/windows-intel-clang-vk.yaml
+++ b/.github/workflows/windows-intel-clang-vk.yaml
@@ -23,4 +23,4 @@ jobs:
       TestTarget: check-hlsl-clang-vk
       OffloadTest-branch: ${{ github.ref }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=On
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON

--- a/.github/workflows/windows-intel-dxc-d3d12.yaml
+++ b/.github/workflows/windows-intel-dxc-d3d12.yaml
@@ -24,4 +24,4 @@ jobs:
       TestTarget: check-hlsl-d3d12
       OffloadTest-branch: ${{ github.ref }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl

--- a/.github/workflows/windows-intel-dxc-d3d12.yaml
+++ b/.github/workflows/windows-intel-dxc-d3d12.yaml
@@ -24,4 +24,4 @@ jobs:
       TestTarget: check-hlsl-d3d12
       OffloadTest-branch: ${{ github.ref }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON

--- a/.github/workflows/windows-intel-dxc-vk.yaml
+++ b/.github/workflows/windows-intel-dxc-vk.yaml
@@ -24,4 +24,4 @@ jobs:
       TestTarget: check-hlsl-vk
       OffloadTest-branch: ${{ github.ref }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON

--- a/.github/workflows/windows-intel-dxc-vk.yaml
+++ b/.github/workflows/windows-intel-dxc-vk.yaml
@@ -24,4 +24,4 @@ jobs:
       TestTarget: check-hlsl-vk
       OffloadTest-branch: ${{ github.ref }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl

--- a/.github/workflows/windows-nvidia-clang-d3d12.yaml
+++ b/.github/workflows/windows-nvidia-clang-d3d12.yaml
@@ -23,4 +23,4 @@ jobs:
       TestTarget: check-hlsl-clang-d3d12
       OffloadTest-branch: ${{ github.ref }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=On
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON

--- a/.github/workflows/windows-nvidia-clang-d3d12.yaml
+++ b/.github/workflows/windows-nvidia-clang-d3d12.yaml
@@ -23,4 +23,4 @@ jobs:
       TestTarget: check-hlsl-clang-d3d12
       OffloadTest-branch: ${{ github.ref }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON

--- a/.github/workflows/windows-nvidia-clang-d3d12.yaml
+++ b/.github/workflows/windows-nvidia-clang-d3d12.yaml
@@ -23,4 +23,4 @@ jobs:
       TestTarget: check-hlsl-clang-d3d12
       OffloadTest-branch: ${{ github.ref }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl

--- a/.github/workflows/windows-nvidia-clang-vk.yaml
+++ b/.github/workflows/windows-nvidia-clang-vk.yaml
@@ -23,4 +23,4 @@ jobs:
       TestTarget: check-hlsl-clang-vk
       OffloadTest-branch: ${{ github.ref }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl

--- a/.github/workflows/windows-nvidia-clang-vk.yaml
+++ b/.github/workflows/windows-nvidia-clang-vk.yaml
@@ -23,4 +23,4 @@ jobs:
       TestTarget: check-hlsl-clang-vk
       OffloadTest-branch: ${{ github.ref }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON

--- a/.github/workflows/windows-nvidia-clang-vk.yaml
+++ b/.github/workflows/windows-nvidia-clang-vk.yaml
@@ -23,4 +23,4 @@ jobs:
       TestTarget: check-hlsl-clang-vk
       OffloadTest-branch: ${{ github.ref }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=On
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON

--- a/.github/workflows/windows-nvidia-dxc-d3d12.yaml
+++ b/.github/workflows/windows-nvidia-dxc-d3d12.yaml
@@ -24,4 +24,4 @@ jobs:
       TestTarget: check-hlsl-d3d12
       OffloadTest-branch: ${{ github.ref }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl

--- a/.github/workflows/windows-nvidia-dxc-d3d12.yaml
+++ b/.github/workflows/windows-nvidia-dxc-d3d12.yaml
@@ -24,4 +24,4 @@ jobs:
       TestTarget: check-hlsl-d3d12
       OffloadTest-branch: ${{ github.ref }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON

--- a/.github/workflows/windows-nvidia-dxc-vk.yaml
+++ b/.github/workflows/windows-nvidia-dxc-vk.yaml
@@ -24,4 +24,4 @@ jobs:
       TestTarget: check-hlsl-vk
       OffloadTest-branch: ${{ github.ref }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON

--- a/.github/workflows/windows-nvidia-dxc-vk.yaml
+++ b/.github/workflows/windows-nvidia-dxc-vk.yaml
@@ -24,4 +24,4 @@ jobs:
       TestTarget: check-hlsl-vk
       OffloadTest-branch: ${{ github.ref }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl

--- a/.github/workflows/windows-qc-clang-d3d12.yaml
+++ b/.github/workflows/windows-qc-clang-d3d12.yaml
@@ -23,4 +23,4 @@ jobs:
       TestTarget: check-hlsl-clang-d3d12
       OffloadTest-branch: ${{ github.ref }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=On
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON

--- a/.github/workflows/windows-qc-clang-d3d12.yaml
+++ b/.github/workflows/windows-qc-clang-d3d12.yaml
@@ -23,4 +23,4 @@ jobs:
       TestTarget: check-hlsl-clang-d3d12
       OffloadTest-branch: ${{ github.ref }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON

--- a/.github/workflows/windows-qc-clang-d3d12.yaml
+++ b/.github/workflows/windows-qc-clang-d3d12.yaml
@@ -23,4 +23,4 @@ jobs:
       TestTarget: check-hlsl-clang-d3d12
       OffloadTest-branch: ${{ github.ref }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl

--- a/.github/workflows/windows-qc-clang-lavapipe.yaml
+++ b/.github/workflows/windows-qc-clang-lavapipe.yaml
@@ -24,4 +24,4 @@ jobs:
       TestTarget: check-hlsl-clang-vk-lavapipe
       OffloadTest-branch: ${{ github.ref }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl

--- a/.github/workflows/windows-qc-clang-lavapipe.yaml
+++ b/.github/workflows/windows-qc-clang-lavapipe.yaml
@@ -24,4 +24,4 @@ jobs:
       TestTarget: check-hlsl-clang-vk-lavapipe
       OffloadTest-branch: ${{ github.ref }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON

--- a/.github/workflows/windows-qc-clang-vk.yaml
+++ b/.github/workflows/windows-qc-clang-vk.yaml
@@ -23,4 +23,4 @@ jobs:
       TestTarget: check-hlsl-clang-vk
       OffloadTest-branch: ${{ github.ref }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl

--- a/.github/workflows/windows-qc-clang-vk.yaml
+++ b/.github/workflows/windows-qc-clang-vk.yaml
@@ -23,4 +23,4 @@ jobs:
       TestTarget: check-hlsl-clang-vk
       OffloadTest-branch: ${{ github.ref }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON

--- a/.github/workflows/windows-qc-clang-vk.yaml
+++ b/.github/workflows/windows-qc-clang-vk.yaml
@@ -23,4 +23,4 @@ jobs:
       TestTarget: check-hlsl-clang-vk
       OffloadTest-branch: ${{ github.ref }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=On
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON

--- a/.github/workflows/windows-qc-clang-warp-d3d12.yaml
+++ b/.github/workflows/windows-qc-clang-warp-d3d12.yaml
@@ -23,4 +23,4 @@ jobs:
       TestTarget: check-hlsl-clang-warp-d3d12
       OffloadTest-branch: ${{ github.ref }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=On
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON

--- a/.github/workflows/windows-qc-clang-warp-d3d12.yaml
+++ b/.github/workflows/windows-qc-clang-warp-d3d12.yaml
@@ -23,4 +23,4 @@ jobs:
       TestTarget: check-hlsl-clang-warp-d3d12
       OffloadTest-branch: ${{ github.ref }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl

--- a/.github/workflows/windows-qc-clang-warp-d3d12.yaml
+++ b/.github/workflows/windows-qc-clang-warp-d3d12.yaml
@@ -23,4 +23,4 @@ jobs:
       TestTarget: check-hlsl-clang-warp-d3d12
       OffloadTest-branch: ${{ github.ref }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON

--- a/.github/workflows/windows-qc-dxc-d3d12.yaml
+++ b/.github/workflows/windows-qc-dxc-d3d12.yaml
@@ -24,4 +24,4 @@ jobs:
       TestTarget: check-hlsl-d3d12
       OffloadTest-branch: ${{ github.ref }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl

--- a/.github/workflows/windows-qc-dxc-d3d12.yaml
+++ b/.github/workflows/windows-qc-dxc-d3d12.yaml
@@ -24,4 +24,4 @@ jobs:
       TestTarget: check-hlsl-d3d12
       OffloadTest-branch: ${{ github.ref }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON

--- a/.github/workflows/windows-qc-dxc-lavapipe.yaml
+++ b/.github/workflows/windows-qc-dxc-lavapipe.yaml
@@ -24,4 +24,4 @@ jobs:
       TestTarget: check-hlsl-vk-lavapipe
       OffloadTest-branch: ${{ github.ref }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON

--- a/.github/workflows/windows-qc-dxc-lavapipe.yaml
+++ b/.github/workflows/windows-qc-dxc-lavapipe.yaml
@@ -24,4 +24,4 @@ jobs:
       TestTarget: check-hlsl-vk-lavapipe
       OffloadTest-branch: ${{ github.ref }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl

--- a/.github/workflows/windows-qc-dxc-vk.yaml
+++ b/.github/workflows/windows-qc-dxc-vk.yaml
@@ -24,4 +24,4 @@ jobs:
       TestTarget: check-hlsl-vk
       OffloadTest-branch: ${{ github.ref }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON

--- a/.github/workflows/windows-qc-dxc-vk.yaml
+++ b/.github/workflows/windows-qc-dxc-vk.yaml
@@ -24,4 +24,4 @@ jobs:
       TestTarget: check-hlsl-vk
       OffloadTest-branch: ${{ github.ref }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl

--- a/.github/workflows/windows-qc-dxc-warp-d3d12.yaml
+++ b/.github/workflows/windows-qc-dxc-warp-d3d12.yaml
@@ -24,4 +24,4 @@ jobs:
       TestTarget: check-hlsl-warp-d3d12
       OffloadTest-branch: ${{ github.ref }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl

--- a/.github/workflows/windows-qc-dxc-warp-d3d12.yaml
+++ b/.github/workflows/windows-qc-dxc-warp-d3d12.yaml
@@ -24,4 +24,4 @@ jobs:
       TestTarget: check-hlsl-warp-d3d12
       OffloadTest-branch: ${{ github.ref }}
       SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,6 +130,9 @@ if (OFFLOADTEST_USE_CLANG_TIDY)
       set(CLANG_TIDY_ARGS --extra-arg=-isysroot${SYSROOT})
     endif()
   endif()
+  # Only lint headers that live inside this project's source tree.
+  set(CLANG_TIDY_ARGS ${CLANG_TIDY_ARGS}
+    --header-filter=^${CMAKE_CURRENT_SOURCE_DIR}/.*)
   if (OFFLOADTEST_CLANG_TIDY_APPLY_FIX)
     set(CLANG_TIDY_ARGS ${CLANG_TIDY_ARGS} --fix)
   endif ()

--- a/include/Image/Color.h
+++ b/include/Image/Color.h
@@ -25,7 +25,7 @@ template <typename T>
 std::enable_if_t<std::is_integral_v<T>, double> toInt(double Val) {
   constexpr double Max = static_cast<double>(std::numeric_limits<T>::max());
   constexpr double Base = Max + 1.0;
-  double Conv = std::clamp(floor(Val * Base), 0.0, Max);
+  const double Conv = std::clamp(floor(Val * Base), 0.0, Max);
   return static_cast<T>(Conv);
 }
 
@@ -40,7 +40,7 @@ std::enable_if_t<std::is_arithmetic_v<T>, double> toDouble(T Val) {
 template <typename NewTy, typename OldTy> NewTy convertColor(OldTy Val) {
   if constexpr (std::is_same_v<NewTy, OldTy>)
     return Val;
-  double Dbl = toDouble(Val);
+  const double Dbl = toDouble(Val);
   assert(Dbl >= 0.0 && Dbl <= 1.0 && "Value should be normalized");
   if constexpr (std::is_integral_v<NewTy>)
     return toInt<NewTy>(Dbl);

--- a/include/Support/Pipeline.h
+++ b/include/Support/Pipeline.h
@@ -1059,11 +1059,11 @@ template <> struct ScalarEnumerationTraits<offloadtest::dx::RootParamKind> {
 };
 
 template <typename T> struct SequenceTraits<SmallVector<SmallVector<T>>> {
-  static size_t size(IO &Io, SmallVector<SmallVector<T>> &Seq) {
+  static size_t size(IO & /*Io*/, SmallVector<SmallVector<T>> &Seq) {
     return Seq.size();
   }
 
-  static SmallVector<T> &element(IO &Io, SmallVector<SmallVector<T>> &Seq,
+  static SmallVector<T> &element(IO & /*Io*/, SmallVector<SmallVector<T>> &Seq,
                                  size_t Index) {
     if (Index >= Seq.size())
       Seq.resize(Index + 1);
@@ -1072,12 +1072,12 @@ template <typename T> struct SequenceTraits<SmallVector<SmallVector<T>>> {
 };
 
 template <typename T> struct SequenceTraits<SmallVector<MutableArrayRef<T>>> {
-  static size_t size(IO &Io, SmallVector<MutableArrayRef<T>> &Seq) {
+  static size_t size(IO & /*Io*/, SmallVector<MutableArrayRef<T>> &Seq) {
     return Seq.size();
   }
 
   static MutableArrayRef<T> &
-  element(IO &Io, SmallVector<MutableArrayRef<T>> &Seq, size_t Index) {
+  element(IO & /*Io*/, SmallVector<MutableArrayRef<T>> &Seq, size_t Index) {
     assert(Index < Seq.size());
     return Seq[Index];
   }

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -365,7 +365,7 @@ public:
     HANDLE Event = CreateEventA(nullptr, false, false, nullptr);
     if (!Event)
 #else // WSL
-    int Event = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
+    const int Event = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
     if (Event == -1)
 #endif
       return llvm::createStringError(std::errc::device_or_resource_busy,
@@ -892,15 +892,9 @@ public:
                            const ShaderBindingTable &SBT, uint32_t Width,
                            uint32_t Height, uint32_t Depth) override;
 
+protected:
   void endEncodingImpl() override { popDebugGroup(); }
 };
-
-llvm::Expected<std::unique_ptr<offloadtest::ComputeEncoder>>
-DXCommandBuffer::createComputeEncoder() {
-  auto Enc = std::make_unique<DXComputeEncoder>(*this);
-  Enc->pushDebugGroup("ComputeEncoder");
-  return Enc;
-}
 
 class DXRenderPass final : public offloadtest::RenderPass {
 public:
@@ -1017,6 +1011,7 @@ public:
     return llvm::Error::success();
   }
 
+protected:
   void endEncodingImpl() override {
     // State transitions
     for (offloadtest::Texture *Tex : Desc.ColorAttachments) {
@@ -1037,125 +1032,6 @@ public:
     popDebugGroup();
   }
 };
-
-llvm::Expected<std::unique_ptr<offloadtest::RenderEncoder>>
-DXCommandBuffer::createRenderEncoder(
-    const offloadtest::RenderPassBeginDesc &Desc) {
-  // The pass carries format / load / store policy; the begin desc supplies
-  // the actual textures. Walk both in lockstep.
-  if (!Desc.Pass)
-    return llvm::createStringError(
-        std::errc::invalid_argument,
-        "RenderPassBeginDesc is missing its RenderPass.");
-  auto &DXPass = llvm::cast<DXRenderPass>(*Desc.Pass);
-  const offloadtest::RenderPassDesc &PassDesc = DXPass.Desc;
-
-  if (Desc.ColorAttachments.size() != PassDesc.ColorAttachments.size())
-    return llvm::createStringError(
-        std::errc::invalid_argument,
-        "RenderPassBeginDesc color attachment count does not match its "
-        "RenderPass.");
-  if (PassDesc.DepthStencil.has_value() != (Desc.DepthStencil != nullptr))
-    return llvm::createStringError(std::errc::invalid_argument,
-                                   "RenderPassBeginDesc depth-stencil "
-                                   "presence does not match its RenderPass.");
-
-  if (auto Err = findAndValidateRenderPassTextureSize(Desc, nullptr, nullptr))
-    return Err;
-
-  // Validate attachments and gather the RTV / DSV CPU handles. RT and DSV
-  // descriptors are owned by the textures themselves; this just collects
-  // them for OMSetRenderTargets.
-  llvm::SmallVector<DXTexture *, 8> RTTextures;
-  llvm::SmallVector<D3D12_CPU_DESCRIPTOR_HANDLE, 8> RTVHandles;
-  RTTextures.reserve(Desc.ColorAttachments.size());
-  RTVHandles.reserve(Desc.ColorAttachments.size());
-  for (offloadtest::Texture *Tex : Desc.ColorAttachments) {
-    if (!Tex)
-      return llvm::createStringError(
-          std::errc::invalid_argument,
-          "RenderPassBeginDesc has a null color attachment texture.");
-    auto &DXTex = llvm::cast<DXTexture>(*Tex);
-    if (DXTex.RTVHandle.ptr == 0)
-      return llvm::createStringError(
-          std::errc::invalid_argument,
-          "Color attachment texture was not created with RenderTarget usage.");
-    RTTextures.push_back(&DXTex);
-    RTVHandles.push_back(DXTex.RTVHandle);
-  }
-
-  DXTexture *DSTexture = nullptr;
-  D3D12_CPU_DESCRIPTOR_HANDLE DSVHandle = {};
-  if (Desc.DepthStencil) {
-    auto &DXDS = llvm::cast<DXTexture>(*Desc.DepthStencil);
-    if (DXDS.DSVHandle.ptr == 0)
-      return llvm::createStringError(
-          std::errc::invalid_argument,
-          "Depth-stencil texture was not created with DepthStencil usage.");
-    DSTexture = &DXDS;
-    DSVHandle = DXDS.DSVHandle;
-  }
-
-  // State transitions
-  for (offloadtest::Texture *Tex : Desc.ColorAttachments) {
-    auto &DXTex = llvm::cast<DXTexture>(*Tex);
-    if (DXTex.PreferredState != D3D12_RESOURCE_STATE_RENDER_TARGET)
-      this->addResourceTransition(DXTex.Resource.Get(), DXTex.PreferredState,
-                                  D3D12_RESOURCE_STATE_RENDER_TARGET);
-  }
-  if (Desc.DepthStencil) {
-    auto &DXTex = llvm::cast<DXTexture>(*Desc.DepthStencil);
-    if (DXTex.PreferredState != D3D12_RESOURCE_STATE_DEPTH_WRITE)
-      this->addResourceTransition(DXTex.Resource.Get(), DXTex.PreferredState,
-                                  D3D12_RESOURCE_STATE_DEPTH_WRITE);
-  }
-
-  this->flushBarrier();
-
-  CmdList->OMSetRenderTargets(static_cast<UINT>(RTVHandles.size()),
-                              RTVHandles.data(),
-                              /*RTsSingleHandleToDescriptorRange=*/false,
-                              Desc.DepthStencil ? &DSVHandle : nullptr);
-
-  for (size_t I = 0; I < PassDesc.ColorAttachments.size(); ++I) {
-    if (PassDesc.ColorAttachments[I].Load != offloadtest::LoadAction::Clear)
-      continue;
-    if (!RTTextures[I]->Desc.OptimizedClearValue)
-      return llvm::createStringError(
-          std::errc::invalid_argument,
-          "LoadAction::Clear requires the render target to have been "
-          "created with an OptimizedClearValue.");
-    const auto *CV =
-        std::get_if<ClearColor>(&*RTTextures[I]->Desc.OptimizedClearValue);
-    assert(CV && "RenderTarget OptimizedClearValue must be a ClearColor");
-    const float ClearArr[4] = {CV->R, CV->G, CV->B, CV->A};
-    CmdList->ClearRenderTargetView(RTVHandles[I], ClearArr, 0, nullptr);
-  }
-  if (PassDesc.DepthStencil) {
-    D3D12_CLEAR_FLAGS Flags = static_cast<D3D12_CLEAR_FLAGS>(0);
-    if (PassDesc.DepthStencil->DepthLoad == offloadtest::LoadAction::Clear)
-      Flags |= D3D12_CLEAR_FLAG_DEPTH;
-    if (PassDesc.DepthStencil->StencilLoad == offloadtest::LoadAction::Clear)
-      Flags |= D3D12_CLEAR_FLAG_STENCIL;
-    if (Flags != 0) {
-      if (!DSTexture->Desc.OptimizedClearValue)
-        return llvm::createStringError(
-            std::errc::invalid_argument,
-            "LoadAction::Clear requires the depth-stencil texture to have "
-            "been created with an OptimizedClearValue.");
-      const auto *CV =
-          std::get_if<ClearDepthStencil>(&*DSTexture->Desc.OptimizedClearValue);
-      assert(CV &&
-             "DepthStencil OptimizedClearValue must be a ClearDepthStencil");
-      CmdList->ClearDepthStencilView(DSVHandle, Flags, CV->Depth, CV->Stencil,
-                                     0, nullptr);
-    }
-  }
-
-  auto Enc = std::make_unique<DXRenderEncoder>(*this, Desc);
-  Enc->pushDebugGroup("RenderEncoder");
-  return Enc;
-}
 
 class DXDevice : public offloadtest::Device {
 public:
@@ -2092,7 +1968,7 @@ public:
     }
 
     if (Config.EnableDebugLayer || Config.EnableValidationLayer)
-      if (auto Err = configureInfoQueue(Device.Get()))
+      if (auto Err = configureInfoQueue())
         return Err;
 
     auto GraphicsQueueOrErr = DXQueue::createGraphicsQueue(Device);
@@ -2147,7 +2023,7 @@ public:
 #include "DXFeatures.def"
   }
 
-  static llvm::Error configureInfoQueue(ID3D12DeviceX *Device) {
+  static llvm::Error configureInfoQueue() {
 #ifdef _WIN32
     ComPtr<ID3D12InfoQueue> InfoQueue;
     if (auto Err = HR::toError(Device->QueryInterface(InfoQueue.GetAddressOf()),
@@ -2844,6 +2720,133 @@ public:
     return llvm::Error::success();
   }
 };
+} // namespace
+
+llvm::Expected<std::unique_ptr<offloadtest::ComputeEncoder>>
+DXCommandBuffer::createComputeEncoder() {
+  auto Enc = std::make_unique<DXComputeEncoder>(*this);
+  Enc->pushDebugGroup("ComputeEncoder");
+  return Enc;
+}
+
+llvm::Expected<std::unique_ptr<offloadtest::RenderEncoder>>
+DXCommandBuffer::createRenderEncoder(
+    const offloadtest::RenderPassBeginDesc &Desc) {
+  // The pass carries format / load / store policy; the begin desc supplies
+  // the actual textures. Walk both in lockstep.
+  if (!Desc.Pass)
+    return llvm::createStringError(
+        std::errc::invalid_argument,
+        "RenderPassBeginDesc is missing its RenderPass.");
+  auto &DXPass = llvm::cast<DXRenderPass>(*Desc.Pass);
+  const offloadtest::RenderPassDesc &PassDesc = DXPass.Desc;
+
+  if (Desc.ColorAttachments.size() != PassDesc.ColorAttachments.size())
+    return llvm::createStringError(
+        std::errc::invalid_argument,
+        "RenderPassBeginDesc color attachment count does not match its "
+        "RenderPass.");
+  if (PassDesc.DepthStencil.has_value() != (Desc.DepthStencil != nullptr))
+    return llvm::createStringError(std::errc::invalid_argument,
+                                   "RenderPassBeginDesc depth-stencil "
+                                   "presence does not match its RenderPass.");
+
+  if (auto Err = findAndValidateRenderPassTextureSize(Desc, nullptr, nullptr))
+    return Err;
+
+  // Validate attachments and gather the RTV / DSV CPU handles. RT and DSV
+  // descriptors are owned by the textures themselves; this just collects
+  // them for OMSetRenderTargets.
+  llvm::SmallVector<DXTexture *, 8> RTTextures;
+  llvm::SmallVector<D3D12_CPU_DESCRIPTOR_HANDLE, 8> RTVHandles;
+  RTTextures.reserve(Desc.ColorAttachments.size());
+  RTVHandles.reserve(Desc.ColorAttachments.size());
+  for (offloadtest::Texture *Tex : Desc.ColorAttachments) {
+    if (!Tex)
+      return llvm::createStringError(
+          std::errc::invalid_argument,
+          "RenderPassBeginDesc has a null color attachment texture.");
+    auto &DXTex = llvm::cast<DXTexture>(*Tex);
+    if (DXTex.RTVHandle.ptr == 0)
+      return llvm::createStringError(
+          std::errc::invalid_argument,
+          "Color attachment texture was not created with RenderTarget usage.");
+    RTTextures.push_back(&DXTex);
+    RTVHandles.push_back(DXTex.RTVHandle);
+  }
+
+  DXTexture *DSTexture = nullptr;
+  D3D12_CPU_DESCRIPTOR_HANDLE DSVHandle = {};
+  if (Desc.DepthStencil) {
+    auto &DXDS = llvm::cast<DXTexture>(*Desc.DepthStencil);
+    if (DXDS.DSVHandle.ptr == 0)
+      return llvm::createStringError(
+          std::errc::invalid_argument,
+          "Depth-stencil texture was not created with DepthStencil usage.");
+    DSTexture = &DXDS;
+    DSVHandle = DXDS.DSVHandle;
+  }
+
+  // State transitions
+  for (offloadtest::Texture *Tex : Desc.ColorAttachments) {
+    auto &DXTex = llvm::cast<DXTexture>(*Tex);
+    if (DXTex.PreferredState != D3D12_RESOURCE_STATE_RENDER_TARGET)
+      this->addResourceTransition(DXTex.Resource.Get(), DXTex.PreferredState,
+                                  D3D12_RESOURCE_STATE_RENDER_TARGET);
+  }
+  if (Desc.DepthStencil) {
+    auto &DXTex = llvm::cast<DXTexture>(*Desc.DepthStencil);
+    if (DXTex.PreferredState != D3D12_RESOURCE_STATE_DEPTH_WRITE)
+      this->addResourceTransition(DXTex.Resource.Get(), DXTex.PreferredState,
+                                  D3D12_RESOURCE_STATE_DEPTH_WRITE);
+  }
+
+  this->flushBarrier();
+
+  CmdList->OMSetRenderTargets(static_cast<UINT>(RTVHandles.size()),
+                              RTVHandles.data(),
+                              /*RTsSingleHandleToDescriptorRange=*/false,
+                              Desc.DepthStencil ? &DSVHandle : nullptr);
+
+  for (size_t I = 0; I < PassDesc.ColorAttachments.size(); ++I) {
+    if (PassDesc.ColorAttachments[I].Load != offloadtest::LoadAction::Clear)
+      continue;
+    if (!RTTextures[I]->Desc.OptimizedClearValue)
+      return llvm::createStringError(
+          std::errc::invalid_argument,
+          "LoadAction::Clear requires the render target to have been "
+          "created with an OptimizedClearValue.");
+    const auto *CV =
+        std::get_if<ClearColor>(&*RTTextures[I]->Desc.OptimizedClearValue);
+    assert(CV && "RenderTarget OptimizedClearValue must be a ClearColor");
+    const float ClearArr[4] = {CV->R, CV->G, CV->B, CV->A};
+    CmdList->ClearRenderTargetView(RTVHandles[I], ClearArr, 0, nullptr);
+  }
+  if (PassDesc.DepthStencil) {
+    D3D12_CLEAR_FLAGS Flags = static_cast<D3D12_CLEAR_FLAGS>(0);
+    if (PassDesc.DepthStencil->DepthLoad == offloadtest::LoadAction::Clear)
+      Flags |= D3D12_CLEAR_FLAG_DEPTH;
+    if (PassDesc.DepthStencil->StencilLoad == offloadtest::LoadAction::Clear)
+      Flags |= D3D12_CLEAR_FLAG_STENCIL;
+    if (Flags != 0) {
+      if (!DSTexture->Desc.OptimizedClearValue)
+        return llvm::createStringError(
+            std::errc::invalid_argument,
+            "LoadAction::Clear requires the depth-stencil texture to have "
+            "been created with an OptimizedClearValue.");
+      const auto *CV =
+          std::get_if<ClearDepthStencil>(&*DSTexture->Desc.OptimizedClearValue);
+      assert(CV &&
+             "DepthStencil OptimizedClearValue must be a ClearDepthStencil");
+      CmdList->ClearDepthStencilView(DSVHandle, Flags, CV->Depth, CV->Stencil,
+                                     0, nullptr);
+    }
+  }
+
+  auto Enc = std::make_unique<DXRenderEncoder>(*this, Desc);
+  Enc->pushDebugGroup("RenderEncoder");
+  return Enc;
+}
 
 TileShape DXTexture::querySparseTileShape(const Device &Dev) const {
   const DXDevice &DeviceDX = llvm::cast<DXDevice>(Dev);
@@ -3061,7 +3064,6 @@ llvm::Error DXComputeEncoder::dispatchRays(const PipelineState &PSO,
   CmdList4->DispatchRays(&RaysDesc);
   return llvm::Error::success();
 }
-} // namespace
 
 llvm::Expected<offloadtest::SubmitResult> DXQueue::submit(
     llvm::SmallVector<std::unique_ptr<offloadtest::CommandBuffer>> CBs) {

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -189,7 +189,7 @@ public:
     if (Desc.Location == MemoryLocation::GpuOnly)
       return llvm::createStringError(std::errc::invalid_argument,
                                      "Cannot map a GpuOnly buffer.");
-    void *Ptr = nullptr;
+    void *Ptr = nullptr; // NOLINT(misc-const-correctness)
     if (auto Err =
             HR::toError(Buffer->Map(0, nullptr, &Ptr), "Failed to map buffer."))
       return std::move(Err);

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -1968,7 +1968,7 @@ public:
     }
 
     if (Config.EnableDebugLayer || Config.EnableValidationLayer)
-      if (auto Err = configureInfoQueue())
+      if (auto Err = configureInfoQueue(Device))
         return Err;
 
     auto GraphicsQueueOrErr = DXQueue::createGraphicsQueue(Device);
@@ -2023,7 +2023,7 @@ public:
 #include "DXFeatures.def"
   }
 
-  static llvm::Error configureInfoQueue() {
+  static llvm::Error configureInfoQueue(const ComPtr<ID3D12DeviceX> &Device) {
 #ifdef _WIN32
     ComPtr<ID3D12InfoQueue> InfoQueue;
     if (auto Err = HR::toError(Device->QueryInterface(InfoQueue.GetAddressOf()),
@@ -2032,6 +2032,8 @@ public:
     InfoQueue->SetBreakOnSeverity(D3D12_MESSAGE_SEVERITY_CORRUPTION, TRUE);
     InfoQueue->SetBreakOnSeverity(D3D12_MESSAGE_SEVERITY_ERROR, TRUE);
     InfoQueue->SetBreakOnSeverity(D3D12_MESSAGE_SEVERITY_WARNING, TRUE);
+#else
+    (void)Device;
 #endif
     return llvm::Error::success();
   }

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -189,7 +189,7 @@ public:
     if (Desc.Location == MemoryLocation::GpuOnly)
       return llvm::createStringError(std::errc::invalid_argument,
                                      "Cannot map a GpuOnly buffer.");
-    void *Ptr = nullptr; // NOLINT(misc-const-correctness)
+    void *Ptr = nullptr;
     if (auto Err =
             HR::toError(Buffer->Map(0, nullptr, &Ptr), "Failed to map buffer."))
       return std::move(Err);

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -816,6 +816,7 @@ public:
     return llvm::Error::success();
   }
 
+protected:
   void endEncodingImpl() override {
     if (ComputeEnc) {
       flushBarrier();
@@ -1014,6 +1015,7 @@ public:
     return llvm::Error::success();
   }
 
+protected:
   void endEncodingImpl() override {
     assert(RenderEnc);
     RenderEnc->popDebugGroup();

--- a/lib/API/Util.h
+++ b/lib/API/Util.h
@@ -27,7 +27,7 @@ llvm::Error findAndValidateRenderPassTextureSize(const RenderPassBeginDesc &,
 
 enum class IntelGpuEra { UnknownOrLegacy, Gen7_to_10, Gen11_to_14_and_Xe };
 
-IntelGpuEra getIntelGpuEra(uint16_t deviceId);
+IntelGpuEra getIntelGpuEra(uint16_t DeviceId);
 } // namespace offloadtest
 
 #endif // OFFLOADTEST_API_UTIL_H

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -403,6 +403,40 @@ static bool isExtensionSupported(
   return false;
 }
 
+static VkAttachmentLoadOp getVkLoadOp(offloadtest::LoadAction Action) {
+  switch (Action) {
+  case offloadtest::LoadAction::Load:
+    return VK_ATTACHMENT_LOAD_OP_LOAD;
+  case offloadtest::LoadAction::Clear:
+    return VK_ATTACHMENT_LOAD_OP_CLEAR;
+  case offloadtest::LoadAction::DontCare:
+    return VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+  }
+  llvm_unreachable("All LoadAction cases handled");
+}
+
+static VkAttachmentStoreOp getVkStoreOp(offloadtest::StoreAction Action) {
+  switch (Action) {
+  case offloadtest::StoreAction::Store:
+    return VK_ATTACHMENT_STORE_OP_STORE;
+  case offloadtest::StoreAction::DontCare:
+    return VK_ATTACHMENT_STORE_OP_DONT_CARE;
+  }
+  llvm_unreachable("All StoreAction cases handled");
+}
+
+static VkRayTracingShaderGroupTypeKHR getRTGroupType(HitGroupType T) {
+  switch (T) {
+  case HitGroupType::Triangles:
+    return VK_RAY_TRACING_SHADER_GROUP_TYPE_TRIANGLES_HIT_GROUP_KHR;
+  case HitGroupType::Procedural:
+    return VK_RAY_TRACING_SHADER_GROUP_TYPE_PROCEDURAL_HIT_GROUP_KHR;
+  }
+  llvm_unreachable("All HitGroupType cases handled");
+}
+
+namespace {
+
 struct VulkanInstance {
   VkInstance Instance;
   VkDebugUtilsMessengerEXT DebugMessenger;
@@ -423,8 +457,6 @@ struct VulkanInstance {
     vkDestroyInstance(Instance, nullptr);
   }
 };
-
-namespace {
 
 struct MeshShaderFunctions {
   PFN_vkCmdDrawMeshTasksEXT VkCmdDrawMeshTasksEXT = nullptr;
@@ -1129,37 +1161,9 @@ public:
                            const ShaderBindingTable &SBT, uint32_t Width,
                            uint32_t Height, uint32_t Depth) override;
 
+protected:
   void endEncodingImpl() override { popDebugGroup(); }
 };
-
-llvm::Expected<std::unique_ptr<offloadtest::ComputeEncoder>>
-VulkanCommandBuffer::createComputeEncoder() {
-  auto Enc = std::make_unique<VKComputeEncoder>(*this);
-  Enc->pushDebugGroup("ComputeEncoder");
-  return Enc;
-}
-
-static VkAttachmentLoadOp getVkLoadOp(offloadtest::LoadAction Action) {
-  switch (Action) {
-  case offloadtest::LoadAction::Load:
-    return VK_ATTACHMENT_LOAD_OP_LOAD;
-  case offloadtest::LoadAction::Clear:
-    return VK_ATTACHMENT_LOAD_OP_CLEAR;
-  case offloadtest::LoadAction::DontCare:
-    return VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-  }
-  llvm_unreachable("All LoadAction cases handled");
-}
-
-static VkAttachmentStoreOp getVkStoreOp(offloadtest::StoreAction Action) {
-  switch (Action) {
-  case offloadtest::StoreAction::Store:
-    return VK_ATTACHMENT_STORE_OP_STORE;
-  case offloadtest::StoreAction::DontCare:
-    return VK_ATTACHMENT_STORE_OP_DONT_CARE;
-  }
-  llvm_unreachable("All StoreAction cases handled");
-}
 
 class VulkanRenderPass final : public offloadtest::RenderPass {
 public:
@@ -1292,6 +1296,7 @@ public:
     return llvm::Error::success();
   }
 
+protected:
   void endEncodingImpl() override {
     vkCmdEndRenderPass(CB.CmdBuffer);
 
@@ -1320,152 +1325,6 @@ public:
     popDebugGroup();
   }
 };
-
-llvm::Expected<std::unique_ptr<offloadtest::RenderEncoder>>
-VulkanCommandBuffer::createRenderEncoder(
-    const offloadtest::RenderPassBeginDesc &Desc) {
-  // The pass carries the VkRenderPass and the format / load / store policy.
-  // The begin desc supplies the textures that get bound for this encoder.
-  if (!Desc.Pass)
-    return llvm::createStringError(
-        std::errc::invalid_argument,
-        "RenderPassBeginDesc is missing its RenderPass.");
-  auto &VKPass = llvm::cast<VulkanRenderPass>(*Desc.Pass);
-  const offloadtest::RenderPassDesc &PassDesc = VKPass.Desc;
-  if (Desc.ColorAttachments.size() != PassDesc.ColorAttachments.size())
-    return llvm::createStringError(
-        std::errc::invalid_argument,
-        "RenderPassBeginDesc color attachment count does not match its "
-        "RenderPass.");
-  if (PassDesc.DepthStencil.has_value() != (Desc.DepthStencil != nullptr))
-    return llvm::createStringError(std::errc::invalid_argument,
-                                   "RenderPassBeginDesc depth-stencil "
-                                   "presence does not match its RenderPass.");
-
-  uint32_t Width = 0, Height = 0;
-  if (auto Err = findAndValidateRenderPassTextureSize(Desc, &Width, &Height))
-    return Err;
-
-  llvm::SmallVector<VkImageView, 9> Views;
-  llvm::SmallVector<VkClearValue, 9> ClearValues;
-
-  for (size_t I = 0; I < Desc.ColorAttachments.size(); ++I) {
-    if (!Desc.ColorAttachments[I])
-      return llvm::createStringError(
-          std::errc::invalid_argument,
-          "RenderPassBeginDesc has a null color attachment texture.");
-    auto &Tex = llvm::cast<VulkanTexture>(*Desc.ColorAttachments[I]);
-    if (Tex.View == VK_NULL_HANDLE)
-      return llvm::createStringError(
-          std::errc::invalid_argument,
-          "Color attachment texture has no image view.");
-    Views.push_back(Tex.View);
-
-    VkClearValue CV = {};
-    if (PassDesc.ColorAttachments[I].Load == offloadtest::LoadAction::Clear) {
-      if (!Tex.Desc.OptimizedClearValue)
-        return llvm::createStringError(
-            std::errc::invalid_argument,
-            "LoadAction::Clear requires the render target to have been "
-            "created with an OptimizedClearValue.");
-      const auto *ColorCV =
-          std::get_if<ClearColor>(&*Tex.Desc.OptimizedClearValue);
-      assert(ColorCV &&
-             "RenderTarget OptimizedClearValue must be a ClearColor");
-      CV.color = {{ColorCV->R, ColorCV->G, ColorCV->B, ColorCV->A}};
-    }
-    ClearValues.push_back(CV);
-  }
-
-  if (Desc.DepthStencil) {
-    auto &Tex = llvm::cast<VulkanTexture>(*Desc.DepthStencil);
-    if (Tex.View == VK_NULL_HANDLE)
-      return llvm::createStringError(
-          std::errc::invalid_argument,
-          "Depth-stencil attachment texture has no image view.");
-    Views.push_back(Tex.View);
-
-    const auto &DS = *PassDesc.DepthStencil;
-    VkClearValue CV = {};
-    if (DS.DepthLoad == offloadtest::LoadAction::Clear ||
-        DS.StencilLoad == offloadtest::LoadAction::Clear) {
-      if (!Tex.Desc.OptimizedClearValue)
-        return llvm::createStringError(
-            std::errc::invalid_argument,
-            "LoadAction::Clear requires the depth-stencil texture to have "
-            "been created with an OptimizedClearValue.");
-      const auto *DepthCV =
-          std::get_if<ClearDepthStencil>(&*Tex.Desc.OptimizedClearValue);
-      assert(DepthCV &&
-             "DepthStencil OptimizedClearValue must be a ClearDepthStencil");
-      CV.depthStencil = {DepthCV->Depth, DepthCV->Stencil};
-    }
-    ClearValues.push_back(CV);
-  }
-
-  for (size_t I = 0; I < Desc.ColorAttachments.size(); ++I) {
-    auto &Tex = llvm::cast<VulkanTexture>(*Desc.ColorAttachments[I]);
-    if (PassDesc.ColorAttachments[I].Load == LoadAction::Load) {
-      this->addImageTransition(
-          this->PendingSrcAccess, /*SrcAccessMask*/
-          VK_ACCESS_COLOR_ATTACHMENT_READ_BIT |
-              VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT, /*DstAccessMask*/
-          Tex.preferredLayoutOrUndefined(),         /*OldLayout*/
-          VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, /*NewLayout*/
-          Tex);
-    }
-  }
-
-  if (Desc.DepthStencil) {
-    auto &Tex = llvm::cast<VulkanTexture>(*Desc.DepthStencil);
-
-    if (PassDesc.DepthStencil->DepthLoad == LoadAction::Load ||
-        PassDesc.DepthStencil->StencilLoad == LoadAction::Load) {
-      this->addImageTransition(
-          this->PendingSrcAccess, /*SrcAccessMask*/
-          VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT |
-              VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT, /*DstAccessMask*/
-          Tex.preferredLayoutOrUndefined(),                 /*OldLayout*/
-          VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL, /*NewLayout*/
-          Tex);
-    }
-  }
-
-  VkFramebufferCreateInfo FBCI = {};
-  FBCI.sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
-  FBCI.renderPass = VKPass.Handle;
-  FBCI.attachmentCount = static_cast<uint32_t>(Views.size());
-  FBCI.pAttachments = Views.data();
-  FBCI.width = Width;
-  FBCI.height = Height;
-  FBCI.layers = 1;
-
-  VkFramebuffer Framebuffer = VK_NULL_HANDLE;
-  if (auto Err =
-          VK::toError(vkCreateFramebuffer(Device, &FBCI, nullptr, &Framebuffer),
-                      "Failed to create framebuffer for RenderEncoder."))
-    return Err;
-
-  // The framebuffer must outlive this encoder and remain valid through GPU
-  // execution; the command buffer destroys it on teardown. The render pass
-  // is owned by the user-supplied VulkanRenderPass.
-  OwnedFramebuffers.push_back(Framebuffer);
-
-  VkRenderPassBeginInfo BeginInfo = {};
-  BeginInfo.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
-  BeginInfo.renderPass = VKPass.Handle;
-  BeginInfo.framebuffer = Framebuffer;
-  BeginInfo.renderArea.extent.width = Width;
-  BeginInfo.renderArea.extent.height = Height;
-  BeginInfo.clearValueCount = static_cast<uint32_t>(ClearValues.size());
-  BeginInfo.pClearValues = ClearValues.data();
-
-  this->flushBarrier();
-
-  vkCmdBeginRenderPass(CmdBuffer, &BeginInfo, VK_SUBPASS_CONTENTS_INLINE);
-
-  return std::make_unique<VulkanRenderEncoder>(*this, Desc);
-}
 
 class VulkanDevice : public offloadtest::Device {
   // VKComputeEncoder needs access to the device's RT entry points and the
@@ -4779,6 +4638,161 @@ public:
   }
 };
 
+} // namespace
+
+llvm::Expected<std::unique_ptr<offloadtest::ComputeEncoder>>
+VulkanCommandBuffer::createComputeEncoder() {
+  auto Enc = std::make_unique<VKComputeEncoder>(*this);
+  Enc->pushDebugGroup("ComputeEncoder");
+  return Enc;
+}
+
+llvm::Expected<std::unique_ptr<offloadtest::RenderEncoder>>
+VulkanCommandBuffer::createRenderEncoder(
+    const offloadtest::RenderPassBeginDesc &Desc) {
+  // The pass carries the VkRenderPass and the format / load / store policy.
+  // The begin desc supplies the textures that get bound for this encoder.
+  if (!Desc.Pass)
+    return llvm::createStringError(
+        std::errc::invalid_argument,
+        "RenderPassBeginDesc is missing its RenderPass.");
+  auto &VKPass = llvm::cast<VulkanRenderPass>(*Desc.Pass);
+  const offloadtest::RenderPassDesc &PassDesc = VKPass.Desc;
+  if (Desc.ColorAttachments.size() != PassDesc.ColorAttachments.size())
+    return llvm::createStringError(
+        std::errc::invalid_argument,
+        "RenderPassBeginDesc color attachment count does not match its "
+        "RenderPass.");
+  if (PassDesc.DepthStencil.has_value() != (Desc.DepthStencil != nullptr))
+    return llvm::createStringError(std::errc::invalid_argument,
+                                   "RenderPassBeginDesc depth-stencil "
+                                   "presence does not match its RenderPass.");
+
+  uint32_t Width = 0, Height = 0;
+  if (auto Err = findAndValidateRenderPassTextureSize(Desc, &Width, &Height))
+    return Err;
+
+  llvm::SmallVector<VkImageView, 9> Views;
+  llvm::SmallVector<VkClearValue, 9> ClearValues;
+
+  for (size_t I = 0; I < Desc.ColorAttachments.size(); ++I) {
+    if (!Desc.ColorAttachments[I])
+      return llvm::createStringError(
+          std::errc::invalid_argument,
+          "RenderPassBeginDesc has a null color attachment texture.");
+    auto &Tex = llvm::cast<VulkanTexture>(*Desc.ColorAttachments[I]);
+    if (Tex.View == VK_NULL_HANDLE)
+      return llvm::createStringError(
+          std::errc::invalid_argument,
+          "Color attachment texture has no image view.");
+    Views.push_back(Tex.View);
+
+    VkClearValue CV = {};
+    if (PassDesc.ColorAttachments[I].Load == offloadtest::LoadAction::Clear) {
+      if (!Tex.Desc.OptimizedClearValue)
+        return llvm::createStringError(
+            std::errc::invalid_argument,
+            "LoadAction::Clear requires the render target to have been "
+            "created with an OptimizedClearValue.");
+      const auto *ColorCV =
+          std::get_if<ClearColor>(&*Tex.Desc.OptimizedClearValue);
+      assert(ColorCV &&
+             "RenderTarget OptimizedClearValue must be a ClearColor");
+      CV.color = {{ColorCV->R, ColorCV->G, ColorCV->B, ColorCV->A}};
+    }
+    ClearValues.push_back(CV);
+  }
+
+  if (Desc.DepthStencil) {
+    auto &Tex = llvm::cast<VulkanTexture>(*Desc.DepthStencil);
+    if (Tex.View == VK_NULL_HANDLE)
+      return llvm::createStringError(
+          std::errc::invalid_argument,
+          "Depth-stencil attachment texture has no image view.");
+    Views.push_back(Tex.View);
+
+    const auto &DS = *PassDesc.DepthStencil;
+    VkClearValue CV = {};
+    if (DS.DepthLoad == offloadtest::LoadAction::Clear ||
+        DS.StencilLoad == offloadtest::LoadAction::Clear) {
+      if (!Tex.Desc.OptimizedClearValue)
+        return llvm::createStringError(
+            std::errc::invalid_argument,
+            "LoadAction::Clear requires the depth-stencil texture to have "
+            "been created with an OptimizedClearValue.");
+      const auto *DepthCV =
+          std::get_if<ClearDepthStencil>(&*Tex.Desc.OptimizedClearValue);
+      assert(DepthCV &&
+             "DepthStencil OptimizedClearValue must be a ClearDepthStencil");
+      CV.depthStencil = {DepthCV->Depth, DepthCV->Stencil};
+    }
+    ClearValues.push_back(CV);
+  }
+
+  for (size_t I = 0; I < Desc.ColorAttachments.size(); ++I) {
+    auto &Tex = llvm::cast<VulkanTexture>(*Desc.ColorAttachments[I]);
+    if (PassDesc.ColorAttachments[I].Load == LoadAction::Load) {
+      this->addImageTransition(
+          this->PendingSrcAccess, /*SrcAccessMask*/
+          VK_ACCESS_COLOR_ATTACHMENT_READ_BIT |
+              VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT, /*DstAccessMask*/
+          Tex.preferredLayoutOrUndefined(),         /*OldLayout*/
+          VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, /*NewLayout*/
+          Tex);
+    }
+  }
+
+  if (Desc.DepthStencil) {
+    auto &Tex = llvm::cast<VulkanTexture>(*Desc.DepthStencil);
+
+    if (PassDesc.DepthStencil->DepthLoad == LoadAction::Load ||
+        PassDesc.DepthStencil->StencilLoad == LoadAction::Load) {
+      this->addImageTransition(
+          this->PendingSrcAccess, /*SrcAccessMask*/
+          VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT |
+              VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT, /*DstAccessMask*/
+          Tex.preferredLayoutOrUndefined(),                 /*OldLayout*/
+          VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL, /*NewLayout*/
+          Tex);
+    }
+  }
+
+  VkFramebufferCreateInfo FBCI = {};
+  FBCI.sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
+  FBCI.renderPass = VKPass.Handle;
+  FBCI.attachmentCount = static_cast<uint32_t>(Views.size());
+  FBCI.pAttachments = Views.data();
+  FBCI.width = Width;
+  FBCI.height = Height;
+  FBCI.layers = 1;
+
+  VkFramebuffer Framebuffer = VK_NULL_HANDLE;
+  if (auto Err =
+          VK::toError(vkCreateFramebuffer(Device, &FBCI, nullptr, &Framebuffer),
+                      "Failed to create framebuffer for RenderEncoder."))
+    return Err;
+
+  // The framebuffer must outlive this encoder and remain valid through GPU
+  // execution; the command buffer destroys it on teardown. The render pass
+  // is owned by the user-supplied VulkanRenderPass.
+  OwnedFramebuffers.push_back(Framebuffer);
+
+  VkRenderPassBeginInfo BeginInfo = {};
+  BeginInfo.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
+  BeginInfo.renderPass = VKPass.Handle;
+  BeginInfo.framebuffer = Framebuffer;
+  BeginInfo.renderArea.extent.width = Width;
+  BeginInfo.renderArea.extent.height = Height;
+  BeginInfo.clearValueCount = static_cast<uint32_t>(ClearValues.size());
+  BeginInfo.pClearValues = ClearValues.data();
+
+  this->flushBarrier();
+
+  vkCmdBeginRenderPass(CmdBuffer, &BeginInfo, VK_SUBPASS_CONTENTS_INLINE);
+
+  return std::make_unique<VulkanRenderEncoder>(*this, Desc);
+}
+
 llvm::Error VKComputeEncoder::batchBuildAS(llvm::ArrayRef<ASBuildItem> Items) {
   if (Items.empty())
     return llvm::Error::success();
@@ -4973,16 +4987,6 @@ llvm::Error VKComputeEncoder::batchBuildAS(llvm::ArrayRef<ASBuildItem> Items) {
 }
 
 // === Ray tracing pipeline + SBT + DispatchRays ============================
-
-static VkRayTracingShaderGroupTypeKHR getRTGroupType(HitGroupType T) {
-  switch (T) {
-  case HitGroupType::Triangles:
-    return VK_RAY_TRACING_SHADER_GROUP_TYPE_TRIANGLES_HIT_GROUP_KHR;
-  case HitGroupType::Procedural:
-    return VK_RAY_TRACING_SHADER_GROUP_TYPE_PROCEDURAL_HIT_GROUP_KHR;
-  }
-  llvm_unreachable("All HitGroupType cases handled");
-}
 
 llvm::Expected<std::unique_ptr<PipelineState>>
 VulkanDevice::createPipelineRT(llvm::StringRef Name, const BindingsDesc &BD,
@@ -5293,7 +5297,6 @@ llvm::Error VKComputeEncoder::dispatchRays(const PipelineState &PSO,
                           Height, Depth);
   return llvm::Error::success();
 }
-} // namespace
 
 llvm::Expected<offloadtest::SubmitResult> VulkanQueue::submit(
     llvm::SmallVector<std::unique_ptr<offloadtest::CommandBuffer>> CBs) {

--- a/lib/Support/OffloadMigration.cpp
+++ b/lib/Support/OffloadMigration.cpp
@@ -37,7 +37,8 @@ static BufferShaderAccessType bufferShaderAccessTypeFromResourceKind(
         toFormat(Resource.BufferPtr->Format, Resource.BufferPtr->Channels);
     if (!FmtOrErr) {
       printf("Invalid format! FMT: %d, CHANNELS: %d\n",
-             Resource.BufferPtr->Format, Resource.BufferPtr->Channels);
+             static_cast<int>(Resource.BufferPtr->Format),
+             Resource.BufferPtr->Channels);
       assert(false && "Invalid format.");
     }
     OutParams.Fmt = *FmtOrErr;

--- a/lib/Support/Pipeline.cpp
+++ b/lib/Support/Pipeline.cpp
@@ -11,6 +11,7 @@
 
 #include "Support/Pipeline.h"
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/STLExtras.h"
 
 using namespace offloadtest;
 
@@ -648,7 +649,7 @@ void MappingTraits<offloadtest::TriangleGeometry>::mapping(
       return;
     }
     std::array<float, 12> T;
-    std::copy(Transform.begin(), Transform.end(), T.begin());
+    llvm::copy(Transform, T.begin());
     G.Transform = T;
   }
 }
@@ -680,7 +681,7 @@ void MappingTraits<offloadtest::InstanceDesc>::mapping(
                " floats (3x4 row-major), got " + llvm::Twine(Transform.size()));
     return;
   }
-  std::copy(Transform.begin(), Transform.end(), std::begin(D.Transform));
+  llvm::copy(Transform, std::begin(D.Transform));
   I.mapOptional("InstanceID", D.InstanceID, 0u);
   uint32_t Mask = D.InstanceMask;
   I.mapOptional("InstanceMask", Mask, 255u);

--- a/tools/imgdiff/imgdiff.cpp
+++ b/tools/imgdiff/imgdiff.cpp
@@ -30,7 +30,9 @@ static cl::opt<std::string> ActualPath(cl::Positional,
                                        cl::desc("<actual image>"),
                                        cl::value_desc("filename"));
 
+namespace {
 enum class ComparisonMode { ExactMatch, CIE76 };
+} // namespace
 
 static cl::opt<ComparisonMode>
     Mode("mode", cl::desc("Comparison Mode"), cl::init(ComparisonMode::CIE76),

--- a/unittests/Image/ColorTests.cpp
+++ b/unittests/Image/ColorTests.cpp
@@ -17,6 +17,7 @@
 
 using namespace offloadtest;
 
+namespace {
 TEST(ColorTests, RoundTrip) {
   {
     Color RGB = Color(1.0, 0.5, 0.0);
@@ -48,3 +49,4 @@ TEST(ColorTests, RoundTrip) {
     EXPECT_EQ(RGB.getAs<uint16_t>(), RGBPrime.getAs<uint16_t>());
   }
 }
+} // namespace


### PR DESCRIPTION
- Modifies the `.clang-tidy` to separate the Checks into multiple lines for better readability, adds -llvm-header-guard to silence clang-tidy warnings/errors regarding `OFFLOADTEST_` prefixes on header guards, and adds `-misc-const-correctness` to disable const correctness checks which have false-positives that differ across clang-tidy versions

- The CMakeLists.txt has been modified to pass `--header-filter=^${CMAKE_CURRENT_SOURCE_DIR}/.*)` to clang-tidy so that it is restricted to scanning project source files. This prevents clang-tidy from scanning llvm-project headers.

- All github workflows now specify -DOFFLOADTEST_USE_CLANG_TIDY=ON (except MacOS which does not have clang-tidy).

- Code refactoring has been performed to eliminate all clang-tidy warnings/errors from the latest clang-tidy version of 22.1.8

Assisted by: Claude Opus 4.8