### PR TITLE
[DirectX] Implement sampler support

### DIFF
--- a/include/API/Device.h
+++ b/include/API/Device.h
@@ -20,6 +20,7 @@
 #include "API/Capabilities.h"
 #include "API/CommandBuffer.h"
 #include "API/RenderPass.h"
+#include "API/Sampler.h"
 #include "API/ShaderBindingTable.h"
 #include "API/Texture.h"
 
@@ -345,6 +346,9 @@ public:
 
   virtual llvm::Expected<std::unique_ptr<Texture>>
   createTexture(std::string Name, const TextureCreateDesc &Desc) = 0;
+
+  virtual llvm::Expected<std::unique_ptr<Sampler>>
+  createSampler(std::string Name, const SamplerCreateDesc &Desc) = 0;
 
   virtual llvm::Expected<std::unique_ptr<MemoryHeap>>
   createMemoryHeap(std::string Name, size_t SizeInBytes) = 0;

--- a/include/API/Sampler.h
+++ b/include/API/Sampler.h
@@ -1,0 +1,62 @@
+//===- Sampler.h - Offload API Sampler ------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef OFFLOADTEST_API_SAMPLER_H
+#define OFFLOADTEST_API_SAMPLER_H
+
+#include "API/API.h"
+#include "API/Resources.h"
+
+namespace offloadtest {
+
+enum class FilterMode { Nearest, Linear };
+
+enum class AddressMode { Clamp, Repeat, Mirror, Border, MirrorOnce };
+
+enum class CompareFunction {
+  Never,
+  Less,
+  Equal,
+  LessEqual,
+  Greater,
+  NotEqual,
+  GreaterEqual,
+  Always
+};
+
+enum class SamplerKind { Sampler, SamplerComparison };
+
+struct SamplerCreateDesc {
+  FilterMode MinFilter = FilterMode::Linear;
+  FilterMode MagFilter = FilterMode::Linear;
+  AddressMode Address = AddressMode::Clamp;
+  float MinLOD = 0.0f;
+  float MaxLOD = std::numeric_limits<float>::max();
+  float MipLODBias = 0.0f;
+  CompareFunction ComparisonOp = CompareFunction::Never;
+  SamplerKind Kind = SamplerKind::Sampler;
+};
+
+class Sampler {
+  GPUAPI API;
+
+public:
+  virtual ~Sampler();
+  Sampler(const Sampler &) = delete;
+  Sampler &operator=(const Sampler &) = delete;
+
+  GPUAPI getAPI() const { return API; }
+  virtual const SamplerCreateDesc &getDesc() const = 0;
+
+protected:
+  explicit Sampler(GPUAPI API) : API(API) {}
+};
+
+} // namespace offloadtest
+
+#endif // OFFLOADTEST_API_SAMPLER_H

--- a/include/API/Texture.h
+++ b/include/API/Texture.h
@@ -106,12 +106,6 @@ inline llvm::Error validateTextureCreateDesc(const TextureCreateDesc &Desc) {
         std::errc::not_supported,
         "DepthStencil combined with Storage is not yet supported.");
 
