### PR TITLE
[SPIR-V] Enable Matrix Layout tests

### DIFF
--- a/test/Feature/CBuffer/Matrix/LayoutKeyword/matrix_multiply.test
+++ b/test/Feature/CBuffer/Matrix/LayoutKeyword/matrix_multiply.test
@@ -20,9 +20,13 @@ cbuffer CB_Vec : register(b4) {
     float2 v;
 };
 
+[[vk::binding(5, 0)]]
 RWBuffer<float> VecMatRM : register(u0);
+[[vk::binding(6, 0)]]
 RWBuffer<float> VecMatCM : register(u1);
+[[vk::binding(7, 0)]]
 RWBuffer<float> MatMatRMCM : register(u2);
+[[vk::binding(8, 0)]]
 RWBuffer<float> MatMatCMRM : register(u3);
 
 float3 vec_mat_rm(float2 v, row_major float2x3 m) { return mul(v, m); }
@@ -190,12 +194,6 @@ DescriptorSets:
         Binding: 8
 ...
 #--- end
-
-# Bug https://github.com/microsoft/DirectXShaderCompiler/issues/8473
-# XFAIL: Vulkan && DXC
-
-# Task: https://github.com/llvm/llvm-project/issues/201712
-# XFAIL: Vulkan && Clang
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -fvk-use-dx-layout -T cs_6_0 -Fo %t.o %t/source.hlsl

--- a/test/Feature/CBuffer/Matrix/LayoutKeyword/single_subscript.test
+++ b/test/Feature/CBuffer/Matrix/LayoutKeyword/single_subscript.test
@@ -8,7 +8,9 @@ cbuffer CBCM : register(b1) {
     column_major float3x2 cm;
 };
 
+[[vk::binding(2, 0)]]
 RWBuffer<float2> Out : register(u0);
+[[vk::binding(3, 0)]]
 RWBuffer<float2> Out2 : register(u1);
 
 float2 subscript_rm(int row, row_major float3x2 m) {
@@ -99,12 +101,6 @@ DescriptorSets:
         Binding: 3
 ...
 #--- end
-
-# Bug https://github.com/microsoft/DirectXShaderCompiler/issues/8473
-# XFAIL: Vulkan && DXC
-
-# Task: https://github.com/llvm/llvm-project/issues/201712
-# XFAIL: Vulkan && Clang
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -fvk-use-dx-layout -T cs_6_0 -Fo %t.o %t/source.hlsl

--- a/test/Feature/CBuffer/Matrix/LayoutKeyword/subscript.test
+++ b/test/Feature/CBuffer/Matrix/LayoutKeyword/subscript.test
@@ -8,7 +8,9 @@ cbuffer CBCM : register(b1) {
     column_major float3x2 cm;
 };
 
+[[vk::binding(2, 0)]]
 RWBuffer<float> Out : register(u0);
+[[vk::binding(3, 0)]]
 RWBuffer<float> Out2 : register(u1);
 
 float subscript_rm(int row, int col, row_major float3x2 m) {
@@ -97,12 +99,6 @@ DescriptorSets:
         Binding: 3
 ...
 #--- end
-
-# Bug https://github.com/microsoft/DirectXShaderCompiler/issues/8473
-# XFAIL: Vulkan && DXC
-
-# Task: https://github.com/llvm/llvm-project/issues/201712
-# XFAIL: Vulkan && Clang
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -fvk-use-dx-layout -T cs_6_0 -Fo %t.o %t/source.hlsl

--- a/test/Feature/CBuffer/Matrix/LayoutKeyword/swizzle.test
+++ b/test/Feature/CBuffer/Matrix/LayoutKeyword/swizzle.test
@@ -8,7 +8,9 @@ cbuffer CB_CM : register(b1) {
     column_major float2x3 cm;
 };
 
+[[vk::binding(2, 0)]]
 RWBuffer<float> OutRM : register(u0);
+[[vk::binding(3, 0)]]
 RWBuffer<float> OutCM : register(u1);
 
 // Zero-based row swizzle getters
@@ -179,12 +181,6 @@ DescriptorSets:
         Binding: 3
 ...
 #--- end
-
-# Bug https://github.com/microsoft/DirectXShaderCompiler/issues/8473
-# XFAIL: Vulkan && DXC
-
-# Task: https://github.com/llvm/llvm-project/issues/201712
-# XFAIL: Vulkan && Clang
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -fvk-use-dx-layout -T cs_6_0 -Fo %t.o %t/source.hlsl

--- a/test/Feature/CBuffer/Matrix/LayoutKeyword/transpose.test
+++ b/test/Feature/CBuffer/Matrix/LayoutKeyword/transpose.test
@@ -16,9 +16,13 @@ cbuffer CB_CM_3x2 : register(b3) {
     column_major float3x2 cm_3x2;
 };
 
+[[vk::binding(4, 0)]]
 RWBuffer<float> OutRM2x3 : register(u0);
+[[vk::binding(5, 0)]]
 RWBuffer<float> OutCM2x3 : register(u1);
+[[vk::binding(6, 0)]]
 RWBuffer<float> OutRM3x2 : register(u2);
+[[vk::binding(7, 0)]]
 RWBuffer<float> OutCM3x2 : register(u3);
 
 float3x2 transpose_rm_2x3(row_major float2x3 m) { return transpose(m); }
@@ -179,12 +183,6 @@ DescriptorSets:
         Binding: 7
 ...
 #--- end
-
-# Bug https://github.com/microsoft/DirectXShaderCompiler/issues/8473
-# XFAIL: Vulkan && DXC
-
-# Unimplemented: https://github.com/llvm/llvm-project/issues/201712
-# XFAIL: Vulkan && Clang
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -fvk-use-dx-layout -T cs_6_0 -Fo %t.o %t/source.hlsl


### PR DESCRIPTION
Enabling these tests is a two part plan
- One for LLVM we needed to fix a legalization crash. This pr fixed it: https://github.com/llvm/llvm-project/pull/209672
- For both DXC and LLVM we needed to apply vk bindings to the RWBuffers