### PR TITLE
XFAIL tests that sink OpImageSampleImplicitLod into control flow

### DIFF
--- a/test/Feature/Textures/Texture2D.CalculateLevelOfDetail.test.yaml
+++ b/test/Feature/Textures/Texture2D.CalculateLevelOfDetail.test.yaml
@@ -133,6 +133,12 @@ Results:
 # Lavapipe (llvmpipe) intermittently crashes (0xc0000005 / SIGSEGV, no output). 
 # UNSUPPORTED: Lavapipe
 
+# OpImageSampleImplicitLod is illegally sunk into control flow, but it seems
+# that intel drivers can handle this.
+#
+# Bug: https://github.com/llvm/llvm-project/issues/212365
+# XFAIL: Clang && Vulkan && !Intel
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T vs_6_6 -E mainVS -Fo %t-vs.o %t/vertex.hlsl
 # RUN: %dxc_target -T ps_6_6 -E mainPS -Fo %t-ps.o %t/pixel.hlsl

--- a/test/Feature/Textures/Texture2D.Sample.test.yaml
+++ b/test/Feature/Textures/Texture2D.Sample.test.yaml
@@ -167,6 +167,12 @@ Results:
 # Lavapipe (llvmpipe) intermittently crashes (0xc0000005 / SIGSEGV, no output). 
 # UNSUPPORTED: Lavapipe
 
+# OpImageSampleImplicitLod is illegally sunk into control flow, but it seems
+# that intel drivers can handle this.
+#
+# Bug: https://github.com/llvm/llvm-project/issues/212365
+# XFAIL: Clang && Vulkan && !Intel
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T vs_6_0 -E mainVS -Fo %t-vs.o %t/vertex.hlsl
 # RUN: %dxc_target -T ps_6_0 -E mainPS -Fo %t-ps.o %t/pixel.hlsl

--- a/test/Feature/Textures/Texture2D.SampleBias.test.yaml
+++ b/test/Feature/Textures/Texture2D.SampleBias.test.yaml
@@ -160,6 +160,12 @@ Results:
 # Lavapipe (llvmpipe) intermittently crashes (0xc0000005 / SIGSEGV, no output). 
 # UNSUPPORTED: Lavapipe
 
+# OpImageSampleImplicitLod is illegally sunk into control flow, but it seems
+# that intel drivers can handle this.
+#
+# Bug: https://github.com/llvm/llvm-project/issues/212365
+# XFAIL: Clang && Vulkan && !Intel
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T vs_6_0 -E mainVS -Fo %t-vs.o %t/vertex.hlsl
 # RUN: %dxc_target -T ps_6_0 -E mainPS -Fo %t-ps.o %t/pixel.hlsl


### PR DESCRIPTION
These three tests have control flow that clang incorrectly sinks OpImageSampleImplicitLod into. See llvm/llvm-project#212365.