### PR TITLE
[SPIRV] Enable particle-life.test

### DIFF
--- a/test/UseCase/particle-life.test
+++ b/test/UseCase/particle-life.test
@@ -351,10 +351,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Unimplemented: CBuffer not implemented in Clang's Vulkan implementation.
-# https://github.com/llvm/llvm-project/issues/124597
-# XFAIL: Clang && Vulkan
-
 # CBuffer bindings seem to be broken under metal
 # Bug https://github.com/llvm/offload-test-suite/issues/55
 # XFAIL: Metal


### PR DESCRIPTION
This PR: https://github.com/llvm/llvm-project/pull/209912 did some vector widdening for cbuffers. It seems to have been the last piece we needed to enable SPIR-V cbuffer support and turn on the particle life use case.