### PR TITLE
Update unimplemented xfails for interlockedor

### DIFF
--- a/test/Feature/HLSLLib/InterlockedOr.32.test
+++ b/test/Feature/HLSLLib/InterlockedOr.32.test
@@ -122,6 +122,9 @@ DescriptorSets:
 ...
 #--- end
 
+# Bug: https://github.com/llvm/offload-test-suite/issues/1402
+# XFAIL: Metal
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/InterlockedOr.32.test
+++ b/test/Feature/HLSLLib/InterlockedOr.32.test
@@ -122,9 +122,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Unimplemented: https://github.com/llvm/llvm-project/issues/99126
-# XFAIL: Clang
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/InterlockedOr.32.test
+++ b/test/Feature/HLSLLib/InterlockedOr.32.test
@@ -123,7 +123,10 @@ DescriptorSets:
 #--- end
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/1402
-# XFAIL: Metal
+# XFAIL: Clang
+
+# Bug: https://github.com/llvm/offload-test-suite/issues/1404
+# XFAIL: Intel && Clang && Vulkan
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/InterlockedOr.int64.test
+++ b/test/Feature/HLSLLib/InterlockedOr.int64.test
@@ -127,9 +127,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Unimplemented: https://github.com/llvm/llvm-project/issues/99126
-# XFAIL: Clang
-
 # Bug: https://github.com/llvm/offload-test-suite/issues/1164
 # XFAIL: Metal && DXC
 

--- a/test/Feature/HLSLLib/InterlockedOr.int64.test
+++ b/test/Feature/HLSLLib/InterlockedOr.int64.test
@@ -127,6 +127,9 @@ DescriptorSets:
 ...
 #--- end
 
+# Bug: https://github.com/llvm/offload-test-suite/issues/1402
+# XFAIL: Clang && !(Intel && !WARP)
+
 # Bug: https://github.com/llvm/offload-test-suite/issues/1164
 # XFAIL: Metal && DXC
 

--- a/test/Feature/HLSLLib/InterlockedOr.resources.32.test
+++ b/test/Feature/HLSLLib/InterlockedOr.resources.32.test
@@ -219,9 +219,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Unimplemented: https://github.com/llvm/llvm-project/issues/99126
-# XFAIL: Clang
-
 # Bug: https://github.com/llvm/offload-test-suite/issues/1164
 # XFAIL: Metal && DXC
 

--- a/test/Feature/HLSLLib/InterlockedOr.resources.32.test
+++ b/test/Feature/HLSLLib/InterlockedOr.resources.32.test
@@ -219,6 +219,9 @@ DescriptorSets:
 ...
 #--- end
 
+# Unimplemented: https://github.com/llvm/llvm-project/issues/194930
+# XFAIL: Clang
+
 # Bug: https://github.com/llvm/offload-test-suite/issues/1164
 # XFAIL: Metal && DXC
 

--- a/test/Feature/HLSLLib/InterlockedOr.resources.int64.test
+++ b/test/Feature/HLSLLib/InterlockedOr.resources.int64.test
@@ -167,6 +167,9 @@ DescriptorSets:
 ...
 #--- end
 
+# Bug: https://github.com/llvm/offload-test-suite/issues/1407
+# XFAIL: Intel && Clang && Vulkan
+
 # Bug: https://github.com/llvm/offload-test-suite/issues/1164
 # XFAIL: Metal
 

--- a/test/Feature/HLSLLib/InterlockedOr.resources.int64.test
+++ b/test/Feature/HLSLLib/InterlockedOr.resources.int64.test
@@ -167,9 +167,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Unimplemented: https://github.com/llvm/llvm-project/issues/99126
-# XFAIL: Clang
-
 # Bug: https://github.com/llvm/offload-test-suite/issues/1164
 # XFAIL: Metal && DXC
 

--- a/test/Feature/HLSLLib/InterlockedOr.resources.int64.test
+++ b/test/Feature/HLSLLib/InterlockedOr.resources.int64.test
@@ -168,7 +168,7 @@ DescriptorSets:
 #--- end
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/1164
-# XFAIL: Metal && DXC
+# XFAIL: Metal
 
 # Unimplemented: https://github.com/microsoft/DirectXShaderCompiler/issues/8451
 # XFAIL: Vulkan && DXC

--- a/test/Feature/HLSLLib/InterlockedOr.resources.typed.int64.test
+++ b/test/Feature/HLSLLib/InterlockedOr.resources.typed.int64.test
@@ -125,6 +125,9 @@ DescriptorSets:
 ...
 #--- end
 