-  // Depth formats require DepthStencil usage; non-depth formats forbid it.
-  if (IsDepth && !IsDS)
-    return llvm::createStringError(
-        std::errc::invalid_argument,
-        "Depth format '%s' requires DepthStencil usage.",
-        getFormatName(Desc.Fmt).data());
   if (!IsDepth && IsDS)
     return llvm::createStringError(
         std::errc::invalid_argument,

--- a/include/Support/OffloadMigration.h
+++ b/include/Support/OffloadMigration.h
@@ -36,6 +36,7 @@ struct ResourceSet {
   std::unique_ptr<MemoryHeap> BackingMemory;
   std::unique_ptr<Buffer> Buf;
   std::unique_ptr<Texture> Tex;
+  std::unique_ptr<Sampler> Smp;
   std::unique_ptr<offloadtest::Buffer> Readback;
   std::unique_ptr<offloadtest::Buffer> CounterReadback;
 
@@ -54,6 +55,8 @@ struct ResourceSet {
               std::unique_ptr<offloadtest::Buffer> Readback)
       : BackingMemory(std::move(BackingMemory)), Tex(std::move(Texture)),
         Readback(std::move(Readback)) {}
+  ResourceSet(std::unique_ptr<offloadtest::Sampler> Smp)
+      : Smp(std::move(Smp)) {}
   explicit ResourceSet(AccelerationStructure *AS) : AS(AS) {}
 
   ResourceSet(const ResourceSet &) = delete;
@@ -61,12 +64,14 @@ struct ResourceSet {
 
   ResourceSet(ResourceSet &&A)
       : BackingMemory(std::move(A.BackingMemory)), Buf(std::move(A.Buf)),
-        Tex(std::move(A.Tex)), Readback(std::move(A.Readback)),
+        Tex(std::move(A.Tex)), Smp(std::move(A.Smp)),
+        Readback(std::move(A.Readback)),
         CounterReadback(std::move(A.CounterReadback)), AS(A.AS) {}
   ResourceSet &operator=(ResourceSet &&A) {
     BackingMemory = std::move(A.BackingMemory);
     Buf = std::move(A.Buf);
     Tex = std::move(A.Tex);
+    Smp = std::move(A.Smp);
     Readback = std::move(A.Readback);
     CounterReadback = std::move(A.CounterReadback);
     AS = A.AS;

--- a/include/Support/Pipeline.h
+++ b/include/Support/Pipeline.h
@@ -16,6 +16,7 @@
 #include "API/AccelerationStructure.h"
 #include "API/Enums.h"
 #include "API/Resources.h"
+#include "API/Sampler.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Error.h"
@@ -141,24 +142,7 @@ static inline DescriptorKind getDescriptorKind(ResourceKind RK) {
   llvm_unreachable("All cases handled");
 }
 
-enum class FilterMode { Nearest, Linear };
-
-enum class AddressMode { Clamp, Repeat, Mirror, Border, MirrorOnce };
-
-enum class CompareFunction {
-  Never,
-  Less,
-  Equal,
-  LessEqual,
-  Greater,
-  NotEqual,
-  GreaterEqual,
-  Always
-};
-
-enum class SamplerKind { Sampler, SamplerComparison };
-
-struct Sampler {
+struct YAMLSampler {
   std::string Name;
   FilterMode MinFilter = FilterMode::Linear;
   FilterMode MagFilter = FilterMode::Linear;
@@ -271,7 +255,7 @@ struct Resource {
   DirectXBinding DXBinding;
   std::optional<VulkanBinding> VKBinding;
   CPUBuffer *BufferPtr = nullptr;
-  Sampler *SamplerPtr = nullptr;
+  YAMLSampler *SamplerPtr = nullptr;
   bool HasCounter = false;
   std::optional<uint32_t> TilesMapped;
   bool IsReserved = false;
@@ -640,7 +624,7 @@ struct Pipeline {
   IOBindings Bindings;
   llvm::SmallVector<PushConstantBlock> PushConstants;
   llvm::SmallVector<CPUBuffer> Buffers;
-  llvm::SmallVector<Sampler> Samplers;
+  llvm::SmallVector<YAMLSampler> Samplers;
   llvm::SmallVector<Result> Results;
   llvm::SmallVector<DescriptorSet> Sets;
   DispatchParametersSet DispatchParameters;
@@ -681,7 +665,7 @@ struct Pipeline {
     return nullptr;
   }
 
-  Sampler *getSampler(llvm::StringRef Name) {
+  YAMLSampler *getSampler(llvm::StringRef Name) {
     for (auto &S : Samplers)
       if (Name == S.Name)
         return &S;
@@ -722,7 +706,7 @@ struct Pipeline {
 LLVM_YAML_IS_SEQUENCE_VECTOR(offloadtest::DescriptorSet)
 LLVM_YAML_IS_SEQUENCE_VECTOR(offloadtest::Resource)
 LLVM_YAML_IS_SEQUENCE_VECTOR(offloadtest::CPUBuffer)
-LLVM_YAML_IS_SEQUENCE_VECTOR(offloadtest::Sampler)
+LLVM_YAML_IS_SEQUENCE_VECTOR(offloadtest::YAMLSampler)
 LLVM_YAML_IS_SEQUENCE_VECTOR(offloadtest::Shader)
 LLVM_YAML_IS_SEQUENCE_VECTOR(offloadtest::dx::RootParameter)
 LLVM_YAML_IS_SEQUENCE_VECTOR(offloadtest::Result)
@@ -754,8 +738,8 @@ template <> struct MappingTraits<offloadtest::CPUBuffer> {
   static void mapping(IO &I, offloadtest::CPUBuffer &R);
 };
 
-template <> struct MappingTraits<offloadtest::Sampler> {
-  static void mapping(IO &I, offloadtest::Sampler &S);
+template <> struct MappingTraits<offloadtest::YAMLSampler> {
+  static void mapping(IO &I, offloadtest::YAMLSampler &S);
 };
 
 template <> struct MappingTraits<offloadtest::Result> {

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -140,6 +140,66 @@ getDXPrimitiveTopology(PrimitiveTopology Topology,
   llvm_unreachable("All PrimitiveTopology cases handled");
 }
 
+static D3D12_FILTER getDXFilterMode(FilterMode MinFilter, FilterMode MagFilter,
+                                    bool IsComparison) {
+  if (IsComparison) {
+    if (MinFilter == FilterMode::Nearest)
+      return MagFilter == FilterMode::Nearest
+                 ? D3D12_FILTER_COMPARISON_MIN_MAG_MIP_POINT
+                 : D3D12_FILTER_COMPARISON_MIN_POINT_MAG_LINEAR_MIP_POINT;
+
+    return MagFilter == FilterMode::Nearest
+               ? D3D12_FILTER_COMPARISON_MIN_LINEAR_MAG_MIP_POINT
+               : D3D12_FILTER_COMPARISON_MIN_MAG_LINEAR_MIP_POINT;
+  }
+  if (MinFilter == FilterMode::Nearest)
+    return MagFilter == FilterMode::Nearest
+               ? D3D12_FILTER_MIN_MAG_MIP_POINT
+               : D3D12_FILTER_MIN_POINT_MAG_LINEAR_MIP_POINT;
+
+  return MagFilter == FilterMode::Nearest
+             ? D3D12_FILTER_MIN_LINEAR_MAG_MIP_POINT
+             : D3D12_FILTER_MIN_MAG_LINEAR_MIP_POINT;
+}
+
+static D3D12_TEXTURE_ADDRESS_MODE getDXTextureAddressMode(AddressMode Mode) {
+  switch (Mode) {
+  case AddressMode::Clamp:
+    return D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
+  case AddressMode::Repeat:
+    return D3D12_TEXTURE_ADDRESS_MODE_WRAP;
+  case AddressMode::Mirror:
+    return D3D12_TEXTURE_ADDRESS_MODE_MIRROR;
+  case AddressMode::Border:
+    return D3D12_TEXTURE_ADDRESS_MODE_BORDER;
+  case AddressMode::MirrorOnce:
+    return D3D12_TEXTURE_ADDRESS_MODE_MIRROR_ONCE;
+  }
+  llvm_unreachable("All cases handled.");
+}
+
+static D3D12_COMPARISON_FUNC getDXComparisonFunc(CompareFunction ComparisonOp) {
+  switch (ComparisonOp) {
+  case CompareFunction::Never:
+    return D3D12_COMPARISON_FUNC_NEVER;
+  case CompareFunction::Less:
+    return D3D12_COMPARISON_FUNC_LESS;
+  case CompareFunction::Equal:
+    return D3D12_COMPARISON_FUNC_EQUAL;
+  case CompareFunction::LessEqual:
+    return D3D12_COMPARISON_FUNC_LESS_EQUAL;
+  case CompareFunction::Greater:
+    return D3D12_COMPARISON_FUNC_GREATER;
+  case CompareFunction::NotEqual:
+    return D3D12_COMPARISON_FUNC_NOT_EQUAL;
+  case CompareFunction::GreaterEqual:
+    return D3D12_COMPARISON_FUNC_GREATER_EQUAL;
+  case CompareFunction::Always:
+    return D3D12_COMPARISON_FUNC_ALWAYS;
+  }
+  llvm_unreachable("All cases handled.");
+}
+
 namespace {
 class DXDevice;
 
@@ -242,10 +302,47 @@ public:
   }
 };
 
+class DXSampler : public offloadtest::Sampler {
+public:
+  D3D12_CPU_DESCRIPTOR_HANDLE Handle = {};
+  std::string Name;
+  SamplerCreateDesc Desc;
+
+  DXSampler(llvm::StringRef Name, SamplerCreateDesc Desc,
+            D3D12_CPU_DESCRIPTOR_HANDLE Handle)
+      : offloadtest::Sampler(GPUAPI::DirectX), Handle(Handle), Name(Name),
+        Desc(Desc) {}
+
+  const SamplerCreateDesc &getDesc() const override { return Desc; }
+
+  static bool classof(const offloadtest::Sampler *S) {
+    return S->getAPI() == GPUAPI::DirectX;
+  }
+};
+
+enum class RootParameterType : uint32_t {
+  DescriptorTable = 0,
+  SamplerTable,
+  Constant,
+  CBV,
+  SRV,
+  UAV,
+};
+
+struct RootSignatureLayout {
+  RootParameterType ParameterType : 3;
+  uint32_t Count : 29;
+
+  RootSignatureLayout(RootParameterType ParameterType, uint32_t Count)
+      : ParameterType(ParameterType), Count(Count) {}
+  RootSignatureLayout() = delete;
+};
+
 class DXPipelineState : public offloadtest::PipelineState {
 public:
   std::string Name;
   ComPtr<ID3D12RootSignature> RootSig;
+  llvm::SmallVector<RootSignatureLayout> Layout;
   ComPtr<ID3D12PipelineState> PSO;
   // Only set for graphics pipelines.
   std::optional<D3D_PRIMITIVE_TOPOLOGY> Topology;
@@ -255,11 +352,13 @@ public:
   bool IsRayTracing = false;
 
   DXPipelineState(llvm::StringRef Name, ComPtr<ID3D12RootSignature> RootSig,
+                  llvm::SmallVector<RootSignatureLayout> Layout,
                   ComPtr<ID3D12PipelineState> PSO,
                   std::optional<D3D_PRIMITIVE_TOPOLOGY> Topology,
                   bool IsRT = false)
       : offloadtest::PipelineState(GPUAPI::DirectX), Name(Name),
-        RootSig(RootSig), PSO(PSO), Topology(Topology), IsRayTracing(IsRT) {}
+        RootSig(RootSig), Layout(std::move(Layout)), PSO(PSO),
+        Topology(Topology), IsRayTracing(IsRT) {}
 
   static bool classof(const offloadtest::PipelineState *B) {
     return B->getAPI() == GPUAPI::DirectX;
@@ -278,9 +377,11 @@ public:
 
   DXRayTracingPipelineState(llvm::StringRef Name,
                             ComPtr<ID3D12RootSignature> RootSig,
+                            llvm::SmallVector<RootSignatureLayout> Layout,
                             ComPtr<ID3D12StateObject> SO,
                             ComPtr<ID3D12StateObjectProperties> Props)
-      : DXPipelineState(Name, RootSig, /*PSO=*/nullptr, std::nullopt,
+      : DXPipelineState(Name, RootSig, std::move(Layout), /*PSO=*/nullptr,
+                        std::nullopt,
                         /*IsRT=*/true),
         StateObject(SO), Properties(Props) {}
 
@@ -1046,15 +1147,18 @@ public:
   DescriptorAllocator RTVAllocator;
   DescriptorAllocator DSVAllocator;
   DescriptorAllocator CSUAllocator;
+  DescriptorAllocator SamplerAllocator;
 
   DXDevice(ComPtr<IDXCoreAdapter> A, ComPtr<ID3D12DeviceX> D, DXQueue Q,
            DescriptorAllocator RTVAllocator, DescriptorAllocator DSVAllocator,
-           DescriptorAllocator CSUAllocator, std::string Desc,
+           DescriptorAllocator CSUAllocator,
+           DescriptorAllocator SamplerAllocator, std::string Desc,
            std::string DriverVer)
       : Adapter(A), Device(D), GraphicsQueue(std::move(Q)),
         RTVAllocator(std::move(RTVAllocator)),
         DSVAllocator(std::move(DSVAllocator)),
-        CSUAllocator(std::move(CSUAllocator)) {
+        CSUAllocator(std::move(CSUAllocator)),
+        SamplerAllocator(std::move(SamplerAllocator)) {
     Description = std::move(Desc);
     DriverVersion = std::move(DriverVer);
     DriverName = "DirectX";
@@ -1096,9 +1200,10 @@ public:
 
   Queue &getGraphicsQueue() override { return GraphicsQueue; }
 
-  llvm::Error
-  createRootSignatureFromShader(llvm::StringRef, const ShaderContainer &Shader,
-                                ComPtr<ID3D12RootSignature> &OutRootSignature) {
+  llvm::Error createRootSignatureFromShader(
+      llvm::StringRef Name, const ShaderContainer &Shader,
+      ComPtr<ID3D12RootSignature> &OutRootSignature,
+      llvm::SmallVectorImpl<RootSignatureLayout> &Layout) {
     // Try pulling a root signature from the DXIL first
     auto ExContainer =
         llvm::object::DXContainer::create(Shader.Shader->getMemBufferRef());
@@ -1118,14 +1223,71 @@ public:
                                           IID_PPV_ARGS(&OutRootSignature)),
               "Failed to create root signature."))
         return Err;
+
+      const std::wstring WStr(Name.begin(), Name.end());
+      OutRootSignature->SetName(WStr.c_str());
+
+      // Deserialize the root signature to determine how we need to bind
+      // descriptor tables
+      ComPtr<ID3D12VersionedRootSignatureDeserializer> Deserializer;
+      if (auto Err = HR::toError(
+              D3D12CreateVersionedRootSignatureDeserializer(
+                  Binary.data(), Binary.size(), IID_PPV_ARGS(&Deserializer)),
+              "Failed to create Root Signature Deserializer"))
+        return Err;
+
+      const D3D12_VERSIONED_ROOT_SIGNATURE_DESC *RootSigDesc = nullptr;
+      if (auto Err =
+              HR::toError(Deserializer->GetRootSignatureDescAtVersion(
+                              D3D_ROOT_SIGNATURE_VERSION_1, &RootSigDesc),
+                          "Failed to deseralize root signature"))
+        return Err;
+
+      for (uint32_t I = 0; I < RootSigDesc->Desc_1_0.NumParameters; ++I) {
+        const D3D12_ROOT_PARAMETER &Parameter =
+            RootSigDesc->Desc_1_0.pParameters[I];
+        switch (Parameter.ParameterType) {
+        case D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE: {
+          uint32_t DescriptorCount = 0;
+          for (uint32_t I = 0;
+               I < Parameter.DescriptorTable.NumDescriptorRanges; ++I)
+            DescriptorCount +=
+                Parameter.DescriptorTable.pDescriptorRanges[I].NumDescriptors;
+
+          if (Parameter.DescriptorTable.NumDescriptorRanges > 0 &&
+              Parameter.DescriptorTable.pDescriptorRanges[0].RangeType ==
+                  D3D12_DESCRIPTOR_RANGE_TYPE_SAMPLER)
+            Layout.push_back(RootSignatureLayout(
+                RootParameterType::SamplerTable, DescriptorCount));
+          else
+            Layout.push_back(RootSignatureLayout(
+                RootParameterType::DescriptorTable, DescriptorCount));
+          break;
+        }
+        case D3D12_ROOT_PARAMETER_TYPE_32BIT_CONSTANTS:
+          Layout.push_back(RootSignatureLayout(
+              RootParameterType::Constant, Parameter.Constants.Num32BitValues));
+          break;
+        case D3D12_ROOT_PARAMETER_TYPE_CBV:
+          Layout.push_back(RootSignatureLayout(RootParameterType::CBV, 1));
+          break;
+        case D3D12_ROOT_PARAMETER_TYPE_SRV:
+          Layout.push_back(RootSignatureLayout(RootParameterType::SRV, 1));
+          break;
+        case D3D12_ROOT_PARAMETER_TYPE_UAV:
+          Layout.push_back(RootSignatureLayout(RootParameterType::UAV, 1));
+          break;
+        }
+      }
     }
 
     return llvm::Error::success();
   }
 
   llvm::Error createRootSignatureFromBindingsDesc(
-      llvm::StringRef, const BindingsDesc &BndDesc, bool IsGraphics,
-      ComPtr<ID3D12RootSignature> &OutRootSignature) {
+      llvm::StringRef Name, const BindingsDesc &BndDesc, bool IsGraphics,
+      ComPtr<ID3D12RootSignature> &OutRootSignature,
+      llvm::SmallVectorImpl<RootSignatureLayout> &Layout) {
     uint32_t DescriptorCount = 0;
     for (auto &D : BndDesc.DescriptorSetDescs)
       DescriptorCount += D.ResourceBindings.size();
@@ -1138,7 +1300,11 @@ public:
       uint32_t DescriptorIdx = 0;
       const uint32_t StartRangeIdx = RangeIdx;
       for (const auto &Binding : Set.ResourceBindings) {
-        switch (getDescriptorKind(Binding.Kind)) {
+        const DescriptorKind Kind = getDescriptorKind(Binding.Kind);
+        if (Kind == DescriptorKind::SAMPLER)
+          continue;
+
+        switch (Kind) {
         case DescriptorKind::SRV:
           Ranges.get()[RangeIdx].RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SRV;
           break;
@@ -1149,7 +1315,8 @@ public:
           Ranges.get()[RangeIdx].RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_CBV;
           break;
         case DescriptorKind::SAMPLER:
-          llvm_unreachable("Not implemented yet."); // Requires a separate heap
+          llvm_unreachable("Sampler should have been filtered out.");
+          break;
         }
         Ranges.get()[RangeIdx].NumDescriptors = Binding.DescriptorCount;
         Ranges.get()[RangeIdx].BaseShaderRegister = Binding.DXBinding.Register;
@@ -1159,12 +1326,48 @@ public:
         RangeIdx++;
         DescriptorIdx += Binding.DescriptorCount;
       }
-      RootParams.push_back(D3D12_ROOT_PARAMETER{
-          D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE,
-          {D3D12_ROOT_DESCRIPTOR_TABLE{
-              static_cast<uint32_t>(Set.ResourceBindings.size()),
-              &Ranges.get()[StartRangeIdx]}},
-          D3D12_SHADER_VISIBILITY_ALL});
+      const uint32_t RangeCount =
+          static_cast<uint32_t>(RangeIdx - StartRangeIdx);
+      if (RangeCount > 0) {
+        RootParams.push_back(
+            D3D12_ROOT_PARAMETER{D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE,
+                                 {D3D12_ROOT_DESCRIPTOR_TABLE{
+                                     RangeCount, &Ranges.get()[StartRangeIdx]}},
+                                 D3D12_SHADER_VISIBILITY_ALL});
+        Layout.push_back(RootSignatureLayout(RootParameterType::DescriptorTable,
+                                             DescriptorIdx));
+      }
+
+      uint32_t SamplerDescriptorIdx = 0;
+      const uint32_t SamplerStartRangeIdx = RangeIdx;
+      for (const auto &Binding : Set.ResourceBindings) {
+        const DescriptorKind Kind = getDescriptorKind(Binding.Kind);
+        if (Kind != DescriptorKind::SAMPLER)
+          continue;
+
+        Ranges.get()[RangeIdx].RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SAMPLER;
+        Ranges.get()[RangeIdx].NumDescriptors = Binding.DescriptorCount;
+        Ranges.get()[RangeIdx].BaseShaderRegister = Binding.DXBinding.Register;
+        Ranges.get()[RangeIdx].RegisterSpace = Binding.DXBinding.Space;
+        Ranges.get()[RangeIdx].OffsetInDescriptorsFromTableStart =
+            SamplerDescriptorIdx;
+
+        RangeIdx++;
+        SamplerDescriptorIdx += Binding.DescriptorCount;
+      }
+
+      const uint32_t SamplerRangeCount =
+          static_cast<uint32_t>(RangeIdx - SamplerStartRangeIdx);
+      if (SamplerRangeCount > 0) {
+        RootParams.push_back(D3D12_ROOT_PARAMETER{
+            D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE,
+            {D3D12_ROOT_DESCRIPTOR_TABLE{
+                static_cast<uint32_t>(RangeIdx - SamplerStartRangeIdx),
+                &Ranges.get()[SamplerStartRangeIdx]}},
+            D3D12_SHADER_VISIBILITY_ALL});
+        Layout.push_back(RootSignatureLayout(RootParameterType::SamplerTable,
+                                             SamplerDescriptorIdx));
+      }
     }
 
     CD3DX12_ROOT_SIGNATURE_DESC Desc;
@@ -1195,32 +1398,37 @@ public:
             "Failed to create root signature."))
       return Err;
 
+    const std::wstring WStr(Name.begin(), Name.end());
+    OutRootSignature->SetName(WStr.c_str());
+
     return llvm::Error::success();
   }
 
   llvm::Error
   createRootSignature(llvm::StringRef Name, const BindingsDesc &BndDesc,
                       const ShaderContainer &Shader, bool IsGraphics,
-                      ComPtr<ID3D12RootSignature> &OutRootSignature) {
+                      ComPtr<ID3D12RootSignature> &OutRootSignature,
+                      llvm::SmallVectorImpl<RootSignatureLayout> &Layout) {
     assert(OutRootSignature.Get() == nullptr);
 
-    if (auto Err =
-            createRootSignatureFromShader(Name, Shader, OutRootSignature))
+    if (auto Err = createRootSignatureFromShader(Name, Shader, OutRootSignature,
+                                                 Layout))
       return Err;
 
     if (OutRootSignature.Get() != nullptr)
       return llvm::Error::success();
 
     return createRootSignatureFromBindingsDesc(Name, BndDesc, IsGraphics,
-                                               OutRootSignature);
+                                               OutRootSignature, Layout);
   }
 
   llvm::Expected<std::unique_ptr<PipelineState>>
   createPipelineCs(llvm::StringRef Name, const BindingsDesc &BndDesc,
                    ShaderContainer CS) override {
     ComPtr<ID3D12RootSignature> RootSig;
+    llvm::SmallVector<RootSignatureLayout> Layout;
     if (auto Err = createRootSignature(Name, BndDesc, CS,
-                                       /*IsGraphics=*/false, RootSig))
+                                       /*IsGraphics=*/false, RootSig, Layout))
       return Err;
 
     auto DXIL = CS.Shader->getBuffer();
@@ -1240,7 +1448,8 @@ public:
             "Failed to create PSO."))
       return Err;
 
-    return std::make_unique<DXPipelineState>(Name, RootSig, PSO, std::nullopt);
+    return std::make_unique<DXPipelineState>(Name, RootSig, std::move(Layout),
+                                             PSO, std::nullopt);
   }
 
   llvm::Expected<std::unique_ptr<PipelineState>>
@@ -1250,8 +1459,9 @@ public:
     assert(Desc.RTFormats.size() <= 8);
 
     ComPtr<ID3D12RootSignature> RootSig;
+    llvm::SmallVector<RootSignatureLayout> Layout;
     if (auto Err = createRootSignature(Name, BndDesc, Desc.VS,
-                                       /*IsGraphics=*/true, RootSig))
+                                       /*IsGraphics=*/true, RootSig, Layout))
       return Err;
 
     std::vector<D3D12_INPUT_ELEMENT_DESC> DXInputLayout;
@@ -1315,7 +1525,7 @@ public:
       return Err;
 
     return std::make_unique<DXPipelineState>(
-        Name, RootSig, PSO,
+        Name, RootSig, std::move(Layout), PSO,
         getDXPrimitiveTopology(Desc.Topology, Desc.PatchControlPoints));
   }
 
@@ -1325,8 +1535,9 @@ public:
     assert(Desc.RTFormats.size() <= 8);
 
     ComPtr<ID3D12RootSignature> RootSig;
+    llvm::SmallVector<RootSignatureLayout> Layout;
     if (auto Err = createRootSignature(Name, BindingsDesc, Desc.MS,
-                                       /*IsGraphics=*/true, RootSig))
+                                       /*IsGraphics=*/true, RootSig, Layout))
       return Err;
 
     const D3D12_SHADER_BYTECODE MSBytecode = {
@@ -1392,7 +1603,8 @@ public:
             "Failed to create mesh shader PSO."))
       return Err;
 
-    return std::make_unique<DXPipelineState>(Name, RootSig, PSO, std::nullopt);
+    return std::make_unique<DXPipelineState>(Name, RootSig, std::move(Layout),
+                                             PSO, std::nullopt);
   }
 
   static std::wstring widen(llvm::StringRef S) {
@@ -1424,8 +1636,9 @@ public:
     ShaderContainer LibContainer = {};
     LibContainer.Shader = Desc.Library;
     ComPtr<ID3D12RootSignature> RootSig;
+    llvm::SmallVector<RootSignatureLayout> Layout;
     if (auto Err = createRootSignature(Name, BndDesc, LibContainer,
-                                       /*IsGraphics=*/false, RootSig))
+                                       /*IsGraphics=*/false, RootSig, Layout))
       return Err;
 
     CD3DX12_STATE_OBJECT_DESC SODesc(
@@ -1492,7 +1705,7 @@ public:
       return Err;
 
     auto State = std::make_unique<DXRayTracingPipelineState>(
-        Name, RootSig, StateObject, Properties);
+        Name, RootSig, Layout, StateObject, Properties);
     // Cache identifiers up-front. The driver-owned blobs are alive for
     // Properties' lifetime, which lives on the PSO.
     //
