### PR TITLE
[Vulkan] Enable Transpose of bool matrix

### DIFF
--- a/test/Feature/HLSLLib/transpose.bool.test
+++ b/test/Feature/HLSLLib/transpose.bool.test
@@ -101,9 +101,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug https://github.com/llvm/llvm-project/issues/186864
-# XFAIL: Clang && Vulkan
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
With issue https://github.com/llvm/llvm-project/issues/186864 now resolved by legalizing the casting rules for the SPIRV backend we can now enable this test case