### PR TITLE
[SPIRV] Enable 1x4 matrix cbuffer

### DIFF
--- a/test/Feature/CBuffer/Matrix/SingleSubscript/mat_cbuffer.f32.test
+++ b/test/Feature/CBuffer/Matrix/SingleSubscript/mat_cbuffer.f32.test
@@ -168,9 +168,6 @@ DescriptorSets:
       VulkanBinding:
         Binding: 7
 
-# BUG https://github.com/llvm/llvm-project/issues/191070
-# XFAIL: Clang && Vulkan
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -fvk-use-dx-layout -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
issue https://github.com/llvm/llvm-project/issues/191070 is now fixed by https://github.com/llvm/llvm-project/pull/209912 so we can enable this test.