### PR TITLE
Add `pow` matrix tests

### DIFF
--- a/test/Feature/HLSLLib/pow_mat.16.test
+++ b/test/Feature/HLSLLib/pow_mat.16.test
@@ -1,0 +1,132 @@
+#--- source.hlsl
+StructuredBuffer<half4> X : register(t0);
+StructuredBuffer<half4> Y : register(t1);
+
+RWStructuredBuffer<half4> Out : register(u2);
+
+[numthreads(1,1,1)]
+void main() {
+  half3x2 H32 = pow(half3x2(X[0].xyz, X[1].xyz),
+                    half3x2(Y[0].xyz, Y[1].xyz));
+  half2x4 H24 = pow(half2x4(X[2], X[3]),
+                    half2x4(Y[2], Y[3]));
+  half3x1 H31 = pow(half3x1(X[4].xyz),
+                    half3x1(Y[4].xyz));
+  half4x4 H44 = pow(half4x4(X[5], X[6], X[7], X[8]),
+                    half4x4(Y[5], Y[6], Y[7], Y[8]));
+  half2x2 H22Const = pow(half2x2(2.0, 4.0, 16.0, 256.0),
+                         half2x2(0.5, 0.5, 0.5, 0.5));
+
+  Out[0] = half4(H32[0], H32[1]);
+  Out[1] = half4(H32[2], 0.0, 0.0);
+  Out[2] = H24[0];
+  Out[3] = H24[1];
+  Out[4] = half4(H31[0], H31[1], H31[2], 0.0);
+  Out[5] = H44[0];
+  Out[6] = H44[1];
+  Out[7] = H44[2];
+  Out[8] = H44[3];
+  Out[9] = half4(H22Const[0], H22Const[1]);
+}
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+Buffers:
+  - Name: X
+    Format: Float16
+    Stride: 8
+    Data: [ 0x4000, 0x4400, 0x4880, 0x0000,
+            0x4C00, 0x4500, 0x4800, 0x0000,
+            0x4000, 0x4400, 0x4800, 0x4C00,
+            0x4200, 0x4400, 0x4500, 0x4000,
+            0x4000, 0x4880, 0x4800, 0x0000,
+            0x4000, 0x4400, 0x4C00, 0x5C00,
+            0x3C00, 0x4900, 0x4900, 0x3400,
+            0x4200, 0x4200, 0x4200, 0x4200,
+            0x3800, 0x3400, 0x4400, 0x4880 ]
+    # 3x2: 2, 4, 9, _, 16, 5, 8, _
+    # 2x4: 2, 4, 8, 16, 3, 4, 5, 2
+    # 3x1: 2, 9, 8, _
+    # 4x4: 2, 4, 16, 256, 1, 10, 10, 0.25,
+    #      3, 3, 3, 3, 0.5, 0.25, 4, 9
+  - Name: Y
+    Format: Float16
+    Stride: 8
+    Data: [ 0x4200, 0x3800, 0x3800, 0x0000,
+            0x3400, 0x3C00, 0x4000, 0x0000,
+            0x3C00, 0x4000, 0x4200, 0x3800,
+            0x3800, 0x4000, 0x3800, 0x4200,
+            0x4200, 0x3800, 0x4000, 0x0000,
+            0x3800, 0x3800, 0x3800, 0x3800,
+            0x4500, 0x3C00, 0x3800, 0x3800,
+            0x0000, 0x3C00, 0x4000, 0x4200,
+            0xBC00, 0xBC00, 0x4000, 0x3800 ]
+    # 3x2: 3, 0.5, 0.5, _, 0.25, 1, 2, _
+    # 2x4: 1, 2, 3, 0.5, 0.5, 2, 0.5, 3
+    # 3x1: 3, 0.5, 2, _
+    # 4x4: 0.5, 0.5, 0.5, 0.5, 5, 1, 0.5, 0.5,
+    #      0, 1, 2, 3, -1, -1, 2, 0.5
+  - Name: Out
+    Format: Float16
+    Stride: 8
+    FillSize: 80
+  - Name: ExpectedOut
+    Format: Float16
+    Stride: 8
+    Data: [ 0x4800, 0x4000, 0x4200, 0x4000,
+            0x4500, 0x5400, 0x0000, 0x0000,
+            0x4000, 0x4C00, 0x6000, 0x4400,
+            0x3EEE, 0x4C00, 0x4079, 0x4800,
+            0x4800, 0x4200, 0x5400, 0x0000,
+            0x3DA8, 0x4000, 0x4400, 0x4C00,
+            0x3C00, 0x4900, 0x4253, 0x3800,
+            0x3C00, 0x4200, 0x4880, 0x4EC0,
+            0x4000, 0x4400, 0x4C00, 0x4200,
+            0x3DA8, 0x4000, 0x4400, 0x4C00 ]
+    # 3x2: 8, 2, 3, 2, 5, 64, _, _
+    # 2x4: 2, 16, 512, 4, 1.732422, 16, 2.236328, 8
+    # 3x1: 8, 3, 64, _
+    # 4x4: 1.414062, 2, 4, 16, 1, 10, 3.162109, 0.5,
+    #      1, 3, 9, 27, 2, 4, 16, 3
+    # 2x2 const: 1.414062, 2, 4, 16
+Results:
+  - Result: Test
+    Rule: BufferFloatULP
+    ULPT: 2
+    Actual: Out
+    Expected: ExpectedOut
+DescriptorSets:
+  - Resources:
+    - Name: X
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: Y
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+    - Name: Out
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 2
+        Space: 0
+      VulkanBinding:
+        Binding: 2
+#--- end
+
+# Unimplemented https://github.com/llvm/llvm-project/issues/184513
+# XFAIL: Clang
+
+# REQUIRES: Half
+# RUN: split-file %s %t
+# RUN: %dxc_target -enable-16bit-types -HV 202x -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/pow_mat.32.test
+++ b/test/Feature/HLSLLib/pow_mat.32.test
@@ -1,0 +1,115 @@
+#--- source.hlsl
+StructuredBuffer<float4> X : register(t0);
+StructuredBuffer<float4> Y : register(t1);
+
+RWStructuredBuffer<float4> Out : register(u2);
+
+[numthreads(1,1,1)]
+void main() {
+  float3x2 F32 = pow(float3x2(X[0].xyz, X[1].xyz),
+                     float3x2(Y[0].xyz, Y[1].xyz));
+  float2x4 F24 = pow(float2x4(X[2], X[3]),
+                     float2x4(Y[2], Y[3]));
+  float3x1 F31 = pow(float3x1(X[4].xyz),
+                     float3x1(Y[4].xyz));
+  float4x4 F44 = pow(float4x4(X[5], X[6], X[7], X[8]),
+                     float4x4(Y[5], Y[6], Y[7], Y[8]));
+  float2x2 F22Const = pow(float2x2(2.0, 4.0, 16.0, 256.0),
+                          float2x2(0.5, 0.5, 0.5, 0.5));
+
+  Out[0] = float4(F32[0], F32[1]);
+  Out[1] = float4(F32[2], 0.0, 0.0);
+  Out[2] = F24[0];
+  Out[3] = F24[1];
+  Out[4] = float4(F31[0], F31[1], F31[2], 0.0);
+  Out[5] = F44[0];
+  Out[6] = F44[1];
+  Out[7] = F44[2];
+  Out[8] = F44[3];
+  Out[9] = float4(F22Const[0], F22Const[1]);
+}
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+Buffers:
+  - Name: X
+    Format: Float32
+    Stride: 16
+    Data: [ 2, 4, 9, 0,
+            16, 5, 8, 0,
+            2, 4, 8, 16,
+            3, 4, 5, 2,
+            2, 9, 8, 0,
+            2, 4, 16, 256,
+            1, 10, 10, 0.25,
+            3, 3, 3, 3,
+            0.5, 0.25, 4, 9 ]
+  - Name: Y
+    Format: Float32
+    Stride: 16
+    Data: [ 3, 0.5, 0.5, 0,
+            0.25, 1, 2, 0,
+            1, 2, 3, 0.5,
+            0.5, 2, 0.5, 3,
+            3, 0.5, 2, 0,
+            0.5, 0.5, 0.5, 0.5,
+            5, 1, 0.5, 0.5,
+            0, 1, 2, 3,
+            -1, -1, 2, 0.5 ]
+  - Name: Out
+    Format: Float32
+    Stride: 16
+    FillSize: 160
+  - Name: ExpectedOut
+    Format: Float32
+    Stride: 16
+    Data: [ 8, 2, 3, 2,
+            5, 64, 0, 0,
+            2, 16, 512, 4,
+            1.732051, 16, 2.236068, 8,
+            8, 3, 64, 0,
+            1.414214, 2, 4, 16,
+            1, 10, 3.162278, 0.5,
+            1, 3, 9, 27,
+            2, 4, 16, 3,
+            1.414214, 2, 4, 16 ]
+Results:
+  - Result: Test
+    Rule: BufferFloatEpsilon
+    Epsilon: 0.0008
+    Actual: Out
+    Expected: ExpectedOut
+DescriptorSets:
+  - Resources:
+    - Name: X
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: Y
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+    - Name: Out
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 2
+        Space: 0
+      VulkanBinding:
+        Binding: 2
+#--- end
+
+# Unimplemented https://github.com/llvm/llvm-project/issues/184513
+# XFAIL: Clang
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -HV 202x -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
Closes #818.

Adds matrix tests for `pow` testing `half` and `float`. Will remove the XFAILs once the Clang implementation is in.

Assisted-by: Github Copilot