@@ -1924,6 +2137,42 @@ public:
     return Tex;
   }
 
+  llvm::Expected<std::unique_ptr<Sampler>>
+  createSampler(std::string Name, const SamplerCreateDesc &Desc) override {
+
+    auto HandleOrErr = SamplerAllocator.allocate();
+    if (!HandleOrErr)
+      return HandleOrErr.takeError();
+    const D3D12_CPU_DESCRIPTOR_HANDLE Handle = *HandleOrErr;
+
+    const D3D12_TEXTURE_ADDRESS_MODE AddressMode =
+        getDXTextureAddressMode(Desc.Address);
+
+    bool IsComparison = false;
+    D3D12_COMPARISON_FUNC ComparisonFunc = D3D12_COMPARISON_FUNC_NONE;
+    if (Desc.Kind == SamplerKind::SamplerComparison) {
+      IsComparison = true;
+      ComparisonFunc = getDXComparisonFunc(Desc.ComparisonOp);
+    }
+
+    const D3D12_SAMPLER_DESC SamplerDesc = {
+        getDXFilterMode(Desc.MinFilter, Desc.MagFilter, IsComparison),
+        AddressMode, // U
+        AddressMode, // V
+        AddressMode, // W
+        Desc.MipLODBias,
+        0, // MaxAnisotropy
+        ComparisonFunc,
+        {0.0f, 0.0f, 0.0f, 0.0f}, // BorderColor
+        Desc.MinLOD,
+        Desc.MaxLOD,
+    };
+
+    Device->CreateSampler(&SamplerDesc, Handle);
+
+    return std::make_unique<DXSampler>(Name, Desc, Handle);
+  }
+
   uint32_t getTextureUploadRowStrideInBytes(
       const TextureCreateDesc &Desc) const override {
     return getAlignedTexturePitch(Desc.Width, getFormatSizeInBytes(Desc.Fmt));
@@ -2031,11 +2280,16 @@ public:
     if (!CSUHeapOrErr)
       return CSUHeapOrErr.takeError();
 
+    auto SamplerHeapOrErr = DescriptorAllocator::create(
+        Device.Get(), D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER, 256);
+    if (!SamplerHeapOrErr)
+      return SamplerHeapOrErr.takeError();
+
     return std::make_unique<DXDevice>(
         Adapter, Device, std::move(*GraphicsQueueOrErr),
         std::move(*RTVHeapOrErr), std::move(*DSVHeapOrErr),
-        std::move(*CSUHeapOrErr), std::string(DescVec.data()),
-        std::move(DriverVer));
+        std::move(*CSUHeapOrErr), std::move(*SamplerHeapOrErr),
+        std::string(DescVec.data()), std::move(DriverVer));
   }
 
   const Capabilities &getCapabilities() override {
@@ -2079,18 +2333,44 @@ public:
     return llvm::Error::success();
   }
 
