### PR TITLE
[SPIRV] remove xfails for Flat and Location decorators

### DIFF
--- a/test/Feature/Semantics/NestedStructSemantics.test
+++ b/test/Feature/Semantics/NestedStructSemantics.test
@@ -102,9 +102,6 @@ Results:
 # Semantics are not implemented in the DXIL backend.
 # XFAIL: Clang && !Vulkan
 
-# Bug https://github.com/llvm/llvm-project/issues/194293
-# XFAIL: Clang && Vulkan
-
 # Driver bug https://gitlab.freedesktop.org/mesa/mesa/-/work_items/15865,
 # Lavapipe (llvmpipe) intermittently crashes (0xc0000005 / SIGSEGV, no output). 
 # UNSUPPORTED: Lavapipe

--- a/test/Feature/Semantics/SemanticTypes.test
+++ b/test/Feature/Semantics/SemanticTypes.test
@@ -104,9 +104,6 @@ Results:
 # Semantics are not implemented in the DXIL backend.
 # XFAIL: Clang && !Vulkan
 
-# Bug https://github.com/llvm/llvm-project/issues/194293
-# XFAIL: Clang && Vulkan
-
 # Driver bug https://gitlab.freedesktop.org/mesa/mesa/-/work_items/15865,
 # Lavapipe (llvmpipe) intermittently crashes (0xc0000005 / SIGSEGV, no output). 
 # UNSUPPORTED: Lavapipe

--- a/test/Feature/Semantics/ShadowedSemantics.test
+++ b/test/Feature/Semantics/ShadowedSemantics.test
@@ -107,9 +107,6 @@ Results:
 # Semantics are not implemented in the DXIL backend.
 # XFAIL: Clang && !Vulkan
 
-# Bug https://github.com/llvm/llvm-project/issues/194293
-# XFAIL: Clang && Vulkan
-
 # Driver bug https://gitlab.freedesktop.org/mesa/mesa/-/work_items/15865,
 # Lavapipe (llvmpipe) intermittently crashes (0xc0000005 / SIGSEGV, no output). 
 # UNSUPPORTED: Lavapipe


### PR DESCRIPTION
Some time ago we added the spir-val as part of testing generated SPIR-V is valid. This caused 3 tests to fail in the offload test suite when clang generated the SPIR-V. PR https://github.com/llvm/llvm-project/pull/210116 has merged and is now adding the proper decorators to the code so we can remove the xfails.