### PR TITLE
[Vulkan][KosmicKrisp] Enable tests that are now passing

### DIFF
--- a/test/Feature/WaveOps/WaveActiveCountBits.test
+++ b/test/Feature/WaveOps/WaveActiveCountBits.test
@@ -66,11 +66,6 @@ DescriptorSets:
 # Bug https://github.com/llvm/offload-test-suite/issues/549
 # XFAIL: QC && Vulkan && Clang
 
-# Bug https://github.com/llvm/offload-test-suite/issues/680
-# Expects: [ 3, 3, 3, 3, 2, 2, 0 ] 
-# Retsult: [ 3, 3, 3, 3, 4, 4, 0 ]
-# XFAIL: Vulkan && KosmicKrisp && Clang
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
This test is now passing.
closes https://github.com/llvm/offload-test-suite/issues/680