-  llvm::Error createDescriptorHeap(Pipeline &P,
-                                   ComPtr<ID3D12DescriptorHeap> &DescHeap) {
+  llvm::Error createDescriptorHeaps(Pipeline &P,
+                                    ComPtr<ID3D12DescriptorHeap> &DescHeap,
+                                    ComPtr<ID3D12DescriptorHeap> &SamplerHeap) {
     if (P.getDescriptorCount() == 0)
       return llvm::Error::success();
+
+    uint32_t DescriptorCount = 0;
+    uint32_t SamplerCount = 0;
+    for (auto &D : P.Sets)
+      for (auto &R : D.Resources)
+        if (R.isSampler())
+          SamplerCount += 1;
+        else
+          DescriptorCount += R.getArraySize();
+
+    // prevent empty heaps
+    if (DescriptorCount == 0)
+      DescriptorCount = 1;
+    if (SamplerCount == 0)
+      SamplerCount = 1;
+
     const D3D12_DESCRIPTOR_HEAP_DESC HeapDesc = {
-        D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV,
-        P.getDescriptorCountWithFlattenedArrays(),
+        D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, DescriptorCount,
         D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE, 0};
     if (auto Err = HR::toError(
             Device->CreateDescriptorHeap(&HeapDesc, IID_PPV_ARGS(&DescHeap)),
             "Failed to create descriptor heap."))
       return Err;
+
+    const D3D12_DESCRIPTOR_HEAP_DESC SamplerHeapDesc = {
+        D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER, SamplerCount,
+        D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE, 0};
+    if (auto Err =
+            HR::toError(Device->CreateDescriptorHeap(
+                            &SamplerHeapDesc, IID_PPV_ARGS(&SamplerHeap)),
+                        "Failed to create sampler descriptor heap."))
+      return Err;
+
     return llvm::Error::success();
   }
 
@@ -2257,15 +2537,26 @@ public:
   }
 
   void buildDescriptorTables(llvm::ArrayRef<DescriptorTable> DescTables,
-                             const ComPtr<ID3D12DescriptorHeap> &DescHeap) {
+                             const ComPtr<ID3D12DescriptorHeap> &DescHeap,
+                             const ComPtr<ID3D12DescriptorHeap> &SamplerHeap) {
     // Bind descriptors in descriptor tables.
     if (!DescHeap)
       return;
+
     uint32_t HeapIndex = 0;
+    uint32_t SamplerHeapIndex = 0;
+
     const D3D12_CPU_DESCRIPTOR_HANDLE HeapStart =
         DescHeap->GetCPUDescriptorHandleForHeapStart();
+    const D3D12_CPU_DESCRIPTOR_HANDLE SamplerHeapStart =
+        SamplerHeap->GetCPUDescriptorHandleForHeapStart();
+
     const uint32_t DescHandleIncSize = Device->GetDescriptorHandleIncrementSize(
         D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+    const uint32_t SamplerHandleIncSize =
+        Device->GetDescriptorHandleIncrementSize(
+            D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER);
+
     for (auto &T : DescTables) {
       for (auto &R : T.Resources) {
         for (const auto &Set : R.second) {
@@ -2313,6 +2604,9 @@ public:
             const DXAccelerationStructure &AccelerationStructureDX =
                 llvm::cast<DXAccelerationStructure>(*Set.AS);
             DescriptorHandle = AccelerationStructureDX.SRVHandle;
+          } else if (Set.Smp != nullptr) {
+            const DXSampler &SamplerDX = llvm::cast<DXSampler>(*Set.Smp);
+            DescriptorHandle = SamplerDX.Handle;
           } else {
             llvm_unreachable("Resource was a texture nor buffer. Samplers "
                              "are unsupported");
@@ -2320,10 +2614,20 @@ public:
 
           assert(DescriptorHandle.ptr != 0 &&
                  "Somehow got a null descriptor :(");
-          Device->CopyDescriptorsSimple(
-              1, {HeapStart.ptr + HeapIndex * DescHandleIncSize},
-              DescriptorHandle, D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
-          HeapIndex += 1;
+
+          if (Set.Smp != nullptr) {
+            Device->CopyDescriptorsSimple(
+                1,
+                {SamplerHeapStart.ptr +
+                 SamplerHeapIndex * SamplerHandleIncSize},
+                DescriptorHandle, D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER);
+            SamplerHeapIndex += 1;
+          } else {
+            Device->CopyDescriptorsSimple(
+                1, {HeapStart.ptr + HeapIndex * DescHandleIncSize},
+                DescriptorHandle, D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+            HeapIndex += 1;
+          }
         }
       }
     }
@@ -2331,14 +2635,16 @@ public:
 
   llvm::Error
   createComputeCommands(Pipeline &P, SharedInvocationState &IS,
-                        const ComPtr<ID3D12DescriptorHeap> &DescHeap) {
+                        const ComPtr<ID3D12DescriptorHeap> &DescHeap,
+                        const ComPtr<ID3D12DescriptorHeap> &SamplerHeap) {
     const DXCommandBuffer &DXCB = llvm::cast<DXCommandBuffer>(*IS.CB);
 
-    CD3DX12_GPU_DESCRIPTOR_HANDLE Handle;
+    CD3DX12_GPU_DESCRIPTOR_HANDLE Handle, SamplerHandle;
     if (DescHeap) {
-      ID3D12DescriptorHeap *const Heaps[] = {DescHeap.Get()};
-      DXCB.CmdList->SetDescriptorHeaps(1, Heaps);
+      ID3D12DescriptorHeap *const Heaps[] = {DescHeap.Get(), SamplerHeap.Get()};
+      DXCB.CmdList->SetDescriptorHeaps(2, Heaps);
       Handle = DescHeap->GetGPUDescriptorHandleForHeapStart();
+      SamplerHandle = SamplerHeap->GetGPUDescriptorHandleForHeapStart();
     }
     const DXPipelineState &DXPipeline =
         llvm::cast<DXPipelineState>(*IS.Pipeline.get());
@@ -2346,8 +2652,21 @@ public:
 
     const uint32_t Inc = Device->GetDescriptorHandleIncrementSize(
         D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+    const uint32_t SamplerInc = Device->GetDescriptorHandleIncrementSize(
+        D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER);
 
     if (P.Settings.DX.RootParams.size() > 0) {
+
+      // Samplers are not supported in RootParams, error if we do find any.
+      for (const auto &Set : P.Sets) {
+        for (const auto &R : Set.Resources) {
+          if (R.isSampler())
+            return llvm::createStringError(
+                "Descriptor tables containing samplers are not yet supported "
+                "with explicit RootParameters.");
+        }
+      }
+
       uint32_t ConstantOffset = 0u;
       uint32_t RootParamIndex = 0u;
       uint32_t DescriptorTableIndex = 0u;
@@ -2403,7 +2722,8 @@ public:
                                                            VirtualAddress);
             break;
           case DescriptorKind::SAMPLER:
-            llvm_unreachable("Not implemented yet.");
+            llvm_unreachable(
+                "Samplers cannot be written directly into the Root Signature.");
           }
           ++RootDescIt;
           break;
@@ -2413,9 +2733,22 @@ public:
       // If no explicit root parameters are provided, fall back to using the
       // descriptor set layout. This is to make it easier to write tests that
       // don't need complicated root signatures.
-      for (uint32_t Idx = 0u; Idx < P.Sets.size(); ++Idx) {
-        DXCB.CmdList->SetComputeRootDescriptorTable(Idx, Handle);
-        Handle.Offset(P.Sets[Idx].Resources.size(), Inc);
+      for (uint32_t I = 0, N = DXPipeline.Layout.size(); I < N; ++I) {
+        const auto &Layout = DXPipeline.Layout[I];
+        switch (Layout.ParameterType) {
+        case RootParameterType::DescriptorTable:
+          DXCB.CmdList->SetComputeRootDescriptorTable(I, Handle);
+          Handle.Offset(Layout.Count, Inc);
+          break;
+        case RootParameterType::SamplerTable:
+          DXCB.CmdList->SetComputeRootDescriptorTable(I, SamplerHandle);
+          SamplerHandle.Offset(Layout.Count, SamplerInc);
+          break;
+        default:
+          return llvm::createStringError(
+              "Root Signatures that contain constants and inline descriptors "
+              "require custom RootParameters to be defined.");
+        }
       }
     }
 
@@ -2462,17 +2795,43 @@ public:
 
   llvm::Error
   createGraphicsCommands(Pipeline &P, SharedInvocationState &IS,
-                         const ComPtr<ID3D12DescriptorHeap> &DescHeap) {
+                         const ComPtr<ID3D12DescriptorHeap> &DescHeap,
+                         const ComPtr<ID3D12DescriptorHeap> &SamplerHeap) {
     const DXPipelineState &DXPipeline =
         llvm::cast<DXPipelineState>(*IS.Pipeline.get());
     const DXCommandBuffer &DXCB = llvm::cast<DXCommandBuffer>(*IS.CB);
-
     DXCB.CmdList->SetGraphicsRootSignature(DXPipeline.RootSig.Get());
+
     if (DescHeap) {
-      ID3D12DescriptorHeap *const Heaps[] = {DescHeap.Get()};
-      DXCB.CmdList->SetDescriptorHeaps(1, Heaps);
-      DXCB.CmdList->SetGraphicsRootDescriptorTable(
-          0, DescHeap->GetGPUDescriptorHandleForHeapStart());
+      ID3D12DescriptorHeap *const Heaps[] = {DescHeap.Get(), SamplerHeap.Get()};
+      DXCB.CmdList->SetDescriptorHeaps(2, Heaps);
+      CD3DX12_GPU_DESCRIPTOR_HANDLE Handle(
+          DescHeap->GetGPUDescriptorHandleForHeapStart());
+      CD3DX12_GPU_DESCRIPTOR_HANDLE SamplerHandle(
+          SamplerHeap->GetGPUDescriptorHandleForHeapStart());
+
+      const uint32_t Inc = Device->GetDescriptorHandleIncrementSize(
+          D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+      const uint32_t SamplerInc = Device->GetDescriptorHandleIncrementSize(
+          D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER);
+
+      for (uint32_t I = 0, N = DXPipeline.Layout.size(); I < N; ++I) {
+        const auto &Layout = DXPipeline.Layout[I];
+        switch (Layout.ParameterType) {
+        case RootParameterType::DescriptorTable:
+          DXCB.CmdList->SetGraphicsRootDescriptorTable(I, Handle);
+          Handle.Offset(Layout.Count, Inc);
+          break;
+        case RootParameterType::SamplerTable:
+          DXCB.CmdList->SetGraphicsRootDescriptorTable(I, SamplerHandle);
+          SamplerHandle.Offset(Layout.Count, SamplerInc);
+          break;
+        default:
+          return llvm::createStringError(
+              "Root Signatures that contain constants and inline descriptors "
+              "require custom RootParameters to be defined.");
+        }
+      }
     }
 
     RenderPassBeginDesc BeginDesc = {};
@@ -2542,8 +2901,8 @@ public:
   llvm::Error executeProgram(Pipeline &P) override {
     llvm::outs() << "Configuring execution on device: " << Description << "\n";
 
-    ComPtr<ID3D12DescriptorHeap> DescHeap;
-    if (auto Err = createDescriptorHeap(P, DescHeap))
+    ComPtr<ID3D12DescriptorHeap> DescHeap, SamplerHeap;
+    if (auto Err = createDescriptorHeaps(P, DescHeap, SamplerHeap))
       return Err;
     llvm::outs() << "Descriptor heap created.\n";
 
@@ -2558,7 +2917,7 @@ public:
       return Err;
     llvm::outs() << "Buffers created.\n";
 
-    buildDescriptorTables(State.DescTables, DescHeap);
+    buildDescriptorTables(State.DescTables, DescHeap, SamplerHeap);
 
     if (!P.AccelStructs.BLAS.empty() || !P.AccelStructs.TLAS.empty()) {
       auto EncOrErr = State.CB->createComputeEncoder();
@@ -2605,7 +2964,7 @@ public:
         return PipelineStateOrErr.takeError();
       State.Pipeline = std::move(*PipelineStateOrErr);
       llvm::outs() << "Compute Pipeline created.\n";
-      if (auto Err = createComputeCommands(P, State, DescHeap))
+      if (auto Err = createComputeCommands(P, State, DescHeap, SamplerHeap))
         return Err;
       llvm::outs() << "Compute command list created.\n";
 
@@ -2711,7 +3070,7 @@ public:
         llvm::outs() << "Mesh Shader Pipeline created.\n";
       }
 
-      if (auto Err = createGraphicsCommands(P, State, DescHeap))
+      if (auto Err = createGraphicsCommands(P, State, DescHeap, SamplerHeap))
         return Err;
       llvm::outs() << "Graphics command list created complete.\n";
     } else if (P.isRayTracing()) {
@@ -2742,7 +3101,7 @@ public:
       State.SBT = std::move(*SBTOrErr);
       llvm::outs() << "Shader Binding Table created.\n";
 
-      if (auto Err = createComputeCommands(P, State, DescHeap))
+      if (auto Err = createComputeCommands(P, State, DescHeap, SamplerHeap))
         return Err;
       llvm::outs() << "RayTracing command list created.\n";
     } else {

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -2658,6 +2658,7 @@ public:
     if (P.Settings.DX.RootParams.size() > 0) {
 
       // Samplers are not supported in RootParams, error if we do find any.
+      // TODO: https://github.com/llvm/offload-test-suite/issues/1400
       for (const auto &Set : P.Sets) {
         for (const auto &R : Set.Resources) {
           if (R.isSampler())

--- a/lib/API/Device.cpp
+++ b/lib/API/Device.cpp
@@ -36,6 +36,8 @@ Queue::~Queue() {}
 
 Texture::~Texture() {}
 
+Sampler::~Sampler() {}
+
 MemoryHeap::~MemoryHeap() {}
 
 RenderPass::~RenderPass() {}

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -498,6 +498,17 @@ public:
   }
 };
 
+class MTLSampler : public offloadtest::Sampler {
+public:
+  SamplerCreateDesc Desc;
+
+  const SamplerCreateDesc &getDesc() const override { return Desc; }
+
+  static bool classof(const offloadtest::Sampler *S) {
+    return S->getAPI() == GPUAPI::Metal;
+  }
+};
+
 /// Metal has no standalone render-pass object: render pass info lives on
 /// MTLRenderPassDescriptor and is consumed when a render command encoder
 /// is created. We therefore just stash the descriptor for the encoder to
@@ -2303,6 +2314,11 @@ public:
       return llvm::createStringError(std::errc::not_enough_memory,
                                      "Failed to create Metal texture.");
     return std::make_unique<MTLTexture>(Tex, Name, Desc);
+  }
+
+  llvm::Expected<std::unique_ptr<Sampler>>
+  createSampler(std::string, const SamplerCreateDesc &) override {
+    return llvm::createStringError("createSampler is unimplemented on Metal.");
   }
 
   uint32_t getTextureUploadRowStrideInBytes(

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -606,6 +606,17 @@ public:
   }
 };
 
+class VulkanSampler : public offloadtest::Sampler {
+public:
+  SamplerCreateDesc Desc;
+
+  const SamplerCreateDesc &getDesc() const override { return Desc; }
+
+  static bool classof(const offloadtest::Sampler *S) {
+    return S->getAPI() == GPUAPI::Vulkan;
+  }
+};
+
 class VulkanAccelerationStructure : public offloadtest::AccelerationStructure {
 public:
   VkDevice Dev;
@@ -2807,6 +2818,11 @@ public:
     return Tex;
   }
 
+  llvm::Expected<std::unique_ptr<Sampler>>
+  createSampler(std::string, const SamplerCreateDesc &) override {
+    return llvm::createStringError("createSampler is unimplemented on Vulkan.");
+  }
+
   uint32_t getTextureUploadRowStrideInBytes(
       const TextureCreateDesc &Desc) const override {
     const uint64_t TightRow =
@@ -3339,7 +3355,7 @@ public:
   llvm::Expected<ResourceRef> createSampler(Resource &R, BufferRef &Host) {
     VkSamplerCreateInfo SamplerInfo = {};
     SamplerInfo.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
-    const Sampler &S = *R.SamplerPtr;
+    const YAMLSampler &S = *R.SamplerPtr;
     SamplerInfo.magFilter = getVKFilter(S.MagFilter);
     SamplerInfo.minFilter = getVKFilter(S.MinFilter);
     SamplerInfo.mipmapMode = VK_SAMPLER_MIPMAP_MODE_NEAREST;

--- a/lib/Support/OffloadMigration.cpp
+++ b/lib/Support/OffloadMigration.cpp
@@ -330,9 +330,23 @@ llvm::Error createResources(Device &Dev, Pipeline &P,
       auto Inserted = IS.TLASes.try_emplace(TD.Name, std::move(Handles));
       assert(Inserted.second && "TLAS bound to multiple resources NYI");
       (void)Inserted;
+    } else if (R.isSampler()) {
+      const SamplerCreateDesc Desc = {
+          R.SamplerPtr->MinFilter,    R.SamplerPtr->MagFilter,
+          R.SamplerPtr->Address,      R.SamplerPtr->MinLOD,
+          R.SamplerPtr->MaxLOD,       R.SamplerPtr->MipLODBias,
+          R.SamplerPtr->ComparisonOp, R.SamplerPtr->Kind,
+      };
+
+      auto SamplerOrErr = Dev.createSampler(R.SamplerPtr->Name, Desc);
+      if (!SamplerOrErr)
+        return SamplerOrErr.takeError();
+
+      ResourceSet RSet(std::move(*SamplerOrErr));
+      ResBundle.push_back(std::move(RSet));
     } else {
       return llvm::createStringError(std::errc::not_supported,
-                                     "Samplers are not yet implemented.");
+                                     "Unrecognized resource type.");
     }
 
     Resources.push_back(std::make_pair(&R, std::move(ResBundle)));

--- a/lib/Support/Pipeline.cpp
+++ b/lib/Support/Pipeline.cpp
@@ -334,8 +334,8 @@ static void setCounters(IO &I, offloadtest::CPUBuffer &B) {
   }
 }
 
-void MappingTraits<offloadtest::Sampler>::mapping(IO &I,
-                                                  offloadtest::Sampler &S) {
+void MappingTraits<offloadtest::YAMLSampler>::mapping(
+    IO &I, offloadtest::YAMLSampler &S) {
   I.mapRequired("Name", S.Name);
   I.mapOptional("Kind", S.Kind);
   I.mapOptional("MinFilter", S.MinFilter);

--- a/test/Feature/Textures/Texture2D.CalculateLevelOfDetail.test.yaml
+++ b/test/Feature/Textures/Texture2D.CalculateLevelOfDetail.test.yaml
@@ -126,8 +126,11 @@ Results:
 ...
 #--- end
 
-# Unimplemented: Clang + DX: https://github.com/llvm/llvm-project/issues/101558
-# XFAIL: DirectX || Metal
+# Unimplemented: https://github.com/llvm/llvm-project/issues/143523
+# XFAIL: Clang && DirectX
+
+# Unimplemented: https://github.com/llvm/offload-test-suite/issues/1226
+# XFAIL: Metal
 
 # Driver bug https://gitlab.freedesktop.org/mesa/mesa/-/work_items/15865,
 # Lavapipe (llvmpipe) intermittently crashes (0xc0000005 / SIGSEGV, no output). 

--- a/test/Feature/Textures/Texture2D.Gather.test.yaml
+++ b/test/Feature/Textures/Texture2D.Gather.test.yaml
@@ -117,8 +117,9 @@ Results:
 ...
 #--- end
 
-# Unimplemented: Clang + DX: https://github.com/llvm/llvm-project/issues/101558
-# XFAIL: DirectX || Metal
+# Unimplemented: Clang: https://github.com/llvm/llvm-project/issues/101558
+# XFAIL: Metal
+# XFAIL: Clang && DirectX
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl

--- a/test/Feature/Textures/Texture2D.Gather.test.yaml
+++ b/test/Feature/Textures/Texture2D.Gather.test.yaml
@@ -117,9 +117,11 @@ Results:
 ...
 #--- end
 
-# Unimplemented: Clang: https://github.com/llvm/llvm-project/issues/101558
-# XFAIL: Metal
+# Unimplemented: https://github.com/llvm/llvm-project/issues/143523
 # XFAIL: Clang && DirectX
+
+# Unimplemented: https://github.com/llvm/offload-test-suite/issues/1226
+# XFAIL: Metal
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl

--- a/test/Feature/Textures/Texture2D.GatherCmp.test.yaml
+++ b/test/Feature/Textures/Texture2D.GatherCmp.test.yaml
@@ -138,8 +138,9 @@ Results:
 ...
 #--- end
 
-# Unimplemented: Clang + DX: https://github.com/llvm/llvm-project/issues/101558
-# XFAIL: DirectX || Metal
+# Unimplemented: Clang: https://github.com/llvm/llvm-project/issues/101558
+# XFAIL: Metal
+# XFAIL: Clang && DirectX
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl

--- a/test/Feature/Textures/Texture2D.GatherCmp.test.yaml
+++ b/test/Feature/Textures/Texture2D.GatherCmp.test.yaml
@@ -138,9 +138,11 @@ Results:
 ...
 #--- end
 
-# Unimplemented: Clang: https://github.com/llvm/llvm-project/issues/101558
-# XFAIL: Metal
+# Unimplemented: https://github.com/llvm/llvm-project/issues/143523
 # XFAIL: Clang && DirectX
+
+# Unimplemented: https://github.com/llvm/offload-test-suite/issues/1226
+# XFAIL: Metal
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl

--- a/test/Feature/Textures/Texture2D.Sample.test.yaml
+++ b/test/Feature/Textures/Texture2D.Sample.test.yaml
@@ -159,9 +159,11 @@ Results:
 ...
 #--- end
 
-# Unimplemented: https://github.com/llvm/offload-test-suite/issues/664
-# XFAIL: DirectX || Metal || Vulkan && Darwin
-# XFAIL: Clang && !Vulkan
+# Unimplemented: https://github.com/llvm/llvm-project/issues/143523
+# XFAIL: Clang && DirectX
+
+# Unimplemented: https://github.com/llvm/offload-test-suite/issues/1226
+# XFAIL: Metal
 
 # Driver bug https://gitlab.freedesktop.org/mesa/mesa/-/work_items/15865,
 # Lavapipe (llvmpipe) intermittently crashes (0xc0000005 / SIGSEGV, no output). 

--- a/test/Feature/Textures/Texture2D.SampleBias.test.yaml
+++ b/test/Feature/Textures/Texture2D.SampleBias.test.yaml
@@ -150,11 +150,11 @@ Results:
 ...
 #--- end
 
-# Unimplemented: https://github.com/llvm/offload-test-suite/issues/664
-# XFAIL: DirectX || Metal || Vulkan && Darwin
+# Unimplemented: https://github.com/llvm/llvm-project/issues/189766
+# XFAIL: Clang && DirectX
 
-# Unimplemented: https://github.com/llvm/llvm-project/issues/175630
-# XFAIL: Clang && !Intel
+# Unimplemented: https://github.com/llvm/offload-test-suite/issues/1226
+# XFAIL: Metal
 
 # Driver bug https://gitlab.freedesktop.org/mesa/mesa/-/work_items/15865,
 # Lavapipe (llvmpipe) intermittently crashes (0xc0000005 / SIGSEGV, no output). 

--- a/test/Feature/Textures/Texture2D.SampleBias.test.yaml
+++ b/test/Feature/Textures/Texture2D.SampleBias.test.yaml
@@ -156,6 +156,9 @@ Results:
 # Unimplemented: https://github.com/llvm/offload-test-suite/issues/1226
 # XFAIL: Metal
 
+# Bug: https://github.com/llvm/offload-test-suite/issues/1405
+# XFAIL: DirectX && Intel
+
 # Driver bug https://gitlab.freedesktop.org/mesa/mesa/-/work_items/15865,
 # Lavapipe (llvmpipe) intermittently crashes (0xc0000005 / SIGSEGV, no output). 
 # UNSUPPORTED: Lavapipe

--- a/test/Feature/Textures/Texture2D.SampleCmp.test.yaml
+++ b/test/Feature/Textures/Texture2D.SampleCmp.test.yaml
@@ -193,7 +193,8 @@ Results:
 #--- end
 
 # Unimplemented: https://github.com/llvm/offload-test-suite/issues/664
-# XFAIL: DirectX || Metal || Vulkan && Darwin
+# XFAIL: Metal || Vulkan && Darwin
+# XFAIL: Clang && DirectX
 
 # Driver bug https://gitlab.freedesktop.org/mesa/mesa/-/work_items/15865,
 # Lavapipe (llvmpipe) intermittently crashes (0xc0000005 / SIGSEGV, no output). 

--- a/test/Feature/Textures/Texture2D.SampleCmp.test.yaml
+++ b/test/Feature/Textures/Texture2D.SampleCmp.test.yaml
@@ -192,9 +192,11 @@ Results:
 ...
 #--- end
 
-# Unimplemented: https://github.com/llvm/offload-test-suite/issues/664
-# XFAIL: Metal || Vulkan && Darwin
+# Unimplemented: https://github.com/llvm/llvm-project/issues/143523
 # XFAIL: Clang && DirectX
+
+# Unimplemented: https://github.com/llvm/offload-test-suite/issues/1226
+# XFAIL: Metal
 
 # Driver bug https://gitlab.freedesktop.org/mesa/mesa/-/work_items/15865,
 # Lavapipe (llvmpipe) intermittently crashes (0xc0000005 / SIGSEGV, no output). 

--- a/test/Feature/Textures/Texture2D.SampleGrad.test.yaml
+++ b/test/Feature/Textures/Texture2D.SampleGrad.test.yaml
@@ -102,9 +102,8 @@ Results:
 ...
 #--- end
 
-# Unimplemented: Clang + DX: https://github.com/llvm/llvm-project/issues/101558
-# XFAIL: DirectX || Metal
-# XFAIL: Clang && !Vulkan
+# Unimplemented: https://github.com/llvm/offload-test-suite/issues/1226
+# XFAIL: Metal
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl

--- a/test/Feature/Textures/Texture2D.Sampler.address.test.yaml
+++ b/test/Feature/Textures/Texture2D.Sampler.address.test.yaml
@@ -160,7 +160,8 @@ Results:
 #--- end
 
 # Unimplemented: https://github.com/llvm/offload-test-suite/issues/664
-# XFAIL: DirectX || Metal
+# XFAIL: Metal
+# XFAIL: Clang && DirectX
 
 # Driver bug https://gitlab.freedesktop.org/mesa/mesa/-/work_items/15865,
 # Lavapipe (llvmpipe) intermittently crashes (0xc0000005 / SIGSEGV, no output). 

--- a/test/Feature/Textures/Texture2D.Sampler.address.test.yaml
+++ b/test/Feature/Textures/Texture2D.Sampler.address.test.yaml
@@ -159,9 +159,11 @@ Results:
 ...
 #--- end
 
-# Unimplemented: https://github.com/llvm/offload-test-suite/issues/664
-# XFAIL: Metal
+# Unimplemented: https://github.com/llvm/llvm-project/issues/143523
 # XFAIL: Clang && DirectX
+
+# Unimplemented: https://github.com/llvm/offload-test-suite/issues/1226
+# XFAIL: Metal
 
 # Driver bug https://gitlab.freedesktop.org/mesa/mesa/-/work_items/15865,
 # Lavapipe (llvmpipe) intermittently crashes (0xc0000005 / SIGSEGV, no output). 

--- a/test/Feature/Textures/Texture2D.Sampler.filter.test.yaml
+++ b/test/Feature/Textures/Texture2D.Sampler.filter.test.yaml
@@ -131,7 +131,8 @@ Results:
 #--- end
 
 # Unimplemented: https://github.com/llvm/offload-test-suite/issues/664
-# XFAIL: DirectX || Metal
+# XFAIL: Metal
+# XFAIL: Clang && DirectX
 
 # Driver bug https://gitlab.freedesktop.org/mesa/mesa/-/work_items/15865,
 # Lavapipe (llvmpipe) intermittently crashes (0xc0000005 / SIGSEGV, no output). 

--- a/test/Feature/Textures/Texture2D.Sampler.filter.test.yaml
+++ b/test/Feature/Textures/Texture2D.Sampler.filter.test.yaml
@@ -130,9 +130,11 @@ Results:
 ...
 #--- end
 
-# Unimplemented: https://github.com/llvm/offload-test-suite/issues/664
-# XFAIL: Metal
+# Unimplemented: https://github.com/llvm/llvm-project/issues/143523
 # XFAIL: Clang && DirectX
+
+# Unimplemented: https://github.com/llvm/offload-test-suite/issues/1226
+# XFAIL: Metal
 
 # Driver bug https://gitlab.freedesktop.org/mesa/mesa/-/work_items/15865,
 # Lavapipe (llvmpipe) intermittently crashes (0xc0000005 / SIGSEGV, no output). 

--- a/test/Feature/Textures/Texture2D.Sampler.mips.test.yaml
+++ b/test/Feature/Textures/Texture2D.Sampler.mips.test.yaml
@@ -93,9 +93,8 @@ Results:
 ...
 #--- end
 
-# Unimplemented: Clang + DX: https://github.com/llvm/llvm-project/issues/101558
-# XFAIL: DirectX || Metal
-# XFAIL: Clang && !Vulkan
+# Unimplemented: https://github.com/llvm/offload-test-suite/issues/1226
+# XFAIL: Metal
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl


### PR DESCRIPTION
This is a cherry-pick and rebase of #1331, plus follow up test updates
to get into a mergeable state. Please refer to that PR for additional
code review context.

Original message:

This change is a lot larger than you would expect from adding samplers.
This is because samplers need to live in a separate DescriptorHeap which
cascaded into a couple of issues:

- Building the descriptor tables requires building tables for both
  sampler and CBV/SRV/UAV descriptors.
- The binding of descriptor tables can no longer be implied based on the
  DescriptorSets defined in .test file
- A layout must be generated when the root signature is generated based
  on the bindings
- In case of root signatures defined in the shader, the layout must be
  extracted from that root signature by deserializing it.

Adding this feature does allow more tests to succeed on DX12.

resolves #664