+# Bug: https://github.com/llvm/llvm-project/issues/116148
+# XFAIL: Clang 
+
 # REQUIRES: Int64TypedResourceAtomics && SM_6_6
 # RUN: split-file %s %t
 # RUN: %dxc_target -HV 202x -T cs_6_6 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/InterlockedOr.resources.typed.int64.test
+++ b/test/Feature/HLSLLib/InterlockedOr.resources.typed.int64.test
@@ -125,9 +125,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Unimplemented: https://github.com/llvm/llvm-project/issues/99126
-# XFAIL: Clang
-
 # REQUIRES: Int64TypedResourceAtomics && SM_6_6
 # RUN: split-file %s %t
 # RUN: %dxc_target -HV 202x -T cs_6_6 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/InterlockedOr.resources.typed.int64.test
+++ b/test/Feature/HLSLLib/InterlockedOr.resources.typed.int64.test
@@ -125,6 +125,9 @@ DescriptorSets:
 ...
 #--- end
 
+# Bug: https://github.com/llvm/offload-test-suite/issues/1407
+# XFAIL: Intel && DXC && Clang && Vulkan
+
 # REQUIRES: Int64TypedResourceAtomics && SM_6_6
 # RUN: split-file %s %t
 # RUN: %dxc_target -HV 202x -T cs_6_6 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/InterlockedOr.resources.typed.int64.test
+++ b/test/Feature/HLSLLib/InterlockedOr.resources.typed.int64.test
@@ -126,7 +126,7 @@ DescriptorSets:
 #--- end
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/1407
-# XFAIL: Intel && DXC && Clang && Vulkan
+# XFAIL: Intel && Clang && Vulkan
 
 # Bug: https://github.com/llvm/llvm-project/issues/116148
 # XFAIL: Clang 

--- a/test/Feature/HLSLLib/InterlockedXor.resources.int64.test
+++ b/test/Feature/HLSLLib/InterlockedXor.resources.int64.test
@@ -192,9 +192,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Unimplemented: https://github.com/llvm/llvm-project/issues/99127
-# XFAIL: Clang
-
 # Bug: https://github.com/llvm/offload-test-suite/issues/1164
 # XFAIL: Metal && DXC
 

--- a/test/Feature/HLSLLib/InterlockedXor.resources.int64.test
+++ b/test/Feature/HLSLLib/InterlockedXor.resources.int64.test
@@ -196,7 +196,7 @@ DescriptorSets:
 # XFAIL: Intel && Clang && Vulkan
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/1164
-# XFAIL: Metal && DXC
+# XFAIL: Metal
 
 # Unimplemented: https://github.com/microsoft/DirectXShaderCompiler/issues/8451
 # XFAIL: Vulkan && DXC

--- a/test/Feature/HLSLLib/InterlockedXor.resources.int64.test
+++ b/test/Feature/HLSLLib/InterlockedXor.resources.int64.test
@@ -192,6 +192,9 @@ DescriptorSets:
 ...
 #--- end
 
+# Bug: https://github.com/llvm/offload-test-suite/issues/1407
+# XFAIL: Intel && Clang && Vulkan
+
 # Bug: https://github.com/llvm/offload-test-suite/issues/1164
 # XFAIL: Metal && DXC
 

--- a/test/Feature/HLSLLib/InterlockedXor.resources.typed.int64.test
+++ b/test/Feature/HLSLLib/InterlockedXor.resources.typed.int64.test
@@ -143,6 +143,9 @@ DescriptorSets:
 # Bug: https://github.com/llvm/offload-test-suite/issues/1407
 # XFAIL: Intel && Clang && Vulkan
 
+# Bug: https://github.com/llvm/llvm-project/issues/116148
+# XFAIL: Clang && DirectX
+
 # REQUIRES: Int64TypedResourceAtomics && SM_6_6
 # RUN: split-file %s %t
 # RUN: %dxc_target -HV 202x -T cs_6_6 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/InterlockedXor.resources.typed.int64.test
+++ b/test/Feature/HLSLLib/InterlockedXor.resources.typed.int64.test
@@ -140,8 +140,8 @@ DescriptorSets:
 ...
 #--- end
 
-# Unimplemented: https://github.com/llvm/llvm-project/issues/99127
-# XFAIL: Clang
+# Bug: https://github.com/llvm/offload-test-suite/issues/1407
+# XFAIL: Intel && Clang && Vulkan
 
 # REQUIRES: Int64TypedResourceAtomics && SM_6_6
 # RUN: split-file %s %t


### PR DESCRIPTION
This PR updates the xfails in the interlocked or tests.
The tests had an xfail since interlockedor was not supported yet in LLVM.
The support landed here: https://github.com/llvm/llvm-project/pull/211639
So now, we can remove the unimplemented xfails and see how the tests actually run.